### PR TITLE
[lit-html] Add `PropertyPart` to directives forward-compat file.

### DIFF
--- a/src/directive.ts
+++ b/src/directive.ts
@@ -108,7 +108,7 @@ class PropertyPart extends AttributePart {
   constructor(legacyPart: legacyLit.PropertyPart) {
     super(legacyPart);
   }
-};
+}
 
 export type{BooleanAttributePart};
 class BooleanAttributePart {

--- a/src/directive.ts
+++ b/src/directive.ts
@@ -104,10 +104,6 @@ class AttributePart {
 export type{PropertyPart};
 class PropertyPart extends AttributePart {
   readonly type = PartType.PROPERTY;
-
-  constructor(legacyPart: legacyLit.PropertyPart) {
-    super(legacyPart);
-  }
 }
 
 export type{BooleanAttributePart};

--- a/src/directive.ts
+++ b/src/directive.ts
@@ -40,7 +40,8 @@ export interface AttributePartInfo {
   readonly tagName: string;
 }
 
-export type Part = ChildPart|AttributePart|BooleanAttributePart|EventPart;
+export type Part =
+    ChildPart|AttributePart|PropertyPart|BooleanAttributePart|EventPart;
 
 export type{ChildPart};
 class ChildPart {
@@ -67,7 +68,8 @@ class ChildPart {
 
 export type{AttributePart};
 class AttributePart {
-  readonly type: typeof PartType.ATTRIBUTE|typeof PartType.PROPERTY;
+  readonly type: typeof PartType.ATTRIBUTE|typeof PartType.PROPERTY =
+      PartType.ATTRIBUTE;
   readonly legacyPart: legacyLit.AttributePart|legacyLit.PropertyPart;
 
   get options(): legacyLit.RenderOptions|undefined {
@@ -96,11 +98,17 @@ class AttributePart {
 
   constructor(legacyPart: legacyLit.AttributePart|legacyLit.PropertyPart) {
     this.legacyPart = legacyPart;
-    this.type = (legacyPart instanceof legacyLit.PropertyPart) ?
-        PartType.PROPERTY :
-        PartType.ATTRIBUTE;
   }
 }
+
+export type{PropertyPart};
+class PropertyPart extends AttributePart {
+  readonly type = PartType.PROPERTY;
+
+  constructor(legacyPart: legacyLit.PropertyPart) {
+    super(legacyPart);
+  }
+};
 
 export type{BooleanAttributePart};
 class BooleanAttributePart {
@@ -194,9 +202,9 @@ function legacyPartToPart(part: legacyLit.Part): Part {
     return new EventPart(part);
   } else if (part instanceof legacyLit.BooleanAttributePart) {
     return new BooleanAttributePart(part);
-  } else if (
-      part instanceof legacyLit.PropertyPart ||
-      part instanceof legacyLit.AttributePart) {
+  } else if (part instanceof legacyLit.PropertyPart) {
+    return new PropertyPart(part);
+  } else if (part instanceof legacyLit.AttributePart) {
     return new AttributePart(part);
   }
   // ElementPartInfo doesn't exist in lit-html v1

--- a/src/test/directive_test.ts
+++ b/src/test/directive_test.ts
@@ -1,0 +1,96 @@
+/**
+ * @license
+ * Copyright (c) 2021 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {directive, Directive, PartInfo, PartType} from '../directive.js';
+import {html, render} from '../lit-html.js';
+
+const assert = chai.assert;
+assert(true);
+
+suite('Forward compatiblity directive API', () => {
+  const makePartInfoTypeTestDirective = () => {
+    let partInfoType: PartInfo['type']|undefined = undefined;
+
+    class TestDirective extends Directive {
+      constructor(partInfo: PartInfo) {
+        super(partInfo);
+        partInfoType = partInfo.type
+      }
+
+      render() {
+        return undefined;
+      }
+    }
+
+    return {
+      directive: directive(TestDirective),
+      getPartInfoType: () => partInfoType,
+    };
+  };
+
+  suite('ChildPart', () => {
+    test('PartInfo has the correct type.', () => {
+      const {directive: testDirective, getPartInfoType} = makePartInfoTypeTestDirective();
+
+      const template = document.createElement('template');
+      render(html`<div>${testDirective()}</div>`, template.content);
+
+      assert.equal(getPartInfoType(), PartType.CHILD);
+    });
+  });
+
+  suite('AttributePart', () => {
+    test('PartInfo has the correct type.', () => {
+      const {directive: testDirective, getPartInfoType} = makePartInfoTypeTestDirective();
+
+      const template = document.createElement('template');
+      render(html`<div p=${testDirective()}></div>`, template.content);
+
+      assert.equal(getPartInfoType(), PartType.ATTRIBUTE);
+    });
+  });
+
+  suite('PropertyPart', () => {
+    test('PartInfo has the correct type.', () => {
+      const {directive: testDirective, getPartInfoType} = makePartInfoTypeTestDirective();
+
+      const template = document.createElement('template');
+      render(html`<div .p=${testDirective()}></div>`, template.content);
+
+      assert.equal(getPartInfoType(), PartType.PROPERTY);
+    });
+  });
+
+  suite('BooleanAttributePart', () => {
+    test('PartInfo has the correct type.', () => {
+      const {directive: testDirective, getPartInfoType} = makePartInfoTypeTestDirective();
+
+      const template = document.createElement('template');
+      render(html`<div ?p=${testDirective()}></div>`, template.content);
+
+      assert.equal(getPartInfoType(), PartType.BOOLEAN_ATTRIBUTE);
+    });
+  });
+
+  suite('EventPart', () => {
+    test('PartInfo has the correct type.', () => {
+      const {directive: testDirective, getPartInfoType} = makePartInfoTypeTestDirective();
+
+      const template = document.createElement('template');
+      render(html`<div @p=${testDirective()}></div>`, template.content);
+
+      assert.equal(getPartInfoType(), PartType.EVENT);
+    });
+  });
+});

--- a/src/test/directive_test.ts
+++ b/src/test/directive_test.ts
@@ -41,7 +41,8 @@ suite('Forward compatiblity directive API', () => {
 
   suite('ChildPart', () => {
     test('PartInfo has the correct type.', () => {
-      const {directive: testDirective, getPartInfoType} = makePartInfoTypeTestDirective();
+      const {directive: testDirective, getPartInfoType} =
+          makePartInfoTypeTestDirective();
 
       const template = document.createElement('template');
       render(html`<div>${testDirective()}</div>`, template.content);
@@ -52,7 +53,8 @@ suite('Forward compatiblity directive API', () => {
 
   suite('AttributePart', () => {
     test('PartInfo has the correct type.', () => {
-      const {directive: testDirective, getPartInfoType} = makePartInfoTypeTestDirective();
+      const {directive: testDirective, getPartInfoType} =
+          makePartInfoTypeTestDirective();
 
       const template = document.createElement('template');
       render(html`<div attr-name=${testDirective()}></div>`, template.content);
@@ -63,7 +65,8 @@ suite('Forward compatiblity directive API', () => {
 
   suite('PropertyPart', () => {
     test('PartInfo has the correct type.', () => {
-      const {directive: testDirective, getPartInfoType} = makePartInfoTypeTestDirective();
+      const {directive: testDirective, getPartInfoType} =
+          makePartInfoTypeTestDirective();
 
       const template = document.createElement('template');
       render(html`<div .propName=${testDirective()}></div>`, template.content);
@@ -74,7 +77,8 @@ suite('Forward compatiblity directive API', () => {
 
   suite('BooleanAttributePart', () => {
     test('PartInfo has the correct type.', () => {
-      const {directive: testDirective, getPartInfoType} = makePartInfoTypeTestDirective();
+      const {directive: testDirective, getPartInfoType} =
+          makePartInfoTypeTestDirective();
 
       const template = document.createElement('template');
       render(html`<div ?attr-name=${testDirective()}></div>`, template.content);
@@ -85,10 +89,12 @@ suite('Forward compatiblity directive API', () => {
 
   suite('EventPart', () => {
     test('PartInfo has the correct type.', () => {
-      const {directive: testDirective, getPartInfoType} = makePartInfoTypeTestDirective();
+      const {directive: testDirective, getPartInfoType} =
+          makePartInfoTypeTestDirective();
 
       const template = document.createElement('template');
-      render(html`<div @event-name=${testDirective()}></div>`, template.content);
+      render(
+          html`<div @event-name=${testDirective()}></div>`, template.content);
 
       assert.equal(getPartInfoType(), PartType.EVENT);
     });

--- a/src/test/directive_test.ts
+++ b/src/test/directive_test.ts
@@ -55,7 +55,7 @@ suite('Forward compatiblity directive API', () => {
       const {directive: testDirective, getPartInfoType} = makePartInfoTypeTestDirective();
 
       const template = document.createElement('template');
-      render(html`<div p=${testDirective()}></div>`, template.content);
+      render(html`<div attr-name=${testDirective()}></div>`, template.content);
 
       assert.equal(getPartInfoType(), PartType.ATTRIBUTE);
     });
@@ -66,7 +66,7 @@ suite('Forward compatiblity directive API', () => {
       const {directive: testDirective, getPartInfoType} = makePartInfoTypeTestDirective();
 
       const template = document.createElement('template');
-      render(html`<div .p=${testDirective()}></div>`, template.content);
+      render(html`<div .propName=${testDirective()}></div>`, template.content);
 
       assert.equal(getPartInfoType(), PartType.PROPERTY);
     });
@@ -77,7 +77,7 @@ suite('Forward compatiblity directive API', () => {
       const {directive: testDirective, getPartInfoType} = makePartInfoTypeTestDirective();
 
       const template = document.createElement('template');
-      render(html`<div ?p=${testDirective()}></div>`, template.content);
+      render(html`<div ?attr-name=${testDirective()}></div>`, template.content);
 
       assert.equal(getPartInfoType(), PartType.BOOLEAN_ATTRIBUTE);
     });
@@ -88,7 +88,7 @@ suite('Forward compatiblity directive API', () => {
       const {directive: testDirective, getPartInfoType} = makePartInfoTypeTestDirective();
 
       const template = document.createElement('template');
-      render(html`<div @p=${testDirective()}></div>`, template.content);
+      render(html`<div @event-name=${testDirective()}></div>`, template.content);
 
       assert.equal(getPartInfoType(), PartType.EVENT);
     });

--- a/test/index.html
+++ b/test/index.html
@@ -9,6 +9,7 @@
   </head>
   <body>
     <script type="module" src="./lit-html_test.js"></script>
+    <script type="module" src="./directive_test.js"></script>
     <script type="module" src="./lib/template-result_test.js"></script>
     <script type="module" src="./lib/template_test.js"></script>
     <script type="module" src="./lib/template-factory_test.js"></script>


### PR DESCRIPTION
This PR separates `PropertyPart` from `AttributePart` in the forward-compatible directive API. `PropertyPart` and `AttributePart` are separate types in both [1.x](https://github.com/lit/lit/blob/39a00486fee64277a630666fde08cddc9a2402c9/src/lib/parts.ts#L448) and [2.x](https://github.com/lit/lit/blob/f50dff4d9066c91cbca12c3b746dd8f7d3fb21e5/packages/lit-html/src/lit-html.ts#L1336).