### PR TITLE
[reactive-element] Change css template tag to return CSSResult

### DIFF
--- a/packages/labs/motion/src/test/flip_test.ts
+++ b/packages/labs/motion/src/test/flip_test.ts
@@ -58,7 +58,7 @@ suite('Flip', () => {
     extraCss?: CSSResultGroup,
     childTemplate?: () => TemplateResult
   ) => {
-    const styles = [
+    const styles: CSSResultGroup = [
       css`
         * {
           box-sizing: border-box;
@@ -226,7 +226,7 @@ suite('Flip', () => {
     options.disabled = true;
     el.shift = true;
     await el.updateComplete;
-    await ((theFlip as unknown) as Flip)?.finished;
+    await (theFlip as unknown as Flip)?.finished;
     assert.notOk(frames);
   });
 
@@ -250,7 +250,7 @@ suite('Flip', () => {
     el.shift = false;
     theFlip = frames = undefined;
     await el.updateComplete;
-    await ((theFlip as unknown) as Flip)?.finished;
+    await (theFlip as unknown as Flip)?.finished;
     assert.notOk(frames);
     // guardValue changed, so should run.
     guardValue = 1;
@@ -263,7 +263,7 @@ suite('Flip', () => {
     el.shift = false;
     theFlip = frames = undefined;
     await el.updateComplete;
-    await ((theFlip as unknown) as Flip)?.finished;
+    await (theFlip as unknown as Flip)?.finished;
     assert.notOk(frames);
     // guardValue changed, so should run.
     guardValue = 2;
@@ -294,7 +294,7 @@ suite('Flip', () => {
     el.shift = false;
     theFlip = frames = undefined;
     await el.updateComplete;
-    await ((theFlip as unknown) as Flip)?.finished;
+    await (theFlip as unknown as Flip)?.finished;
     assert.notOk(frames);
     // guardValue changed, so should run.
     guardValue = [1, 2, 3, 4];
@@ -307,7 +307,7 @@ suite('Flip', () => {
     el.shift = false;
     theFlip = frames = undefined;
     await el.updateComplete;
-    await ((theFlip as unknown) as Flip)?.finished;
+    await (theFlip as unknown as Flip)?.finished;
     assert.notOk(frames);
     // guardValue changed, so should run.
     guardValue = [1, 2];
@@ -535,7 +535,8 @@ suite('Flip', () => {
       disconnectElement = flip.element;
       const p = disconnectElement!.parentElement!.getBoundingClientRect();
       const r = disconnectElement!.getBoundingClientRect();
-      const s = disconnectElement!.previousElementSibling!.getBoundingClientRect();
+      const s =
+        disconnectElement!.previousElementSibling!.getBoundingClientRect();
       if (!shouldRender) {
         assert.equal(
           r.bottom - p.top,

--- a/packages/reactive-element/CHANGELOG.md
+++ b/packages/reactive-element/CHANGELOG.md
@@ -17,6 +17,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- ### Removed -->
 <!-- ### Fixed -->
 
+## Unreleased
+
+### Changed
+
+- (Since 1.0.0-rc.2) Reverted change of the `css` tag's return to CSSResultGroup, which was a breaking change. The `css` tag again returns a `CSSResult` object.
+- (Since 1.0.0-rc.2) Remove the `CSSResultFlatArray` type alias in `css-tag.ts`.
+
+<!-- ### Added -->
+<!-- ### Removed -->
+<!-- ### Fixed -->
+
 ## 1.0.0-rc.2 - 2021-05-07
 
 ### Changed

--- a/packages/reactive-element/src/css-tag.ts
+++ b/packages/reactive-element/src/css-tag.ts
@@ -102,7 +102,7 @@ export const unsafeCSS = (value: unknown) => {
 export const css = (
   strings: TemplateStringsArray,
   ...values: (CSSResultGroup | number)[]
-): CSSResultGroup => {
+): CSSResult => {
   const cssText =
     strings.length === 1
       ? strings[0]

--- a/packages/reactive-element/src/css-tag.ts
+++ b/packages/reactive-element/src/css-tag.ts
@@ -15,21 +15,36 @@ export const supportsAdoptingStyleSheets =
   'adoptedStyleSheets' in Document.prototype &&
   'replace' in CSSStyleSheet.prototype;
 
+/**
+ * A CSSResult or native CSSStyleSheet.
+ *
+ * In browsers that support constructible CSS style sheets, CSSStyleSheet
+ * object can be used for styling along side CSSResult from the `css`
+ * template tag.
+ */
 export type CSSResultOrNative = CSSResult | CSSStyleSheet;
-
-export type CSSResultFlatArray = CSSResultOrNative[];
 
 export type CSSResultArray = Array<CSSResultOrNative | CSSResultArray>;
 
+/**
+ * A single CSSResult, CSSStyleSheet, or an array or nested arrays of those.
+ */
 export type CSSResultGroup = CSSResultOrNative | CSSResultArray;
 
 const constructionToken = Symbol();
 
+/**
+ * A container for a string of CSS text, that may be used to create a CSSStyleSheet.
+ *
+ * CSSResult is the return value of `css`-tagged template literals and
+ * `unsafeCSS()`. In order to ensure that CSSResults are only created via the
+ * `css` tag and `unsafeCSS()`, CSSResult cannot be constructed directly.
+ */
 export class CSSResult {
   readonly cssText: string;
   private _styleSheet?: CSSStyleSheet;
 
-  constructor(cssText: string, safeToken: symbol) {
+  private constructor(cssText: string, safeToken: symbol) {
     if (safeToken !== constructionToken) {
       throw new Error(
         'CSSResult is not constructable. Use `unsafeCSS` or `css` instead.'
@@ -55,6 +70,10 @@ export class CSSResult {
   }
 }
 
+type ConstructableCSSResult = CSSResult & {
+  new (cssText: string, safeToken: symbol): CSSResult;
+};
+
 const cssResultCache = new Map<string, CSSResult>();
 
 const getCSSResult = (cssText: string): CSSResult => {
@@ -62,7 +81,10 @@ const getCSSResult = (cssText: string): CSSResult => {
   if (result === undefined) {
     cssResultCache.set(
       cssText,
-      (result = new CSSResult(cssText, constructionToken))
+      (result = new (CSSResult as ConstructableCSSResult)(
+        cssText,
+        constructionToken
+      ))
     );
   }
   return result;
@@ -94,10 +116,12 @@ export const unsafeCSS = (value: unknown) => {
 };
 
 /**
- * Template tag which which can be used with LitElement's [[LitElement.styles |
- * `styles`]] property to set element styles. For security reasons, only literal
- * string values may be used. To incorporate non-literal values [[`unsafeCSS`]]
- * may be used inside a template string part.
+ * A template literal tag which can be used with LitElement's
+ * [[LitElement.styles | `styles`]] property to set element styles.
+ *
+ * For security reasons, only literal string values and number may be used in
+ * embedded expressions. To incorporate non-literal values [[`unsafeCSS`]] may
+ * be used inside an expression.
  */
 export const css = (
   strings: TemplateStringsArray,
@@ -124,7 +148,7 @@ export const css = (
  */
 export const adoptStyles = (
   renderRoot: ShadowRoot,
-  styles: CSSResultFlatArray
+  styles: Array<CSSResultOrNative>
 ) => {
   if (supportsAdoptingStyleSheets) {
     (renderRoot as ShadowRoot).adoptedStyleSheets = styles.map((s) =>

--- a/packages/reactive-element/src/reactive-element.ts
+++ b/packages/reactive-element/src/reactive-element.ts
@@ -15,7 +15,6 @@ import {
   adoptStyles,
   CSSResultGroup,
   CSSResultOrNative,
-  CSSResultFlatArray,
 } from './css-tag.js';
 import type {
   ReactiveController,
@@ -404,7 +403,7 @@ export abstract class ReactiveElement
    * @nocollapse
    * @category styles
    */
-  static elementStyles: CSSResultFlatArray = [];
+  static elementStyles: Array<CSSResultOrNative> = [];
 
   /**
    * Array of styles to apply to the element. The styles should be defined
@@ -638,7 +637,9 @@ export abstract class ReactiveElement
    * @nocollapse
    * @category styles
    */
-  protected static finalizeStyles(styles?: CSSResultGroup): CSSResultFlatArray {
+  protected static finalizeStyles(
+    styles?: CSSResultGroup
+  ): Array<CSSResultOrNative> {
     const elementStyles = [];
     if (Array.isArray(styles)) {
       // Dedupe the flattened array in reverse order to preserve the last items.

--- a/packages/reactive-element/src/test/css-tag_test.ts
+++ b/packages/reactive-element/src/test/css-tag_test.ts
@@ -91,7 +91,7 @@ suite('Styling', () => {
     test('`CSSResult` cannot be constructed', async () => {
       // Note, this is done for security, instead use `css` or `unsafeCSS`
       assert.throws(() => {
-        new CSSResult('throw', Symbol());
+        new (CSSResult as any)('throw', Symbol());
       });
     });
 

--- a/packages/reactive-element/src/test/reactive-element_styling_test.ts
+++ b/packages/reactive-element/src/test/reactive-element_styling_test.ts
@@ -7,7 +7,7 @@ import {
   css,
   ReactiveElement,
   unsafeCSS,
-  CSSResultArray,
+  CSSResultGroup,
 } from '../reactive-element.js';
 
 import {
@@ -586,7 +586,7 @@ const extraGlobals = window as LitExtraGlobals;
       customElements.define(
         base,
         class extends RenderingElement {
-          static finalizeStyles(styles: CSSResultArray) {
+          static finalizeStyles(styles: CSSResultGroup) {
             getStylesCounter++;
             return super.finalizeStyles(styles);
           }

--- a/packages/reactive-element/src/test/reactive-element_styling_test.ts
+++ b/packages/reactive-element/src/test/reactive-element_styling_test.ts
@@ -402,7 +402,7 @@ const extraGlobals = window as LitExtraGlobals;
             div {
               border: 2px solid blue;
             }
-          `;
+          ` as CSSResultGroup;
         }
 
         render() {
@@ -439,7 +439,7 @@ const extraGlobals = window as LitExtraGlobals;
         class extends BaseClass {
           static get styles() {
             return [
-              super.styles,
+              BaseClass.styles,
               css`
                 p {
                   display: block;


### PR DESCRIPTION
Fixes #1894

Also removes a couple of unnecessary type aliases, mainly just so we're not required to support those exports publicly.