### PR TITLE
[localize] Fix duplicate and out-of-order localized template values

### DIFF
--- a/packages/localize-tools/CHANGELOG.md
+++ b/packages/localize-tools/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Fix bugs relating to expression values being substituted in duplicate or
+  incorrect order in localized templates.
+
+- Fix bug relating to `START_LIT_LOCALIZE_EXPR_` strings appearing inside
+  localized templates.
+
 ## [0.3.2] - 2021-05-07
 
 ### Fixed

--- a/packages/localize-tools/src/modes/runtime.ts
+++ b/packages/localize-tools/src/modes/runtime.ts
@@ -157,19 +157,19 @@ function generateLocaleModule(
     entries.push(`'${msg.name}': ${msgStr},`);
   }
   return `
-     // Do not modify this file by hand!
-     // Re-generate this file by running lit-localize
+    // Do not modify this file by hand!
+    // Re-generate this file by running lit-localize
 
-     ${importLit ? "import {html} from 'lit';" : ''}
-     ${importStr ? "import {str} from '@lit/localize';" : ''}
+    ${importLit ? "import {html} from 'lit';" : ''}
+    ${importStr ? "import {str} from '@lit/localize';" : ''}
 
-     /* eslint-disable no-irregular-whitespace */
-     /* eslint-disable @typescript-eslint/no-explicit-any */
+    /* eslint-disable no-irregular-whitespace */
+    /* eslint-disable @typescript-eslint/no-explicit-any */
 
-     export const templates = {
-       ${entries.join('\n')}
-     };
-   `;
+    export const templates = {
+      ${entries.join('\n')}
+    };
+  `;
 }
 
 /**

--- a/packages/localize-tools/src/modes/runtime.ts
+++ b/packages/localize-tools/src/modes/runtime.ts
@@ -157,19 +157,19 @@ function generateLocaleModule(
     entries.push(`'${msg.name}': ${msgStr},`);
   }
   return `
-    // Do not modify this file by hand!
-    // Re-generate this file by running lit-localize
+     // Do not modify this file by hand!
+     // Re-generate this file by running lit-localize
 
-    ${importLit ? "import {html} from 'lit';" : ''}
-    ${importStr ? "import {str} from '@lit/localize';" : ''}
+     ${importLit ? "import {html} from 'lit';" : ''}
+     ${importStr ? "import {str} from '@lit/localize';" : ''}
 
-    /* eslint-disable no-irregular-whitespace */
-    /* eslint-disable @typescript-eslint/no-explicit-any */
+     /* eslint-disable no-irregular-whitespace */
+     /* eslint-disable @typescript-eslint/no-explicit-any */
 
