### PR TITLE
[reactive-element] Adds `decorators` to `static properties`

### DIFF
--- a/packages/reactive-element/CHANGELOG.md
+++ b/packages/reactive-element/CHANGELOG.md
@@ -24,7 +24,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - (Since 1.0.0-rc.2) Added ability to specify decorators in `static properties`
   by adding a `decorators` array with decorator function calls. Use
   `reactive: false` if the property should not be reactive, for example to
-  decorate a method.
+  decorate a method [#1884](https://github.com/lit/lit/pull/1884).
+
+### Changed
+
+- (Since 1.0.0-rc.2) [Breaking] Property options now merge between superclasses
+  and subclasses for individual properties [#1884](https://github.com/lit/lit/pull/1884)..
 
 ## 1.0.0-rc.2 - 2021-05-07
 

--- a/packages/reactive-element/CHANGELOG.md
+++ b/packages/reactive-element/CHANGELOG.md
@@ -17,6 +17,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- ### Removed -->
 <!-- ### Fixed -->
 
+## Unreleased
+
+### Added
+
+- (Since 1.0.0-rc.2) Added ability to specify decorators in `static properties`
+  by adding a `decorators` array with decorator function calls. Use
+  `reactive: false` if the property should not be reactive, for example to
+  decorate a method.
+
 ## 1.0.0-rc.2 - 2021-05-07
 
 ### Changed

--- a/packages/reactive-element/src/decorators/base.ts
+++ b/packages/reactive-element/src/decorators/base.ts
@@ -4,30 +4,17 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {ReactiveElement} from '../reactive-element.js';
-
-export type Constructor<T> = {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  new (...args: any[]): T;
-};
-
-// From the TC39 Decorators proposal
-export interface ClassDescriptor {
-  kind: 'class';
-  elements: ClassElement[];
-  finisher?: <T>(clazz: Constructor<T>) => void | Constructor<T>;
-}
-
-// From the TC39 Decorators proposal
-export interface ClassElement {
-  kind: 'field' | 'method';
-  key: PropertyKey;
-  placement: 'static' | 'prototype' | 'own';
-  initializer?: Function;
-  extras?: ClassElement[];
-  finisher?: <T>(clazz: Constructor<T>) => void | Constructor<T>;
-  descriptor?: PropertyDescriptor;
-}
+import {
+  ReactiveElement,
+  ClassElement,
+  Constructor,
+} from '../reactive-element.js';
+export {
+  Constructor,
+  ClassElement,
+  ClassDescriptor,
+  CompatiblePropertyDecorator,
+} from '../reactive-element.js';
 
 export const legacyPrototypeMethod = (
   descriptor: PropertyDescriptor,

--- a/packages/reactive-element/src/reactive-element.ts
+++ b/packages/reactive-element/src/reactive-element.ts
@@ -539,11 +539,9 @@ export abstract class ReactiveElement
         Object.defineProperty(this.prototype, name, descriptor);
       }
     }
-    if (options.decorators !== undefined) {
-      options.decorators.forEach((decorator) => {
-        decorator(this.prototype, name);
-      });
-    }
+    options.decorators?.forEach((decorator) => {
+      decorator(this.prototype, name);
+    });
   }
 
   /**

--- a/packages/reactive-element/src/test/decorators/properties_decorators_test.ts
+++ b/packages/reactive-element/src/test/decorators/properties_decorators_test.ts
@@ -1,0 +1,225 @@
+/**
+ * @license
+ * Copyright 2017 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {decorateProperty} from '../../decorators/base.js';
+import {query} from '../../decorators/query.js';
+import {property} from '../../decorators/property.js';
+import {ReactiveElement, PropertyValues} from '../../reactive-element.js';
+import {
+  generateElementName,
+  canTestReactiveElement,
+  RenderingElement,
+  html,
+} from '../test-helpers.js';
+import {assert} from '@esm-bundle/chai';
+
+suite('decorators in static properties', () => {
+  let container: HTMLElement;
+
+  setup(async () => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  teardown(() => {
+    document.body.removeChild(container);
+  });
+
+  class WithDecorations extends ReactiveElement {
+    decorations?: {name: PropertyKey; value: string}[];
+  }
+
+  const wasDecorated = (value: string) =>
+    decorateProperty({
+      finisher: (ctor: typeof ReactiveElement, name: PropertyKey) => {
+        ctor.addInitializer((e: ReactiveElement) => {
+          (e as WithDecorations).decorations ??= [];
+          (e as WithDecorations).decorations!.push({name, value});
+        });
+      },
+    });
+
+  test('can apply decorator to reactive property', async () => {
+    let changedSnapshot: PropertyValues;
+    class A extends WithDecorations {
+      static get properties() {
+        return {
+          foo: {decorators: [wasDecorated('a'), wasDecorated('b')]},
+          bar: {decorators: [wasDecorated('c'), wasDecorated('d')]},
+        };
+      }
+
+      updated(changed: PropertyValues) {
+        changedSnapshot = new Map(changed);
+      }
+    }
+    customElements.define(generateElementName(), A);
+    const el = new A();
+    container.appendChild(el);
+    await el.updateComplete;
+    assert.deepEqual(changedSnapshot!, new Map());
+    assert.deepEqual(el.decorations, [
+      {name: 'foo', value: 'a'},
+      {name: 'foo', value: 'b'},
+      {name: 'bar', value: 'c'},
+      {name: 'bar', value: 'd'},
+    ]);
+    (el as any).foo = 'test';
+    (el as any).bar = 'test2';
+    await el.updateComplete;
+    assert.deepEqual(
+      changedSnapshot!,
+      new Map([
+        ['foo', undefined],
+        ['bar', undefined],
+      ])
+    );
+  });
+
+  test('can apply decorators to non-reactive property', async () => {
+    class A extends WithDecorations {
+      static get properties() {
+        return {
+          method: {
+            reactive: false,
+            decorators: [wasDecorated('a'), wasDecorated('b')],
+          },
+        };
+      }
+      called = 0;
+      method() {
+        this.called++;
+      }
+    }
+    customElements.define(generateElementName(), A);
+    const el = new A();
+    container.appendChild(el);
+    await el.updateComplete;
+    assert.deepEqual(el.decorations, [
+      {name: 'method', value: 'a'},
+      {name: 'method', value: 'b'},
+    ]);
+    el.method();
+    el.method();
+    assert.equal(el.called, 2);
+  });
+
+  (canTestReactiveElement ? test : test.skip)(
+    'can apply query decorator',
+    async () => {
+      class A extends RenderingElement {
+        static get properties() {
+          return {
+            div: {reactive: false, decorators: [query('#blah')]},
+          };
+        }
+
+        div?: HTMLDivElement;
+
+        render() {
+          return html` <div id="blah">This one</div> `;
+        }
+      }
+      customElements.define(generateElementName(), A);
+      const el = new A();
+      container.appendChild(el);
+      await el.updateComplete;
+      assert.equal(el.div, el.shadowRoot!.firstElementChild as HTMLDivElement);
+    }
+  );
+
+  test('can compose decorators via subclassing', async () => {
+    class A extends WithDecorations {
+      static get properties() {
+        return {
+          foo: {
+            decorators: [wasDecorated('a')],
+          },
+          method: {
+            reactive: false,
+            decorators: [wasDecorated('m1'), wasDecorated('m2')],
+          },
+        };
+      }
+      called = 0;
+      method() {
+        this.called++;
+      }
+    }
+    customElements.define(generateElementName(), A);
+    class B extends A {
+      static get properties() {
+        return {
+          foo: {
+            decorators: [wasDecorated('b')],
+          },
+          bar: {decorators: [wasDecorated('c'), wasDecorated('d')]},
+          method: {
+            reactive: false,
+            decorators: [wasDecorated('m3')],
+          },
+          method2: {
+            reactive: false,
+            decorators: [wasDecorated('m4'), wasDecorated('m5')],
+          },
+        };
+      }
+      called2 = 0;
+      method2() {
+        this.called2++;
+      }
+    }
+    customElements.define(generateElementName(), B);
+    const el1 = new A();
+    container.appendChild(el1);
+    await el1.updateComplete;
+    assert.deepEqual(el1.decorations, [
+      {name: 'foo', value: 'a'},
+      {name: 'method', value: 'm1'},
+      {name: 'method', value: 'm2'},
+    ]);
+    const el2 = new B();
+    container.appendChild(el2);
+    assert.deepEqual(el2.decorations, [
+      {name: 'foo', value: 'a'},
+      {name: 'method', value: 'm1'},
+      {name: 'method', value: 'm2'},
+      {name: 'foo', value: 'b'},
+      {name: 'bar', value: 'c'},
+      {name: 'bar', value: 'd'},
+      {name: 'method', value: 'm3'},
+      {name: 'method2', value: 'm4'},
+      {name: 'method2', value: 'm5'},
+    ]);
+  });
+
+  test('can applying property decorator', async () => {
+    class A extends WithDecorations {
+      static get properties() {
+        return {
+          foo: {
+            hasChanged: (a: number, b: number) => a > b,
+            decorators: [property({reflect: true})],
+          },
+        };
+      }
+
+      foo: number;
+      constructor() {
+        super();
+        this.foo = 1;
+      }
+    }
+    customElements.define(generateElementName(), A);
+    const el = new A();
+    container.appendChild(el);
+    await el.updateComplete;
+    assert.equal(el.getAttribute('foo'), '1');
+    el.foo = -1;
+    await el.updateComplete;
+    assert.equal(el.getAttribute('foo'), '1');
+  });
+});

--- a/packages/reactive-element/src/test/decorators/property_test.ts
+++ b/packages/reactive-element/src/test/decorators/property_test.ts
@@ -269,7 +269,7 @@ suite('@property', () => {
     const el1 = new E();
 
     class F extends E {
-      @property({type: Number}) foo = 2;
+      @property({type: Number, reflect: false}) foo = 2;
     }
 
     customElements.define(generateElementName(), F);


### PR DESCRIPTION
Fixes https://github.com/lit/lit/issues/1924

* Adds ability to specify decorators in `static properties` by adding a `decorators` array with decorator function calls. Use `reactive: false` if the property should not be reactive, for example to decorate a method.
* Also fixes an issue where initializers were shared with superclass when subclassing.
* Changes how individual property options are handled between super and subclasses. Now options are merged whereas previously they were overridden.

Note, this was done in `static properties` rather than introducing a new explicit configuration property for decorators because `static properties` automatically composes from super to subclass. Adding another configuration property which presumably would need the same treatment would add a chunk of additional code.