### PR TITLE
[localize] Remove export/more concise hash delimiter code

### DIFF
--- a/packages/localize/CHANGELOG.md
+++ b/packages/localize/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - It is no longer necessary to provide a message `id`. When omitted, an id will
   be automatically generated from the string contents of the template.
 
+- Remove unintentional export of `_msg` function (use `msg`).
+
 ## [0.5.1] - 2020-11-09
 
 ### Fixed

--- a/packages/localize/src_client/id-generation.ts
+++ b/packages/localize/src_client/id-generation.ts
@@ -17,7 +17,7 @@ import {fnv1a64} from './fnv1a64.js';
  *
  * This is the "record separator" ASCII character.
  */
-export const HASH_DELIMITER = String.fromCharCode(30);
+export const HASH_DELIMITER = '\x1E';
 
 /**
  * Id scheme version prefix to distinguish this implementation from potential

--- a/packages/localize/src_client/lit-localize.ts
+++ b/packages/localize/src_client/lit-localize.ts
@@ -314,24 +314,24 @@ const setLocale: ((newLocale: string) => Promise<void>) & {
  *   - args: In the case that `template` is a function, it will be invoked with
  *     these arguments.
  */
-export function _msg(template: string, options?: {id?: string}): string;
+function _msg(template: string, options?: {id?: string}): string;
 
-export function _msg(
+function _msg(
   template: TemplateResult,
   options?: {id?: string}
 ): TemplateResult;
 
-export function _msg<F extends (...args: any[]) => string>(
+function _msg<F extends (...args: any[]) => string>(
   fn: F,
   options: {id?: string; args: Parameters<F>}
 ): string;
 
-export function _msg<F extends (...args: any[]) => TemplateResult>(
+function _msg<F extends (...args: any[]) => TemplateResult>(
   fn: F,
   options: {id?: string; args: Parameters<F>}
 ): TemplateResult;
 
-export function _msg(
+function _msg(
   template: TemplateLike,
   options?: {id?: string; args?: any[]}
 ): string | TemplateResult {


### PR DESCRIPTION
- Remove unintentional _msg export
- Use ascii escape sequence instead of `fromCharCode`