### PR TITLE
[all] Fix errors reported by the internal linter.

### DIFF
--- a/packages/lit-element/src/lit-element.ts
+++ b/packages/lit-element/src/lit-element.ts
@@ -104,7 +104,7 @@ export class LitElement extends ReactiveElement {
     // any styles in Lit content render before adoptedStyleSheets. This is
     // important so that adoptedStyleSheets have precedence over styles in
     // the shadowRoot.
-    this.renderOptions.renderBefore ??= renderRoot!.firstChild as ChildNode;
+    this.renderOptions.renderBefore ??= renderRoot.firstChild as ChildNode;
     return renderRoot;
   }
 

--- a/packages/lit-html/src/directives/async-append.ts
+++ b/packages/lit-html/src/directives/async-append.ts
@@ -86,9 +86,9 @@ class AsyncAppendDirective extends AsyncDirective {
 
   disconnected() {
     // Pause iteration while disconnected
-    this._reconnectPromise = new Promise(
-      (resolve) => (this._reconnectResolver = resolve)
-    );
+    this._reconnectPromise = new Promise((resolve) => {
+      this._reconnectResolver = resolve;
+    });
   }
 
   reconnected() {

--- a/packages/lit-html/src/directives/async-replace.ts
+++ b/packages/lit-html/src/directives/async-replace.ts
@@ -64,9 +64,9 @@ class AsyncReplaceDirective extends AsyncDirective {
 
   disconnected() {
     // Pause iteration while disconnected
-    this._reconnectPromise = new Promise(
-      (resolve) => (this._reconnectResolver = resolve)
-    );
+    this._reconnectPromise = new Promise((resolve) => {
+      this._reconnectResolver = resolve;
+    });
   }
 
   reconnected() {

--- a/packages/lit-html/src/directives/cache.ts
+++ b/packages/lit-html/src/directives/cache.ts
@@ -20,7 +20,10 @@ import {
 } from '../directive-helpers.js';
 
 class CacheDirective extends Directive {
-  private _templateCache = new WeakMap<TemplateStringsArray, ChildPart>();
+  private readonly _templateCache = new WeakMap<
+    TemplateStringsArray,
+    ChildPart
+  >();
   private _value?: TemplateResult;
 
   constructor(partInfo: PartInfo) {

--- a/packages/lit-html/src/directives/style-map.ts
+++ b/packages/lit-html/src/directives/style-map.ts
@@ -75,7 +75,7 @@ class StyleMapDirective extends Directive {
     // Remove old properties that no longer exist in styleInfo
     // We use forEach() instead of for-of so that re don't require down-level
     // iteration.
-    this._previousStyleProperties!.forEach((name) => {
+    this._previousStyleProperties.forEach((name) => {
       // If the name isn't in styleInfo or it's null/undefined
       if (styleInfo[name] == null) {
         this._previousStyleProperties!.delete(name);

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -518,7 +518,9 @@ const getTemplateHtml = (
           end
         : s +
           marker +
-          (attrNameEndIndex === -2 ? (attrNames.push(undefined), i) : end);
+          (attrNameEndIndex === -2
+            ? (attrNames.push(undefined), String(i))
+            : end);
   }
 
   // Returned as an array for terseness

--- a/packages/lit-html/src/polyfill-support.ts
+++ b/packages/lit-html/src/polyfill-support.ts
@@ -166,9 +166,7 @@ const ENABLE_SHADYDOM_NOPATCH = true;
       }
       const scopeCss = cssForScope(scope);
       // Remove styles and store textContent.
-      const styles = element.content.querySelectorAll(
-        'style'
-      ) as NodeListOf<HTMLStyleElement>;
+      const styles = element.content.querySelectorAll('style');
       // Store the css in this template in the scope css and remove the <style>
       // from the template _before_ the node-walk captures part indices
       scopeCss.push(

--- a/packages/reactive-element/src/decorators/base.ts
+++ b/packages/reactive-element/src/decorators/base.ts
@@ -81,7 +81,7 @@ export const decorateProperty = ({
     if (descriptor !== undefined) {
       Object.defineProperty(protoOrDescriptor, name, descriptor(name));
     }
-    finisher?.(ctor, name!);
+    finisher?.(ctor, name);
     // Babel standard mode
   } else {
     // Note, the @property decorator saves `key` as `originalKey`

--- a/packages/reactive-element/src/reactive-element.ts
+++ b/packages/reactive-element/src/reactive-element.ts
@@ -707,9 +707,9 @@ export abstract class ReactiveElement
     // ensures first update will be caught by an early access of
     // `updateComplete`
     this.requestUpdate();
-    (this.constructor as typeof ReactiveElement)._initializers?.forEach((i) =>
-      i(this)
-    );
+    (this.constructor as typeof ReactiveElement)._initializers?.forEach((i) => {
+      i(this);
+    });
   }
 
   /**
@@ -1082,7 +1082,9 @@ export abstract class ReactiveElement
   // Note, this is an override point for polyfill-support.
   // @internal
   _$didUpdate(changedProperties: PropertyValues) {
-    this.__controllers?.forEach((c) => c.hostUpdated?.());
+    this.__controllers?.forEach((c) => {
+      c.hostUpdated?.();
+    });
     if (!this.hasUpdated) {
       this.hasUpdated = true;
       this.firstUpdated(changedProperties);


### PR DESCRIPTION
I'm working on getting set up for another import and in my CL the linter pointed out some stuff that seemed useful to upstream. Most of the internal linter complaints are that they don't want `_`-prefixed private properties, so I just ignored those. Also, there are a couple of places where we use `forEach` instead of for-of that it doesn't like, but there were comments indicating that these are intentional.

As far as the stuff it found that seems legit, there are a handful of unnecessary assertions and also a few places where arrow functions that return undefined weren't using a block body. I think they prefer that style for arrow functions because it makes it obvious that the result must be undefined - also, it turned out to improve the formatting in most places IMO.

---

Also, there was one place where a string and number were being concatenated with `+`, so I wrapped the number in `String(...)`, and one place where a class member could be made `readonly`.