### PR TITLE
[lit-html] Allow styleMap values to be nullable

### DIFF
--- a/src/directives/style-map.ts
+++ b/src/directives/style-map.ts
@@ -15,7 +15,7 @@
 import {AttributePart, directive, Part, PropertyPart} from '../lit-html.js';
 
 export interface StyleInfo {
-  readonly [name: string]: string;
+  readonly [name: string]: string | undefined | null;
 }
 
 /**

--- a/src/directives/style-map.ts
+++ b/src/directives/style-map.ts
@@ -15,7 +15,7 @@
 import {AttributePart, directive, Part, PropertyPart} from '../lit-html.js';
 
 export interface StyleInfo {
-  readonly [name: string]: string | undefined | null;
+  readonly [name: string]: string|undefined|null;
 }
 
 /**

--- a/src/directives/style-map.ts
+++ b/src/directives/style-map.ts
@@ -82,7 +82,7 @@ export const styleMap = directive((styleInfo: StyleInfo) => (part: Part) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (style as any)[name] = styleInfo[name];
     } else {
-      style.setProperty(name, styleInfo[name]);
+      style.setProperty(name, styleInfo[name] || '');
     }
   }
 });


### PR DESCRIPTION
Fixes this error:
![image](https://user-images.githubusercontent.com/18034092/108011677-9bf25800-6fd5-11eb-8e67-16e1334389f7.png)

Here's the spec for [CSSStyleDeclaration.setProperty](https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-setproperty). It appears to treat `null` and `''` (empty string) differently. Step 3 says an empty string value triggers `removeProperty`. Steps 6 says that after parsing the value, just return void if it's null (no `removeProperty`).

I'm not sure the reasoning behind making `null` a noop (if that's indeed the case). Of course it's a spec not a user guide.

In any case, the idea is that noops have no place in declarative code. To be declarative, the UI must match the declaration. So, if you declare the style as "empty" (null or undefined), then that style should become empty (unset).

This is the current behavior in plain JS, but typescript forbids `undefined`.