### PR TITLE
[@lit-labs/motion] Fix package.json's files section to include flip-controller.

### DIFF
--- a/packages/labs/motion/CHANGELOG.md
+++ b/packages/labs/motion/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- ### Removed -->
 <!-- ### Fixed -->
 
+## Unreleased
+
+### Fixed
+
+- Included `flip-controller` in `package.json` `files` section [#1796](https://github.com/lit/lit/issues/1796).
+
 ## [1.0.0-rc.1] - 2021-04-20
 
 ### Changed

--- a/packages/labs/motion/package.json
+++ b/packages/labs/motion/package.json
@@ -27,6 +27,7 @@
     "!/src/test/",
     "/index.{d.ts,d.ts.map,js,js.map}",
     "/flip.{d.ts,d.ts.map,js,js.map}",
+    "/flip-controller.{d.ts,d.ts.map,js,js.map}",
     "/position.{d.ts,d.ts.map,js,js.map}"
   ],
   "scripts": {


### PR DESCRIPTION
Fixes #1796.