### PR TITLE
Prevent `styleMap` from writing to the 'style' attribute.

### DIFF
--- a/packages/lit-html/src/directives/style-map.ts
+++ b/packages/lit-html/src/directives/style-map.ts
@@ -66,10 +66,6 @@ class StyleMapDirective extends Directive {
 
     if (this._previousStyleProperties === undefined) {
       this._previousStyleProperties = new Set();
-      for (const name in styleInfo) {
-        this._previousStyleProperties.add(name);
-      }
-      return this.render(styleInfo);
     }
 
     // Remove old properties that no longer exist in styleInfo


### PR DESCRIPTION
Internally, `styleMap` can't update the style attribute dynamically because it isn't allowed by the sanitizer. However, this directive already handles updates using the style property, so this change falls through to use that in all cases.