### PR TITLE
[labs/task] Add task.js to package exports

### DIFF
--- a/packages/labs/task/CHANGELOG.md
+++ b/packages/labs/task/CHANGELOG.md
@@ -17,6 +17,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- ### Removed -->
 <!-- ### Fixed -->
 
+## Unreleased
+
+<!-- ### Changed -->
+<!-- ### Added -->
+<!-- ### Removed -->
+
+### Fixed
+
+- Added `task.js` to the package exports ([#1824](https://github.com/lit/lit/issues/1824)).
+
 ## 1.0.0-rc.1 - 2021-04-20
 
 ### Changed

--- a/packages/labs/task/package.json
+++ b/packages/labs/task/package.json
@@ -20,6 +20,10 @@
     ".": {
       "development": "./development/index.js",
       "default": "./index.js"
+    },
+    "./task.js": {
+      "development": "./development/task.js",
+      "default": "./task.js"
     }
   },
   "files": [


### PR DESCRIPTION
This was reported on Slack.