### PR TITLE
Incrimination of kickCount in ReactControllerHost

### DIFF
--- a/packages/labs/react/src/use-controller.ts
+++ b/packages/labs/react/src/use-controller.ts
@@ -32,7 +32,7 @@ class ReactControllerHost<C extends ReactiveController>
   /* @internal */
   _updatePending = true;
   private _resolveUpdate!: (value: boolean | PromiseLike<boolean>) => void;
-
+  // Count of the number of kicks performed
   private _kickCount: number;
   // A function to trigger an update of the React component
   private _kick: (k: number) => void;
@@ -59,7 +59,10 @@ class ReactControllerHost<C extends ReactiveController>
     if (!this._updatePending) {
       this._updatePending = true;
       // Trigger a React update by updating some state
-      microtask.then(() => this._kick(this._kickCount + 1));
+      microtask.then(() => {
+        this._kickCount++;
+        this._kick(this._kickCount);
+      });
     }
   }
 


### PR DESCRIPTION
**Fixes #1815** 

The _kickCount property is not linked to the react component, meaning the _kick function, does not change the value of _kickCount. I would consider: using a [proxy](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) or If there is no reason to keep the _kickCount updated: removing the property from ReactControllerHost, and instead setting it to a random hash or timestamp in the component.

_Linted, formatted, and tested._