### PR TITLE
[reactive-element] Make unsafeCSS() use the CSSResult cache

### DIFF
--- a/packages/reactive-element/src/test/css-tag_test.ts
+++ b/packages/reactive-element/src/test/css-tag_test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {css, CSSResult} from '../css-tag.js';
+import {css, CSSResult, unsafeCSS} from '../css-tag.js';
 import {assert} from '@esm-bundle/chai';
 
 suite('Styling', () => {
@@ -22,6 +22,21 @@ suite('Styling', () => {
       // Alias avoids syntax highlighting issues in editors
       const cssValue = css;
       const makeStyle = () => cssValue`foo`;
+      const style1 = makeStyle();
+      assert.equal(
+        (style1 as CSSResult).styleSheet,
+        (style1 as CSSResult).styleSheet
+      );
+      const style2 = makeStyle();
+      assert.equal(
+        (style1 as CSSResult).styleSheet,
+        (style2 as CSSResult).styleSheet
+      );
+    });
+
+    test('unsafeCSS() CSSResults always produce the same stylesheet', () => {
+      // Alias avoids syntax highlighting issues in editors
+      const makeStyle = () => unsafeCSS(`foo`);
       const style1 = makeStyle();
       assert.equal(
         (style1 as CSSResult).styleSheet,

--- a/packages/reactive-element/src/test/reactive-element_styling_test.ts
+++ b/packages/reactive-element/src/test/reactive-element_styling_test.ts
@@ -224,6 +224,30 @@ import {assert} from '@esm-bundle/chai';
       );
     });
 
+    test('unsafeCSS can be used standalone', async () => {
+      const name = generateElementName();
+      customElements.define(
+        name,
+        class extends RenderingElement {
+          static get styles() {
+            return unsafeCSS('div {border: 2px solid blue}');
+          }
+
+          render() {
+            return html` <div>Testing</div>`;
+          }
+        }
+      );
+      const el = document.createElement(name);
+      container.appendChild(el);
+      await (el as ReactiveElement).updateComplete;
+      const div = el.shadowRoot!.querySelector('div');
+      assert.equal(
+        getComputedStyleValue(div!, 'border-top-width').trim(),
+        '2px'
+      );
+    });
+
     test('`static get styles` applies last instance of style', async () => {
       const name = generateElementName();
       const s1 = css`


### PR DESCRIPTION
Fixes #1846

Also adds a test that `unsafeCSS()` is a valid top-level style. This means that the recommended pattern for including external CSS text can be `static styles = unsafeCSS(cssText)`, without using the `css` tag.

The PR also updates the `css` tag caching to have a fast path for strings with no interpolations.