### PR TITLE
Adds decorators for `@compute`, `@observe`, and `@listen`

### DIFF
--- a/packages/reactive-element/CHANGELOG.md
+++ b/packages/reactive-element/CHANGELOG.md
@@ -17,6 +17,27 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- ### Removed -->
 <!-- ### Fixed -->
 
+## Unreleased
+
+### Added
+
+- (Since 1.0.0-rc.2) Adds `@computed` decorator for creating computed properties. Decorator specifies an array of deps which are the names of dependent properties
+  and a compute function which is called with dependency values and should return
+  the computed property value.
+
+- (Since 1.0.0-rc.2) Adds `@observe` decorator for observing property changes. Decorator specifies an observe function which receives the current and previous
+  value of the property as well as the name of the property. Note, the observed
+  property must be a reactive property.
+
+- (Since 1.0.0-rc.2) Adds `@listen` decorator for declaratively adding event
+  listeners. The decorator should be placed on an element property which is an
+  event listener function. The decorator must provide an object which specifies
+  the event `type`, `options`, and an optional `target`. The `target` defaults
+  to the element itself or may be `root` to add the listener to the element's
+  `renderRoot`, or an instance of `EventTarget`. If `target` is an `EventTarget`,
+  the listener is dynamically added and removed when the element is connected
+  and disconnected.
+
 ## 1.0.0-rc.2 - 2021-05-07
 
 ### Changed

--- a/packages/reactive-element/src/decorators/computed.ts
+++ b/packages/reactive-element/src/decorators/computed.ts
@@ -1,0 +1,126 @@
+/**
+ * @license
+ * Copyright 2017 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * IMPORTANT: For compatibility with tsickle and the Closure JS compiler, all
+ * property decorators (but not class decorators) in this file that have
+ * an @ExportDecoratedItems annotation must be defined as a regular function,
+ * not an arrow function.
+ */
+
+import {ReactiveElement, PropertyDeclaration} from '../reactive-element.js';
+import {decorateProperty} from './base.js';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ComputedFunction = (...args: any[]) => unknown;
+interface ComputedInfo {
+  computed: ComputedFunction;
+  deps: string[];
+}
+type ComputedPropsMap = Map<PropertyKey, ComputedInfo>;
+
+const computedInfo: WeakMap<
+  typeof ReactiveElement,
+  ComputedPropsMap
+> = new WeakMap();
+
+const previousElementValues: WeakMap<
+  ReactiveElement,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Map<PropertyKey, any>
+> = new WeakMap();
+
+const getPreviousValues = (el: ReactiveElement) => {
+  let previousValues = previousElementValues.get(el);
+  if (previousValues === undefined) {
+    previousElementValues.set(el, (previousValues = new Map()));
+  }
+  return previousValues;
+};
+
+/**
+ * Adds a computed property.
+ *
+ * @param computed {Function} A function which computes the property value given
+ * the values of the properties identified via the deps param.
+ *
+ * @param deps {Array} An array of the property names of the dependencies of
+ * the computed function.
+ *
+ * @example
+ * ```ts
+ * class MyElement {
+ *   @property()
+ *   @computed((a, b) => a + b, ['a', 'b'])
+ *   computed;
+ * }
+ * ```
+ * @category Decorator
+ */
+export function computed(computed: ComputedFunction, deps: string[]) {
+  return decorateProperty({
+    finisher: (ctor: typeof ReactiveElement, name: PropertyKey) => {
+      let computedProps = computedInfo.get(ctor);
+      // Setup computed properties for this class
+      if (computedProps === undefined) {
+        computedInfo.set(ctor, (computedProps = new Map()));
+        // Returns the value of the given property. If this is a computed
+        // property, its value is computed and then returned.
+        // Note, a property value is only computed once per update. This
+        // effectively makes computing properties a DAG.
+        const computeValue = (
+          el: ReactiveElement,
+          name: PropertyKey,
+          hasComputed: Set<ComputedInfo>,
+          info?: ComputedInfo
+        ) => {
+          if (info !== undefined && !hasComputed.has(info)) {
+            hasComputed.add(info);
+            const previousValues = getPreviousValues(el);
+            // Calculate if deps are dirty;
+            // Note, requires manual dirty tracking.
+            let depsDirty = info.deps.length === 0;
+            info.deps.forEach((d: string) => {
+              const previous = previousValues!.get(d);
+              const depInfo = computedProps!.get(d);
+              const value = computeValue(el, d, hasComputed, depInfo);
+              previousValues.set(d, value);
+              if (!depsDirty) {
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                const {hasChanged} = (el.constructor as any).getPropertyOptions(
+                  d
+                ) as PropertyDeclaration;
+                depsDirty = hasChanged!(value, previous);
+              }
+            });
+            // Only compute if deps are dirty.
+            if (depsDirty) {
+              const args = info.deps.map((n: PropertyKey) =>
+                computeValue(el, n, hasComputed, computedProps!.get(n))
+              );
+              ((el as unknown) as {[key: string]: unknown})[
+                name as string
+              ] = info.computed.apply(null, args);
+            }
+          }
+          return el[name as keyof ReactiveElement];
+        };
+
+        ctor.addInitializer((el: ReactiveElement) => {
+          el.addController({
+            hostUpdate() {
+              const hasComputed: Set<ComputedInfo> = new Set();
+              computedProps!.forEach((info, name) =>
+                computeValue(el, name, hasComputed, info)
+              );
+            },
+          });
+        });
+      }
+      computedProps.set(name, {computed, deps});
+    },
+  });
+}

