### PR TITLE
chore: include package exports field

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "/lit-html.d.ts.map",
     "/lib/",
     "/directives/",
-    "/polyfills",
+    "/polyfills/",
     "/src/",
     "/ts3.4/",
     "!/src/test/"
@@ -80,5 +80,13 @@
     "src/**/*.{js,ts}": [
       "eslint --fix"
     ]
+  },
+  "exports": {
+    ".": "./lit-html.js",
+    "./directives/*": "./directives/*.js",
+    "./lib/*": "./lib/*.js",
+    "./polyfills/": "./polyfills/*.js",
+    "./src/*": "./src/*.ts",
+    "./ts3.4/*": "./ts3.4/*.ts"
   }
 }


### PR DESCRIPTION
# What it does

- Define [Package entrypoints](https://nodejs.org/api/packages.html#packages_package_entry_points)

## Why

It will help bundlers to tree shaking the bundle and services like skypack.dev (@FredKSchott) can inspect all entry points to avoid serving some files as raw or helps to generate URLs correctly.