### PR TITLE
Fix nuke

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -156,6 +156,7 @@ packages/lit-starter-ts/docs-src/*
 packages/lit-starter-ts/**/rollup-config.js
 packages/lit-starter-ts/**/custom-elements.json
 
+package-lock.json
 packages/localize/examples/
 packages/localize-tools/testdata/
 packages/localize-tools/config.schema.json

--- a/.prettierignore-sync
+++ b/.prettierignore-sync
@@ -7,6 +7,7 @@ packages/{*,labs/*}/{.gitignore,.prettierignore}
 packages/{lit-starter-ts,lit-starter-js}/.eslintignore
 
 [inline]
+package-lock.json
 packages/localize/examples/
 packages/localize-tools/testdata/
 packages/localize-tools/config.schema.json

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "format:prettier": "prettier \"**/*.{cjs,html,js,json,md,ts}\" --write",
     "ignore-sync": "ignore-sync .",
     "lint": "eslint \"**/*.{js,ts}\"",
-    "nuke": "rm -rf node_modules packages/{*,labs/*}/node_modules && npm install && npm run bootstrap && npm run clean",
+    "nuke": "rm -rf node_modules package-lock.json && npm install && npx lerna exec 'rm -rf node_modules package-lock.json' && npx lerna bootstrap && npm run clean",
     "test": "(cd packages/tests && npm test) && (cd packages/labs/ssr && npm test) && (cd packages/localize && npm test) && (cd packages/localize-tools && npm test) && (cd packages/lit-starter-ts && npm test) && (cd packages/lit-starter-js && npm test)",
     "prepare": "husky install"
   },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "format:prettier": "prettier \"**/*.{cjs,html,js,json,md,ts}\" --write",
     "ignore-sync": "ignore-sync .",
     "lint": "eslint \"**/*.{js,ts}\"",
-    "nuke": "rm -rf node_modules package-lock.json && npm install && npx lerna exec 'rm -rf node_modules package-lock.json' && npx lerna bootstrap && npm run clean",
+    "nuke": "rm -rf node_modules package-lock.json && npm install && lerna exec 'rm -rf node_modules package-lock.json' && lerna bootstrap && npm run clean",
     "test": "(cd packages/tests && npm test) && (cd packages/labs/ssr && npm test) && (cd packages/localize && npm test) && (cd packages/localize-tools && npm test) && (cd packages/lit-starter-ts && npm test) && (cd packages/lit-starter-js && npm test)",
     "prepare": "husky install"
   },


### PR DESCRIPTION
The nuke script was broken, because `/bin/sh` doesn't necessarily support brace expansion, and because we weren't including `package-lock.json` files.

Also, don't auto-format `package-lock.json` files. Creates pointless churn and is confusing.