### PR TITLE
[localize] Fix missing `str` tag in generated output

### DIFF
--- a/packages/localize-tools/CHANGELOG.md
+++ b/packages/localize-tools/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Fixed missing `str` tag in generated translation templates.
 
 ## [0.3.1] - 2021-04-20
 

--- a/packages/localize-tools/src/messages.ts
+++ b/packages/localize-tools/src/messages.ts
@@ -46,10 +46,9 @@ export interface ProgramMessage extends Message {
   desc: string | undefined;
 
   /**
-   * True if this message was tagged as a Lit template, or was a function that
-   * returned a Lit template.
+   * The template literal tag this message has.
    */
-  isLitTemplate: boolean;
+  tag: 'html' | 'str' | undefined;
 }
 
 /**

--- a/packages/localize-tools/src/modes/runtime.ts
+++ b/packages/localize-tools/src/modes/runtime.ts
@@ -123,8 +123,9 @@ function generateLocaleModule(
   // The unique set of message names we found in this XLB translations file.
   const translatedMsgNames = new Set<string>();
 
-  // Whether we'll need to import the lit "html" function.
+  // Whether we need to import the lit html or localize str tags.
   let importLit = false;
+  let importStr = false;
 
   const entries = [];
   for (const msg of translations) {
@@ -141,8 +142,10 @@ function generateLocaleModule(
     entries.push(`'${msg.name}': ${patchedMsgStr},`);
   }
   for (const msg of canonMsgs) {
-    if (msg.isLitTemplate) {
+    if (msg.tag === 'html') {
       importLit = true;
+    } else if (msg.tag === 'str') {
+      importStr = true;
     }
     if (translatedMsgNames.has(msg.name)) {
       continue;
@@ -158,6 +161,7 @@ function generateLocaleModule(
     // Re-generate this file by running lit-localize
 
     ${importLit ? "import {html} from 'lit';" : ''}
+    ${importStr ? "import {str} from '@lit/localize';" : ''}
 
     /* eslint-disable no-irregular-whitespace */
     /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -222,6 +226,5 @@ function makeMessageString(
     }
   }
 
-  const tag = canon.isLitTemplate ? 'html' : '';
-  return `${tag}\`${fragments.join('')}\``;
+  return `${canon.tag ?? ''}\`${fragments.join('')}\``;
 }

--- a/packages/localize-tools/src/modes/transform.ts
+++ b/packages/localize-tools/src/modes/transform.ts
@@ -324,7 +324,7 @@ class Transformer {
     if (templateResult.error) {
       throw new Error(stringifyDiagnostics([templateResult.error]));
     }
-    const {isLitTemplate: isLitTagged} = templateResult.result;
+    const {tag} = templateResult.result;
     let {template} = templateResult.result;
 
     const optionsResult = extractOptions(optionsArg, this.sourceFile);
@@ -332,7 +332,7 @@ class Transformer {
       throw new Error(stringifyDiagnostics([optionsResult.error]));
     }
     const options = optionsResult.result;
-    const id = options.id ?? generateMsgIdFromAstNode(template, isLitTagged);
+    const id = options.id ?? generateMsgIdFromAstNode(template, tag === 'html');
 
     const sourceExpressions = new Map<string, ts.Expression>();
     if (ts.isTemplateExpression(template)) {
@@ -387,7 +387,7 @@ class Transformer {
 
     // Nothing more to do with a simple string.
     if (ts.isStringLiteral(template)) {
-      if (isLitTagged) {
+      if (tag === 'html') {
         throw new KnownError(
           'Internal error: string literal cannot be html-tagged'
         );
@@ -401,9 +401,9 @@ class Transformer {
     // Given: html`Hello <b>${"World"}</b>`
     // Generate: html`Hello <b>World</b>`
     template = makeTemplateLiteral(
-      this.recursivelyFlattenTemplate(template, isLitTagged)
+      this.recursivelyFlattenTemplate(template, tag === 'html')
     );
-    return isLitTagged ? tagLit(template) : template;
+    return tag === 'html' ? tagLit(template) : template;
   }
 
   /**

--- a/packages/localize-tools/testdata/build-runtime-xlb/goldens/tsout/es-419.ts
+++ b/packages/localize-tools/testdata/build-runtime-xlb/goldens/tsout/es-419.ts
@@ -2,6 +2,7 @@
 // Re-generate this file by running lit-localize
 
 import {html} from 'lit';
+import {str} from '@lit/localize';
 
 /* eslint-disable no-irregular-whitespace */
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -14,7 +15,7 @@ export const templates = {
   hbe936ff3da20ffdf: html`Hola <b><!-- comment -->Mundo</b>!`,
   hc1c6bfa4414cb3e3: html`[SALT] Clic <a href="${0}">aquí</a>!`,
   myId: `Hola Mundo`,
-  s00ad08ebae1e0f74: `Hola ${0}!`,
+  s00ad08ebae1e0f74: str`Hola ${0}!`,
   s03c68d79ad36e8d4: `described 0`,
   s0f19e6c4e521dd53: `Mundo`,
   s8c0ec8d1fb9e6e32: `Hola Mundo!`,

--- a/packages/localize-tools/testdata/build-runtime-xliff/goldens/tsout/es-419.ts
+++ b/packages/localize-tools/testdata/build-runtime-xliff/goldens/tsout/es-419.ts
@@ -2,6 +2,7 @@
 // Re-generate this file by running lit-localize
 
 import {html} from 'lit';
+import {str} from '@lit/localize';
 
 /* eslint-disable no-irregular-whitespace */
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -15,7 +16,7 @@ export const templates = {
   hc1c6bfa4414cb3e3: html`[SALT] Clic <a href="${0}">aquí</a>!`,
   hf979404a36e879cb: html`c:${2} a:${0} b:${1}`,
   myId: `Hola Mundo`,
-  s00ad08ebae1e0f74: `Hola ${0}!`,
+  s00ad08ebae1e0f74: str`Hola ${0}!`,
   s03c68d79ad36e8d4: `described 0`,
   s0f19e6c4e521dd53: `Mundo`,
   s8c0ec8d1fb9e6e32: `Hola Mundo!`,

--- a/packages/localize-tools/testdata/build-runtime-xliff/goldens/tsout/zh_CN.ts
+++ b/packages/localize-tools/testdata/build-runtime-xliff/goldens/tsout/zh_CN.ts
@@ -2,6 +2,7 @@
 // Re-generate this file by running lit-localize
 
 import {html} from 'lit';
+import {str} from '@lit/localize';
 
 /* eslint-disable no-irregular-whitespace */
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -9,7 +10,7 @@ import {html} from 'lit';
 export const templates = {
   h3c44aff2d5f5ef6b: html`你好 <b>世界</b>!`,
   s8c0ec8d1fb9e6e32: `你好，世界!`,
-  s00ad08ebae1e0f74: `Hello ${0}!`,
+  s00ad08ebae1e0f74: str`Hello ${0}!`,
   h82ccc38d4d46eaa9: html`Hello <b>${0}</b>!`,
   h99e74f744fda7e25: html`Click <a href="${0}">here</a>!`,
   hc1c6bfa4414cb3e3: html`[SALT] Click <a href="${0}">here</a>!`,


### PR DESCRIPTION
Non-html strings with expressions need to be tagged with the `str` function. However, we had a bug where we weren't including this `str` function in the generated output, so variable substitution was not occurring in those cases.