### PR TITLE
[localize] Release tools 0.3.4 and localize 0.10.2

### DIFF
--- a/packages/localize-tools/CHANGELOG.md
+++ b/packages/localize-tools/CHANGELOG.md
@@ -5,7 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+## [0.3.4] - 2021-05-18
+
+### Fixed
+
+- Fix `Cannot find module '..../@lit/localize/internal/id-generation.js'` error
+  by bumping `@lit/localize` dependency.
 
 ## [0.3.3] - 2021-05-18
 

--- a/packages/localize-tools/package.json
+++ b/packages/localize-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lit/localize-tools",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "publishConfig": {
     "access": "public"
   },
@@ -37,7 +37,7 @@
     "/config.schema.json"
   ],
   "dependencies": {
-    "@lit/localize": "^0.10.1",
+    "@lit/localize": "^0.10.2",
     "fs-extra": "^9.0.0",
     "glob": "^7.1.6",
     "jsonschema": "^1.4.0",

--- a/packages/localize/CHANGELOG.md
+++ b/packages/localize/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+<!-- ## Unreleased -->
+
+## [0.10.2] - 2021-05-18
+
+### Fixed
+
+- Internal refactoring.
 
 ### Fixed
 

--- a/packages/localize/package.json
+++ b/packages/localize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lit/localize",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
I forgot that an earlier refactoring requires an updated import from `localize-tools` to `localize`.