### PR TITLE
[labs/react] Omit 'children' from element type in props

### DIFF
--- a/packages/labs/react/src/create-component.ts
+++ b/packages/labs/react/src/create-component.ts
@@ -123,8 +123,10 @@ export const createComponent = <I extends HTMLElement, E>(
 
   // Props the user is allowed to use, includes standard attributes, children,
   // ref, as well as special event and element properties.
+  // TODO: we might need to omit more properties from HTMLElement than just
+  // 'children', but 'children' is special to JSX, so we must at least do that.
   type UserProps = React.PropsWithChildren<
-    React.PropsWithRef<Partial<I> & Events<E>>
+    React.PropsWithRef<Partial<Omit<I, 'children'>> & Events<E>>
   >;
 
   // Props used by this component wrapper. This is the UserProps and the

--- a/packages/labs/react/src/test/create-component_test.tsx
+++ b/packages/labs/react/src/test/create-component_test.tsx
@@ -7,11 +7,14 @@
 import {ReactiveElement} from '@lit/reactive-element';
 import {property} from '@lit/reactive-element/decorators/property.js';
 import {customElement} from '@lit/reactive-element/decorators/custom-element.js';
-import * as ReactModule from 'react';
+import type * as ReactModule from 'react';
 import 'react/umd/react.development.js';
 import 'react-dom/umd/react-dom.development.js';
 import {createComponent} from '../create-component.js';
 import {assert} from '@esm-bundle/chai';
+
+// Needed for JSX expressions
+const React = window.React;
 
 const elementName = 'basic-element';
 @customElement(elementName)
@@ -81,12 +84,23 @@ suite('createComponent', () => {
     props?: ReactModule.ComponentProps<typeof BasicElementComponent>
   ) => {
     window.ReactDOM.render(
-      window.React.createElement(BasicElementComponent, props),
+      <BasicElementComponent {...props}/>,
       container
     );
     el = container.querySelector(elementName)! as BasicElement;
     await el.updateComplete;
   };
+
+  test('works with text children', async () => {
+    const name = 'World';
+    window.ReactDOM.render(
+      <BasicElementComponent>Hello {name}</BasicElementComponent>,
+      container
+    );
+    el = container.querySelector(elementName)! as BasicElement;
+    await el.updateComplete;
+    assert.equal(el.textContent, 'Hello World');
+  });
 
   test('wrapper renders custom element that updates', async () => {
     await renderReactComponent();

--- a/packages/labs/react/tsconfig.json
+++ b/packages/labs/react/tsconfig.json
@@ -19,9 +19,10 @@
     "noImplicitThis": true,
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
-    "experimentalDecorators": true
+    "experimentalDecorators": true,
+    "jsx": "react"
   },
-  "include": ["src/**/*.ts"],
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
   "exclude": [],
   "references": [
     {"path": "../../lit-html"},


### PR DESCRIPTION
Fixes #1826 