### PR TITLE
feat: add directives.js to fix #1736

### DIFF
--- a/packages/lit/package.json
+++ b/packages/lit/package.json
@@ -31,6 +31,9 @@
     "./directive.js": {
       "default": "./directive.js"
     },
+    "./directives.js": {
+      "default": "./directives.js"
+    },
     "./directives/": {
       "default": "./directives/"
     },

--- a/packages/lit/src/directives.ts
+++ b/packages/lit/src/directives.ts
@@ -1,0 +1,20 @@
+/**
+ * @license
+ * Copyright 2017 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+ export * from 'lit-html/directives/async-append.js';
+ export * from 'lit-html/directives/async-replace.js';
+ export * from 'lit-html/directives/cache.js';
+ export * from 'lit-html/directives/class-map.js';
+ export * from 'lit-html/directives/guard.js';
+ export * from 'lit-html/directives/if-defined.js';
+ export * from 'lit-html/directives/live.js';
+ export * from 'lit-html/directives/ref.js';
+ export * from 'lit-html/directives/repeat.js';
+ export * from 'lit-html/directives/style-map.js';
+ export * from 'lit-html/directives/template-content.js';
+ export * from 'lit-html/directives/unsafe-html.js';
+ export * from 'lit-html/directives/unsafe-svg.js';
+ export * from 'lit-html/directives/until.js';


### PR DESCRIPTION
Fixes #1736.

## Changes
1. Add `directives.js` to re-export all directives from `lit-html/directives`
1. Add `./directives.js` in export map