-    export const templates = {
-      ${entries.join('\n')}
-    };
-  `;
+     export const templates = {
+       ${entries.join('\n')}
+     };
+   `;
 }
 
 /**
@@ -195,15 +195,49 @@ function makeMessageString(
   // the source locale value anyway (because of variable scoping).
   //
   // For example, if some placeholders were reordered from [0 1 2] to [2 0 1],
-  // then we'll generate a template like: html`foo ${2} bar ${0} baz ${1}`
-  const placeholderOrder = new Map<string, number>(
-    canon.contents
-      .filter((value) => typeof value !== 'string')
-      .map((placeholder, idx) => [
-        (placeholder as Placeholder).untranslatable,
-        idx,
-      ])
-  );
+  // then we'll generate a template like: html`foo ${2} bar ${0} baz ${1}`.
+  //
+  // This map provides the absolute index within a template for each expression
+  // within the template. We identify each expression with the compound key
+  // [placeholder id, relative expression index].
+  //
+  // Note that any given XLIFF/XLB <ph> placeholder can contain zero, one, or
+  // many ${} expressions, so the index of the _placeholder_ is not the same as
+  // the index of the _expression_:
+  //
+  //   <ph>&lt;a href="http://example.com/"></ph>
+  //   <ph>&lt;a href="${/*0*/ url}"></ph>
+  //   <ph>&lt;a href="${/*1*/ url}/${/*2*/ path}"></ph>
+  const placeholderOrder = new Map<string, number>();
+
+  const placeholderOrderKey = (
+    placeholder: Placeholder,
+    placeholderRelativeExpressionIdx: number
+  ) =>
+    JSON.stringify([
+      // TODO(aomarks) For XLIFF files, we have a unique numeric ID for each
+      // placeholder that would be preferable to use as the key here over the
+      // placeholder text itself. However, we don't currently have that ID for
+      // XLB. To add it to XLB, we need to do some research into the correct XML
+      // representation, and then make a breaking change. See
+      // https://github.com/lit/lit/issues/1897.
+      placeholder.untranslatable,
+      placeholderRelativeExpressionIdx,
+    ]);
+
+  let absIdx = 0;
+  for (const content of canon.contents) {
+    if (typeof content === 'string') {
+      continue;
+    }
+    const template = parseStringAsTemplateLiteral(content.untranslatable);
+    if (ts.isNoSubstitutionTemplateLiteral(template)) {
+      continue;
+    }
+    for (let relIdx = 0; relIdx < template.templateSpans.length; relIdx++) {
+      placeholderOrder.set(placeholderOrderKey(content, relIdx), absIdx++);
+    }
+  }
 
   const fragments = [];
   for (const content of contents) {
@@ -215,12 +249,12 @@ function makeMessageString(
         fragments.push(template.text);
       } else {
         fragments.push(template.head.text);
-        for (const span of template.templateSpans) {
-          // Substitute the value with the index (see note above).
-          fragments.push(
-            '${' + placeholderOrder.get(content.untranslatable) + '}'
-          );
-          fragments.push(span.literal.text);
+        for (let relIdx = 0; relIdx < template.templateSpans.length; relIdx++) {
+          const absIdx: number = placeholderOrder.get(
+            placeholderOrderKey(content, relIdx)
+          )!;
+          fragments.push('${' + absIdx + '}');
+          fragments.push(template.templateSpans[relIdx].literal.text);
         }
       }
     }

--- a/packages/localize-tools/src/program-analysis.ts
+++ b/packages/localize-tools/src/program-analysis.ts
@@ -20,9 +20,10 @@ type ResultOrError<R, E> =
 /**
  * Extract translation messages from all files in a TypeScript program.
  */
-export function extractMessagesFromProgram(
-  program: ts.Program
-): {messages: ProgramMessage[]; errors: ts.Diagnostic[]} {
+export function extractMessagesFromProgram(program: ts.Program): {
+  messages: ProgramMessage[];
+  errors: ts.Diagnostic[];
+} {
   const messages: ProgramMessage[] = [];
   const errors: ts.Diagnostic[] = [];
   for (const sourcefile of program.getSourceFiles()) {
@@ -369,7 +370,9 @@ interface Expression {
  */
 const EXPRESSION_RAND = String(Math.random()).slice(2);
 const EXPRESSION_START = `_START_LIT_LOCALIZE_EXPR_${EXPRESSION_RAND}_`;
+const EXPRESSION_START_REGEXP = new RegExp(EXPRESSION_START, 'g');
 const EXPRESSION_END = `_END_LIT_LOCALIZE_EXPR_${EXPRESSION_RAND}_`;
+const EXPRESSION_END_REGEXP = new RegExp(EXPRESSION_END, 'g');
 
 /**
  * Our template is split apart based on template string literal expressions.
@@ -428,8 +431,8 @@ function replaceExpressionsAndHtmlWithPlaceholders(
       // need to fix the syntax.
       contents.push({
         untranslatable: part.untranslatable
-          .replace(EXPRESSION_START, '${')
-          .replace(EXPRESSION_END, '}'),
+          .replace(EXPRESSION_START_REGEXP, '${')
+          .replace(EXPRESSION_END_REGEXP, '}'),
       });
     }
   }
@@ -521,9 +524,10 @@ function replaceHtmlWithPlaceholders(
  *
  *   <b class="red">foo</b> --> {open: '<b class="red">, close: '</b>'}
  */
-function serializeOpenCloseTags(
-  node: parse5.ChildNode
-): {open: string; close: string} {
+function serializeOpenCloseTags(node: parse5.ChildNode): {
+  open: string;
+  close: string;
+} {
   const withoutChildren: parse5.ChildNode = {...node, childNodes: []};
   const fakeParent = {childNodes: [withoutChildren]} as parse5.Node;
   const serialized = parse5.serialize(fakeParent);
@@ -624,9 +628,10 @@ export function isStrTaggedTemplate(
  * same content, de-duplicate them. For those with the same ID and different
  * content, return an error.
  */
-function dedupeMessages(
-  messages: ProgramMessage[]
-): {messages: ProgramMessage[]; errors: ts.Diagnostic[]} {
+function dedupeMessages(messages: ProgramMessage[]): {
+  messages: ProgramMessage[];
+  errors: ts.Diagnostic[];
+} {
   const errors: ts.Diagnostic[] = [];
   const cache = new Map<string, ProgramMessage>();
   for (const message of messages) {

--- a/packages/localize-tools/testdata/build-runtime-xliff/goldens/foo.ts
+++ b/packages/localize-tools/testdata/build-runtime-xliff/goldens/foo.ts
@@ -45,4 +45,13 @@ msg(html`a:${'A'} b:${'B'} c:${'C'}`);
 // Custom ID
 msg('Hello World', {id: 'myId'});
 
+// Description
 msg('described 0', {desc: 'Description of 0'});
+
+// This example has 4 <ph> placeholders. The 2nd has two expressions, and the
+// rest have 0 expressions. Ensure that we index these expressions as [0, 1] by
+// counting _expressions_, instead of [2, 2] by counting _placeholders_ See
+// https://github.com/lit/lit/issues/1896).
+const urlBase = 'http://example.com/';
+const urlPath = 'foo';
+msg(html`<b>Hello</b>! Click <a href="${urlBase}/${urlPath}">here</a>!`);

--- a/packages/localize-tools/testdata/build-runtime-xliff/goldens/tsout/es-419.ts
+++ b/packages/localize-tools/testdata/build-runtime-xliff/goldens/tsout/es-419.ts
@@ -11,6 +11,7 @@ export const templates = {
   h349c3c4777670217: html`[SALT] Hola <b>${0}</b>!`,
   h3c44aff2d5f5ef6b: html`Hola <b>Mundo</b>!`,
   h82ccc38d4d46eaa9: html`Hola <b>${0}</b>!`,
+  h8d70dfec810d1eae: html`<b>Hola</b>! Clic <a href="${0}/${1}">aquí</a>!`,
   h99e74f744fda7e25: html`Clic <a href="${0}">aquí</a>!`,
   hbe936ff3da20ffdf: html`Hola <b><!-- comment -->Mundo</b>!`,
   hc1c6bfa4414cb3e3: html`[SALT] Clic <a href="${0}">aquí</a>!`,

--- a/packages/localize-tools/testdata/build-runtime-xliff/goldens/tsout/zh_CN.ts
+++ b/packages/localize-tools/testdata/build-runtime-xliff/goldens/tsout/zh_CN.ts
@@ -20,4 +20,5 @@ export const templates = {
   hf979404a36e879cb: html`a:${0} b:${1} c:${2}`,
   myId: `Hello World`,
   s03c68d79ad36e8d4: `described 0`,
+  h8d70dfec810d1eae: html`<b>Hello</b>! Click <a href="${0}/${1}">here</a>!`,
 };

--- a/packages/localize-tools/testdata/build-runtime-xliff/goldens/xliff/es-419.xlf
+++ b/packages/localize-tools/testdata/build-runtime-xliff/goldens/xliff/es-419.xlf
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-strict.xsd">
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
 <file target-language="es-419" source-language="en" original="lit-localize-inputs" datatype="plaintext">
 <body>
 <trans-unit id="s8c0ec8d1fb9e6e32">
@@ -39,27 +39,21 @@
   <target>Hola <ph id="0">&lt;b>&lt;!-- comment --></ph>Mundo<ph id="1">&lt;/b></ph>!</target>
 </trans-unit>
 <trans-unit id="hf979404a36e879cb">
-  <source>a:<ph id="0">${"A"}</ph> b:<ph id="1">${"B"}</ph> c:<ph id="2">${"C"}</ph></source>
-  <target>c:<ph id="2">${"C"}</ph> a:<ph id="0">${"A"}</ph> b:<ph id="1">${"B"}</ph></target>
+  <source>a:<ph id="0">${'A'}</ph> b:<ph id="1">${'B'}</ph> c:<ph id="2">${'C'}</ph></source>
+  <target>c:<ph id="2">${'C'}</ph> a:<ph id="0">${'A'}</ph> b:<ph id="1">${'B'}</ph></target>
 </trans-unit>
 <trans-unit id="myId">
   <source>Hello World</source>
   <target>Hola Mundo</target>
 </trans-unit>
+<trans-unit id="h8d70dfec810d1eae">
+  <source><ph id="0">&lt;b></ph>Hello<ph id="1">&lt;/b></ph>! Click <ph id="2">&lt;a href="${urlBase}/${urlPath}"></ph>here<ph id="3">&lt;/a></ph>!</source>
+  <target><ph id="0">&lt;b></ph>Hola<ph id="1">&lt;/b></ph>! Clic <ph id="2">&lt;a href="${urlBase}/${urlPath}"></ph>aquí<ph id="3">&lt;/a></ph>!</target>
+</trans-unit>
 <trans-unit id="s03c68d79ad36e8d4">
   <note>Description of 0</note>
   <source>described 0</source>
   <target>described 0</target>
-</trans-unit>
-<trans-unit id="s03c68e79ad36ea87">
-  <note>Parent description / Description of 1</note>
-  <source>described 1</source>
-  <target>described 1</target>
-</trans-unit>
-<trans-unit id="s03c68f79ad36ec3a">
-  <note>Parent description / Description of 2</note>
-  <source>described 2</source>
-  <target>described 2</target>
 </trans-unit>
 </body>
 </file>

--- a/packages/localize-tools/testdata/build-runtime-xliff/input/foo.ts
+++ b/packages/localize-tools/testdata/build-runtime-xliff/input/foo.ts
@@ -40,9 +40,18 @@ msg(html`[SALT] Hello <b>${msg('World')}</b>!`);
 msg(html`Hello <b><!-- comment -->World</b>!`);
 
 // Lit template with expression order inversion
-msg(html`a:${"A"} b:${"B"} c:${"C"}`);
+msg(html`a:${'A'} b:${'B'} c:${'C'}`);
 
 // Custom ID
 msg('Hello World', {id: 'myId'});
 
+// Description
 msg('described 0', {desc: 'Description of 0'});
+
+// This example has 4 <ph> placeholders. The 2nd has two expressions, and the
+// rest have 0 expressions. Ensure that we index these expressions as [0, 1] by
+// counting _expressions_, instead of [2, 2] by counting _placeholders_ See
+// https://github.com/lit/lit/issues/1896).
+const urlBase = 'http://example.com/';
+const urlPath= 'foo';
+msg(html`<b>Hello</b>! Click <a href="${urlBase}/${urlPath}">here</a>!`);

--- a/packages/localize-tools/testdata/build-runtime-xliff/input/xliff/es-419.xlf
+++ b/packages/localize-tools/testdata/build-runtime-xliff/input/xliff/es-419.xlf
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-strict.xsd">
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
 <file target-language="es-419" source-language="en" original="lit-localize-inputs" datatype="plaintext">
 <body>
 <trans-unit id="s8c0ec8d1fb9e6e32">
@@ -39,27 +39,21 @@
   <target>Hola <ph id="0">&lt;b>&lt;!-- comment --></ph>Mundo<ph id="1">&lt;/b></ph>!</target>
 </trans-unit>
 <trans-unit id="hf979404a36e879cb">
-  <source>a:<ph id="0">${"A"}</ph> b:<ph id="1">${"B"}</ph> c:<ph id="2">${"C"}</ph></source>
-  <target>c:<ph id="2">${"C"}</ph> a:<ph id="0">${"A"}</ph> b:<ph id="1">${"B"}</ph></target>
+  <source>a:<ph id="0">${'A'}</ph> b:<ph id="1">${'B'}</ph> c:<ph id="2">${'C'}</ph></source>
+  <target>c:<ph id="2">${'C'}</ph> a:<ph id="0">${'A'}</ph> b:<ph id="1">${'B'}</ph></target>
 </trans-unit>
 <trans-unit id="myId">
   <source>Hello World</source>
   <target>Hola Mundo</target>
 </trans-unit>
+<trans-unit id="h8d70dfec810d1eae">
+  <source><ph id="0">&lt;b></ph>Hello<ph id="1">&lt;/b></ph>! Click <ph id="2">&lt;a href="${urlBase}/${urlPath}"></ph>here<ph id="3">&lt;/a></ph>!</source>
+  <target><ph id="0">&lt;b></ph>Hola<ph id="1">&lt;/b></ph>! Clic <ph id="2">&lt;a href="${urlBase}/${urlPath}"></ph>aquí<ph id="3">&lt;/a></ph>!</target>
+</trans-unit>
 <trans-unit id="s03c68d79ad36e8d4">
   <note>Description of 0</note>
   <source>described 0</source>
   <target>described 0</target>
-</trans-unit>
-<trans-unit id="s03c68e79ad36ea87">
-  <note>Parent description / Description of 1</note>
-  <source>described 1</source>
-  <target>described 1</target>
-</trans-unit>
-<trans-unit id="s03c68f79ad36ec3a">
-  <note>Parent description / Description of 2</note>
-  <source>described 2</source>
-  <target>described 2</target>
 </trans-unit>
 </body>
 </file>


### PR DESCRIPTION
Fixes two bugs relating to localized template values:

1. When we generated localized templates, we replace expressions with numbers, representing the position of that value in the source template, to account for the possibility of expressions changing position (see https://github.com/lit/lit/pull/1625 for more details). However, we were incorrectly indexing using the position of the `<ph>` placeholder that *contained* the expression, instead of the index of the expression itself (note that a `<ph>` can contain any combination of HTML and zero or more placehlders). So the offsets could be wrong, and were sometimes duplicated.

2. We use the special string `_START_LIT_LOCALIZE_EXPR_${RANDOM}_` as a delimiter during internal template decomposition, but a `replace` operation was accidentally only matching the first occurrence, instead of all occurrences. So a template like `<a href="${url}/${base}">` previously contained this literal string.

Fixes https://github.com/lit/lit/issues/1896