--- a/packages/reactive-element/src/decorators/listen.ts
+++ b/packages/reactive-element/src/decorators/listen.ts
@@ -1,0 +1,165 @@
+/**
+ * @license
+ * Copyright 2017 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * IMPORTANT: For compatibility with tsickle and the Closure JS compiler, all
+ * property decorators (but not class decorators) in this file that have
+ * an @ExportDecoratedItems annotation must be defined as a regular function,
+ * not an arrow function.
+ */
+
+import {ReactiveElement} from '../reactive-element.js';
+import {decorateProperty} from './base.js';
+
+interface ListenInfo {
+  type: string;
+  prop: PropertyKey;
+  options?: EventListenerOptions;
+  target: '' | 'root' | EventTarget;
+}
+
+type Listeners = ListenInfo[];
+
+const hostListeners: WeakMap<typeof ReactiveElement, Listeners> = new WeakMap();
+const rootListeners: WeakMap<typeof ReactiveElement, Listeners> = new WeakMap();
+const targetedListeners: WeakMap<
+  typeof ReactiveElement,
+  Listeners
+> = new WeakMap();
+
+// This is done so we can call the listener in the right context.
+// TODO(sorvell): Alternatively, can require users to bind the function, but this
+// seemslike a foot gun.
+const listenerMap: WeakMap<
+  ReactiveElement,
+  Map<ListenInfo, EventListener>
+> = new WeakMap();
+
+const getListener = (
+  el: ReactiveElement,
+  listener: EventListener,
+  info: ListenInfo
+) => {
+  let listeners = listenerMap.get(el);
+  if (listeners === undefined) {
+    listenerMap.set(el, (listeners = new Map()));
+  }
+  let listenFn = listeners.get(info);
+  if (listenFn === undefined) {
+    listeners.set(info, (listenFn = listener.bind(el)));
+  }
+  return listenFn;
+};
+
+const addRemoveListeners = (
+  el: ReactiveElement,
+  listeners: Listeners,
+  remove = false
+) => {
+  listeners.forEach((info: ListenInfo) => {
+    const {type, prop, options, target} = info;
+    const eventTarget =
+      target === 'root'
+        ? el.renderRoot
+        : target instanceof EventTarget
+        ? target
+        : el;
+    const listener = (((el as unknown) as {[prop: string]: Element | null})[
+      prop as string
+    ] as unknown) as EventListener;
+    const listenFn = getListener(el, listener, info);
+    if (remove) {
+      eventTarget.removeEventListener(type, listenFn, options);
+    } else {
+      eventTarget.addEventListener(type, listenFn, options);
+    }
+  });
+};
+
+const hasRootListeners: Set<ReactiveElement> = new Set();
+
+/**
+ * Adds an event listener.
+ *
+ * @param options {object} An object specifying event listener options. This
+ * object must include the `type` of the event for which to listen and
+ * optionally may include an `options` property to specify the
+ * `EventListenerOptions` and a `target` property. When `target` is not provided
+ * the event listener is installed on the element itself. If set to `root`,
+ * the listener is installed on the element `renderRoot`. Otherwise
+ * `target` is assumed to be an `EventTarget` and the listener is installed
+ * directly on it. When the `target` is an `EventTarget`, the listener is
+ * dynamically added and removed when the element is connected/disconnected
+ * from the DOM.
+ *
+ * @example
+ * ```ts
+ * class MyElement {
+ *   @listen('click')
+ *   private _clickHandler(e: Event) => {
+ *     this.clickedOn = e.target.localName;
+ *   }
+ *   @listen('keydown', window, {capture: true}))
+ *   private _keyDown(e: Event) => {
+ *     this.key = e.target.keyCode;
+ *   }
+ * }
+ * ```
+ * @category Decorator
+ */
+export function listen({
+  type,
+  options,
+  target,
+}: {
+  type: string;
+  options?: EventListenerOptions;
+  target?: '' | 'root' | EventTarget;
+}) {
+  return decorateProperty({
+    finisher: (ctor: typeof ReactiveElement, prop: PropertyKey) => {
+      let host = hostListeners.get(ctor);
+      let root = rootListeners.get(ctor);
+      let targeted = targetedListeners.get(ctor);
+      // Setup listener tracking for this class
+      if (host === undefined) {
+        hostListeners.set(ctor, (host = []));
+        rootListeners.set(ctor, (root = []));
+        targetedListeners.set(ctor, (targeted = []));
+        ctor.addInitializer((el: ReactiveElement) => {
+          // Add host listeners early
+          addRemoveListeners(el, host!);
+          el.addController({
+            hostConnected() {
+              // Add renderRoot listeners once, when renderRoot is available.
+              if (!hasRootListeners.has(el)) {
+                hasRootListeners.add(el);
+                addRemoveListeners(el, root!);
+              }
+              // Add targeted listeners on every connection
+              addRemoveListeners(el, targeted!);
+            },
+            hostDisconnected() {
+              addRemoveListeners(el, targeted!, true);
+            },
+          });
+        });
+      }
+      const list =
+        target === 'root'
+          ? root!
+          : target instanceof EventTarget
+          ? targeted!
+          : host!;
+      list.push({
+        type,
+        prop,
+        options,
+        target: target ?? '',
+      });
+    },
+  });
+}

--- a/packages/reactive-element/src/decorators/observe.ts
+++ b/packages/reactive-element/src/decorators/observe.ts
@@ -1,0 +1,105 @@
+/**
+ * @license
+ * Copyright 2017 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * IMPORTANT: For compatibility with tsickle and the Closure JS compiler, all
+ * property decorators (but not class decorators) in this file that have
+ * an @ExportDecoratedItems annotation must be defined as a regular function,
+ * not an arrow function.
+ */
+
+import {ReactiveElement, PropertyDeclaration} from '../reactive-element.js';
+import {decorateProperty} from './base.js';
+
+type ObserveFunction = (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  value: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  oldValue: any,
+  name: PropertyKey
+) => void;
+
+type ObservedPropsMap = Map<PropertyKey, ObserveFunction>;
+
+const observedInfo: WeakMap<
+  typeof ReactiveElement,
+  ObservedPropsMap
+> = new WeakMap();
+
+// Note, previous values are not provided via `hostUpdated`
+// but are needed here. Therefore, tracking is done manually.
+const previousValues: WeakMap<
+  ReactiveElement,
+  Map<PropertyKey, unknown>
+> = new WeakMap();
+const getAndUpdatePreviousValue = (
+  el: ReactiveElement,
+  name: PropertyKey,
+  value: unknown
+) => {
+  let previousProps = previousValues.get(el);
+  if (previousProps === undefined) {
+    previousValues.set(el, (previousProps = new Map()));
+  }
+  const previous = previousProps.get(name);
+  previousProps.set(name, value);
+  return previous;
+};
+
+/**
+ * Adds a property value observer.
+ *
+ * @param observe {ObserveFunction} A function which observes the property value
+ * change. It is passed the current and previous value as well as the name
+ * of the property.
+ *
+ * @example
+ * ```ts
+ * class MyElement {
+ *   @property()
+ *   @observe((value, previous, name) => {
+ *     const max = 5;
+ *     if (value > max) {
+ *       this[name] = previous;
+ *       console.log(`Element of type ${this.localName}, property ${name}
+ *         with value '${value}' exceeded maximum of '${max}', resetting
+ *         to '${previous}'.`)
+ *     }
+ *   })
+ *   observedProp;
+ * }
+ * ```
+ * @category Decorator
+ */
+export function observe(observer: ObserveFunction) {
+  return decorateProperty({
+    finisher: (ctor: typeof ReactiveElement, name: PropertyKey) => {
+      let observedProps = observedInfo.get(ctor);
+      // Setup observed properties for this class
+      if (observedProps === undefined) {
+        observedInfo.set(ctor, (observedProps = new Map()));
+        ctor.addInitializer((el: ReactiveElement) => {
+          el.addController({
+            hostUpdated() {
+              observedProps!.forEach((observer, name) => {
+                const value = el[name as keyof ReactiveElement];
+                const previous = getAndUpdatePreviousValue(el, name, value);
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                const {hasChanged} = (el.constructor as any).getPropertyOptions(
+                  name
+                ) as PropertyDeclaration;
+                if (hasChanged!(value, previous)) {
+                  observer.call(el, value, previous, name);
+                }
+              });
+            },
+          });
+        });
+      }
+      observedProps.set(name, observer);
+    },
+  });
+}

--- a/packages/reactive-element/src/test/decorators/computed_test.ts
+++ b/packages/reactive-element/src/test/decorators/computed_test.ts
@@ -1,0 +1,277 @@
+/**
+ * @license
+ * Copyright 2017 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {ReactiveElement} from '../../reactive-element.js';
+import {property} from '../../decorators/property.js';
+import {computed} from '../../decorators/computed.js';
+import {generateElementName} from '../test-helpers.js';
+import {assert} from '@esm-bundle/chai';
+
+suite('@computed', () => {
+  let container: HTMLElement;
+
+  setup(() => {
+    container = document.createElement('div');
+    container.id = 'test-container';
+    document.body.appendChild(container);
+  });
+
+  teardown(() => {
+    if (container !== undefined) {
+      container.parentElement!.removeChild(container);
+      (container as any) = undefined;
+    }
+  });
+
+  test('can compute value', async () => {
+    let computedValue = 1;
+    class E extends ReactiveElement {
+      @property()
+      @computed(() => computedValue, [])
+      computedProp = -1;
+    }
+    customElements.define(generateElementName(), E);
+    const el = new E();
+    container.appendChild(el);
+    assert.equal(el.computedProp, -1);
+    await el.updateComplete;
+    assert.equal(el.computedProp, 1);
+    computedValue++;
+    el.requestUpdate();
+    await el.updateComplete;
+    assert.equal(el.computedProp, 2);
+  });
+
+  test('can use deps', async () => {
+    class E extends ReactiveElement {
+      @property()
+      @computed((dep1: number, dep2: number) => dep1 + dep2, ['dep1', 'dep2'])
+      computedProp = -1;
+
+      @property()
+      dep1 = 1;
+
+      @property()
+      dep2 = 2;
+    }
+    customElements.define(generateElementName(), E);
+    const el = new E();
+    container.appendChild(el);
+    assert.equal(el.computedProp, -1);
+    await el.updateComplete;
+    assert.equal(el.computedProp, 3);
+    el.dep2 = 5;
+    await el.updateComplete;
+    assert.equal(el.computedProp, 6);
+    el.dep1 = 3;
+    el.dep2 = 11;
+    await el.updateComplete;
+    assert.equal(el.computedProp, 14);
+  });
+
+  test('deps can be computed properties', async () => {
+    class E extends ReactiveElement {
+      @property()
+      @computed((c1d1, c2) => c1d1 + c2, ['c1d1', 'c2'])
+      c1 = -1;
+
+      @property()
+      c1d1 = 1;
+
+      @property()
+      @computed((c2d1, c3) => c2d1 + c3, ['c2d1', 'c3'])
+      c2 = -2;
+
+      @property()
+      c2d1 = 2;
+
+      @property()
+      @computed((c3d1, c3d2) => c3d1 + c3d2, ['c3d1', 'c3d2'])
+      c3 = -3;
+
+      @property()
+      c3d1 = 3;
+
+      @property()
+      c3d2 = 4;
+
+      @property()
+      @computed((c1, c2, c3) => c1 + c2 + c3, ['c1', 'c2', 'c3'])
+      total = -4;
+    }
+    customElements.define(generateElementName(), E);
+    const el = new E();
+    container.appendChild(el);
+    assert.equal(el.c3, -3);
+    assert.equal(el.c2, -2);
+    assert.equal(el.c1, -1);
+    assert.equal(el.total, -4);
+    await el.updateComplete;
+    assert.equal(el.c3, 7);
+    assert.equal(el.c2, 9);
+    assert.equal(el.c1, 10);
+    assert.equal(el.total, 26);
+    el.c3d1 = 10;
+    await el.updateComplete;
+    assert.equal(el.c3, 14);
+    assert.equal(el.c2, 16);
+    assert.equal(el.c1, 17);
+    assert.equal(el.total, 47);
+    el.c1d1 = 50;
+    el.c2d1 = 60;
+    el.c3d1 = 70;
+    el.c3d2 = 80;
+    await el.updateComplete;
+    assert.equal(el.c3, 150);
+    assert.equal(el.c2, 210);
+    assert.equal(el.c1, 260);
+    assert.equal(el.total, 620);
+  });
+
+  test('computes only if deps change', async () => {
+    let didCompute = false;
+    class E extends ReactiveElement {
+      @property()
+      @computed(
+        (dep1: number, dep2: number) => {
+          didCompute = true;
+          return dep1 + dep2;
+        },
+        ['dep1', 'dep2']
+      )
+      computedProp = -1;
+
+      @property()
+      dep1 = 1;
+
+      @property()
+      dep2 = 2;
+    }
+    customElements.define(generateElementName(), E);
+    const el = new E();
+    container.appendChild(el);
+    assert.equal(el.computedProp, -1);
+    await el.updateComplete;
+    assert.isTrue(didCompute);
+    didCompute = false;
+    el.requestUpdate();
+    await el.updateComplete;
+    assert.isFalse(didCompute);
+    didCompute = false;
+    el.dep2 = 5;
+    await el.updateComplete;
+    assert.isTrue(didCompute);
+  });
+
+  test('values computed at most once per update', async () => {
+    let c1Count = 0;
+    let c2Count = 0;
+    let c3Count = 0;
+    let c4Count = 0;
+    const assertCounts = (
+      count1: number,
+      count2: number,
+      count3: number,
+      count4: number
+    ) => {
+      assert.equal(c1Count, count1);
+      assert.equal(c2Count, count2);
+      assert.equal(c3Count, count3);
+      assert.equal(c4Count, count4);
+      c1Count = c2Count = c3Count = c4Count = 0;
+    };
+    class E extends ReactiveElement {
+      @property()
+      @computed(
+        (c1d1, c2) => {
+          c1Count++;
+          return c1d1 + c2;
+        },
+        ['c1d1', 'c2']
+      )
+      c1 = -1;
+
+      @property()
+      c1d1 = 1;
+
+      @property()
+      @computed(
+        (c2d1, c3) => {
+          c2Count++;
+          return c2d1 + c3;
+        },
+        ['c2d1', 'c3']
+      )
+      c2 = -2;
+
+      @property()
+      c2d1 = 2;
+
+      @property()
+      @computed(
+        (c3d1, c3d2) => {
+          c3Count++;
+          return c3d1 + c3d2;
+        },
+        ['c3d1', 'c3d2']
+      )
+      c3 = -3;
+
+      @property()
+      c3d1 = 3;
+
+      @property()
+      c3d2 = 4;
+
+      @property()
+      @computed(
+        (c1, c2, c3) => {
+          c4Count++;
+          return c1 + c2 + c3;
+        },
+        ['c1', 'c2', 'c3']
+      )
+      total = -4;
+    }
+    customElements.define(generateElementName(), E);
+    const el = new E();
+    container.appendChild(el);
+    assertCounts(0, 0, 0, 0);
+    await el.updateComplete;
+    assertCounts(1, 1, 1, 1);
+    el.c1d1 = 10;
+    await el.updateComplete;
+    assertCounts(1, 0, 0, 1);
+    el.c1d1 = 10;
+    await el.updateComplete;
+    assertCounts(0, 0, 0, 0);
+    el.c2d1 = 60;
+    await el.updateComplete;
+    assertCounts(1, 1, 0, 1);
+    el.c3d1 = 70;
+    await el.updateComplete;
+    assertCounts(1, 1, 1, 1);
+    el.requestUpdate();
+    await el.updateComplete;
+    assertCounts(0, 0, 0, 0);
+  });
+
+  test('compute function cannot reference element', async () => {
+    class E extends ReactiveElement {
+      @property()
+      @computed(() => {
+        assert.notOk(this);
+        return 'ok';
+      }, [])
+      computedProp = '';
+    }
+    customElements.define(generateElementName(), E);
+    const el = new E();
+    container.appendChild(el);
+    await el.updateComplete;
+    assert.equal(el.computedProp, 'ok');
+  });
+});

--- a/packages/reactive-element/src/test/decorators/listen_test.ts
+++ b/packages/reactive-element/src/test/decorators/listen_test.ts
@@ -1,0 +1,175 @@
+/**
+ * @license
+ * Copyright 2017 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {ReactiveElement} from '../../reactive-element.js';
+import {listen} from '../../decorators/listen.js';
+import {generateElementName} from '../test-helpers.js';
+import {assert} from '@esm-bundle/chai';
+
+suite('@listen', () => {
+  let container: HTMLElement;
+
+  setup(() => {
+    container = document.createElement('div');
+    container.id = 'test-container';
+    document.body.appendChild(container);
+  });
+
+  teardown(() => {
+    if (container !== undefined) {
+      container.parentElement!.removeChild(container);
+      (container as any) = undefined;
+    }
+  });
+
+  test('can listen on host and root', async () => {
+    class E extends ReactiveElement {
+      hostListenInfo = {};
+      rootListenInfo = {};
+      @listen({type: 'foo'})
+      _hostHandler(e: Event) {
+        this.hostListenInfo = {
+          type: e.type,
+          name: (e.target as Element).localName,
+        };
+      }
+
+      @listen({type: 'foo', target: 'root'})
+      _rootHandler(e: Event) {
+        this.rootListenInfo = {
+          type: e.type,
+          name: (e.target as Element).localName,
+        };
+      }
+    }
+    const name = generateElementName();
+    customElements.define(name, E);
+    const el = new E();
+    container.appendChild(el);
+    await el.updateComplete;
+    assert.deepEqual(el.hostListenInfo, {});
+    assert.deepEqual(el.rootListenInfo, {});
+    el.dispatchEvent(new Event('foo'));
+    assert.deepEqual(el.hostListenInfo, {type: 'foo', name});
+    assert.deepEqual(el.rootListenInfo, {});
+    el.hostListenInfo = el.rootListenInfo = {};
+    el.shadowRoot!.dispatchEvent(new Event('foo'));
+    assert.deepEqual(el.rootListenInfo, {type: 'foo', name: undefined});
+    assert.deepEqual(el.hostListenInfo, {});
+    el.hostListenInfo = el.rootListenInfo = {};
+    el.shadowRoot!.dispatchEvent(new Event('foo', {composed: true}));
+    assert.deepEqual(el.rootListenInfo, {type: 'foo', name: undefined});
+    assert.deepEqual(el.hostListenInfo, {type: 'foo', name});
+    el.remove();
+    el.hostListenInfo = el.rootListenInfo = {};
+    el.shadowRoot!.dispatchEvent(new Event('foo', {composed: true}));
+    assert.deepEqual(el.rootListenInfo, {type: 'foo', name: undefined});
+    assert.deepEqual(el.hostListenInfo, {type: 'foo', name});
+  });
+
+  test('can listen with event options', async () => {
+    class E extends ReactiveElement {
+      listenInfo: string[] = [];
+      @listen({type: 'foo', options: {capture: true}})
+      _hostHandler() {
+        this.listenInfo.push('@listen');
+      }
+
+      constructor() {
+        super();
+        this.addEventListener('foo', () => {
+          this.listenInfo.push('addEventListener');
+        });
+      }
+    }
+    const name = generateElementName();
+    customElements.define(name, E);
+    const el = new E();
+    container.appendChild(el);
+    await el.updateComplete;
+    assert.deepEqual(el.listenInfo, []);
+    el.dispatchEvent(new Event('foo'));
+    assert.deepEqual(el.listenInfo, ['@listen', 'addEventListener']);
+  });
+
+  test('can listen on target', async () => {
+    class E extends ReactiveElement {
+      targetListenInfo = {};
+      @listen({type: 'foo', target: document})
+      _targetHandler(e: Event) {
+        this.targetListenInfo = {
+          type: e.type,
+          target: e.target,
+        };
+      }
+    }
+    const name = generateElementName();
+    customElements.define(name, E);
+    const el = new E();
+    container.appendChild(el);
+    await el.updateComplete;
+    assert.deepEqual(el.targetListenInfo, {});
+    document.dispatchEvent(new Event('foo'));
+    assert.deepEqual(el.targetListenInfo, {type: 'foo', target: document});
+    el.targetListenInfo = {};
+    el.remove();
+    document.dispatchEvent(new Event('foo'));
+    assert.deepEqual(el.targetListenInfo, {});
+    container.appendChild(el);
+    document.dispatchEvent(new Event('foo'));
+    assert.deepEqual(el.targetListenInfo, {type: 'foo', target: document});
+    // add/remove one more time
+    el.targetListenInfo = {};
+    el.remove();
+    document.dispatchEvent(new Event('foo'));
+    assert.deepEqual(el.targetListenInfo, {});
+    container.appendChild(el);
+    document.dispatchEvent(new Event('foo'));
+    assert.deepEqual(el.targetListenInfo, {type: 'foo', target: document});
+  });
+
+  test('can install multiple listener types', async () => {
+    class E extends ReactiveElement {
+      listenInfo: {}[] = [];
+      @listen({type: 'click'})
+      @listen({type: 'bar', target: 'root'})
+      @listen({type: 'click', target: document})
+      _handler(e: Event) {
+        this.listenInfo.push({
+          type: e.type,
+          currentTarget: e.currentTarget,
+        });
+      }
+    }
+    const name = generateElementName();
+    customElements.define(name, E);
+    const el = new E();
+    container.appendChild(el);
+    await el.updateComplete;
+    assert.deepEqual(el.listenInfo, []);
+    el.renderRoot.dispatchEvent(new Event('bar'));
+    assert.deepEqual(el.listenInfo, [
+      {type: 'bar', currentTarget: el.renderRoot},
+    ]);
+    el.listenInfo = [];
+    el.renderRoot.dispatchEvent(
+      new Event('click', {composed: true, bubbles: true})
+    );
+    assert.deepEqual(el.listenInfo, [
+      {type: 'click', currentTarget: el},
+      {type: 'click', currentTarget: document},
+    ]);
+    el.listenInfo = [];
+    document.dispatchEvent(new Event('click', {composed: true, bubbles: true}));
+    assert.deepEqual(el.listenInfo, [{type: 'click', currentTarget: document}]);
+    el.remove();
+    el.listenInfo = [];
+    document.dispatchEvent(new Event('click', {composed: true, bubbles: true}));
+    assert.deepEqual(el.listenInfo, []);
+    el.dispatchEvent(new Event('click', {composed: true, bubbles: true}));
+    assert.deepEqual(el.listenInfo, [{type: 'click', currentTarget: el}]);
+  });
+});

--- a/packages/reactive-element/src/test/decorators/observe_test.ts
+++ b/packages/reactive-element/src/test/decorators/observe_test.ts
@@ -1,0 +1,162 @@
+/**
+ * @license
+ * Copyright 2017 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {ReactiveElement} from '../../reactive-element.js';
+import {property} from '../../decorators/property.js';
+import {computed} from '../../decorators/computed.js';
+import {observe} from '../../decorators/observe.js';
+import {generateElementName} from '../test-helpers.js';
+import {assert} from '@esm-bundle/chai';
+
+suite('@observe', () => {
+  let container: HTMLElement;
+
+  setup(() => {
+    container = document.createElement('div');
+    container.id = 'test-container';
+    document.body.appendChild(container);
+  });
+
+  teardown(() => {
+    if (container !== undefined) {
+      container.parentElement!.removeChild(container);
+      (container as any) = undefined;
+    }
+  });
+
+  test('can observe value', async () => {
+    class E extends ReactiveElement {
+      observeInfo1 = {};
+      observeInfo2 = {};
+
+      @property()
+      @observe(function (
+        this: E,
+        value: number,
+        old: number | undefined,
+        name: PropertyKey
+      ) {
+        this.observeInfo1 = {value, old, name};
+      })
+      prop1?: number;
+
+      @property()
+      @observe(function (
+        this: E,
+        value: number,
+        old: number | undefined,
+        name: PropertyKey
+      ) {
+        this.observeInfo2 = {value, old, name};
+      })
+      prop2 = 'hi';
+    }
+    customElements.define(generateElementName(), E);
+    const el = new E();
+    container.appendChild(el);
+    await el.updateComplete;
+    assert.deepEqual(el.observeInfo1, {});
+    assert.deepEqual(el.observeInfo2, {
+      value: 'hi',
+      old: undefined,
+      name: 'prop2',
+    });
+    el.observeInfo1 = el.observeInfo2 = {};
+    el.prop1 = 1;
+    await el.updateComplete;
+    assert.deepEqual(el.observeInfo1, {
+      value: 1,
+      old: undefined,
+      name: 'prop1',
+    });
+    assert.deepEqual(el.observeInfo2, {});
+    el.observeInfo1 = el.observeInfo2 = {};
+    el.prop1 = 2;
+    el.prop2 = 'yo';
+    await el.updateComplete;
+    assert.deepEqual(el.observeInfo1, {value: 2, old: 1, name: 'prop1'});
+    assert.deepEqual(el.observeInfo2, {value: 'yo', old: 'hi', name: 'prop2'});
+    el.observeInfo1 = el.observeInfo2 = {};
+    el.requestUpdate();
+    await el.updateComplete;
+    assert.deepEqual(el.observeInfo1, {});
+    assert.deepEqual(el.observeInfo2, {});
+  });
+
+  test('can use hasChanged', async () => {
+    class E extends ReactiveElement {
+      observeInfo = {};
+      @property({
+        hasChanged: (v: number, p?: number) => p === undefined || v > p,
+      })
+      @observe(function (
+        this: E,
+        value: number,
+        old: number | undefined,
+        name: PropertyKey
+      ) {
+        this.observeInfo = {value, old, name};
+      })
+      prop = 1;
+    }
+    customElements.define(generateElementName(), E);
+    const el = new E();
+    container.appendChild(el);
+    await el.updateComplete;
+    assert.deepEqual(el.observeInfo, {value: 1, old: undefined, name: 'prop'});
+    el.observeInfo = {};
+    el.prop = 5;
+    await el.updateComplete;
+    assert.deepEqual(el.observeInfo, {value: 5, old: 1, name: 'prop'});
+    el.prop = 4;
+    el.observeInfo = {};
+    await el.updateComplete;
+    assert.deepEqual(el.observeInfo, {});
+    // Should not provoke an update, but force update to verify custom
+    // hasChanged handling is working.
+    el.requestUpdate();
+    await el.updateComplete;
+    assert.deepEqual(el.observeInfo, {});
+    el.prop = 5;
+    el.observeInfo = {};
+    await el.updateComplete;
+    assert.deepEqual(el.observeInfo, {value: 5, old: 4, name: 'prop'});
+  });
+
+  test('can observe computed property', async () => {
+    class E extends ReactiveElement {
+      observeInfo = {};
+      @property({
+        hasChanged: (v: number, p?: number) => p === undefined || v > p,
+      })
+      @computed((d1: number, d2: number) => d1 + d2, ['d1', 'd2'])
+      @observe(function (
+        this: E,
+        value: number,
+        old: number | undefined,
+        name: PropertyKey
+      ) {
+        this.observeInfo = {value, old, name};
+      })
+      prop?: number;
+
+      @property()
+      d1 = 1;
+
+      @property()
+      d2 = 2;
+    }
+    customElements.define(generateElementName(), E);
+    const el = new E();
+    container.appendChild(el);
+    await el.updateComplete;
+    assert.deepEqual(el.observeInfo, {value: 3, old: undefined, name: 'prop'});
+    el.observeInfo = {};
+    el.d1 = 10;
+    await el.updateComplete;
+    assert.deepEqual(el.observeInfo, {value: 12, old: 3, name: 'prop'});
+  });
+});


### PR DESCRIPTION
* Adds `@computed` decorator for creating computed properties. Decorator specifies an array of deps which are the names of dependent properties and a compute function which is called with dependency values and should return the computed property value.

* Adds `@observe` decorator for observing property changes. Decorator specifies an observe function which receives the current and previous value of the property as well as the name of the property. Note, the observed property must be a reactive property.

* Adds `@listen` decorator for declaratively adding event listeners. The decorator should be placed on an element property which is an event listener function. The decorator must provide an object which specifies the event `type`, `options`, and an optional `target`. The `target` defaults to the element itself or may be `root` to add the listener to the element's
 `renderRoot`, or an instance of `EventTarget`. If `target` is an `EventTarget`,
the listener is dynamically added and removed when the element is connected and disconnected.