### PR TITLE
Don't remove attributes with noChange on first render

### DIFF
--- a/packages/lit-html/CHANGELOG.md
+++ b/packages/lit-html/CHANGELOG.md
@@ -17,6 +17,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- ### Fixed -->
 <!-- ### Removed -->
 
+## Unreleased
+
+<!-- ### Changed -->
+<!-- ### Added -->
+
+### Fixed
+
+- Binding `noChange` into an attribute expression now no longer removes the attribute on first render.
+
+<!-- ### Removed -->
+
 ## [2.0.0-rc.3] - 2021-05-07
 
 ### Fixed

--- a/packages/lit-html/src/test/lit-html_test.ts
+++ b/packages/lit-html/src/test/lit-html_test.ts
@@ -965,7 +965,7 @@ suite('lit-html', () => {
       assertContent('<div>baz</div><div foo="bar"></div>');
     });
 
-    test('renders undefined in attributes', () => {
+    test('renders undefined in interpolated attributes', () => {
       render(html`<div attribute="it's ${undefined}"></div>`, container);
       assert.equal(
         stripExpressionComments(container.innerHTML),
@@ -980,6 +980,11 @@ suite('lit-html', () => {
 
     test('renders null in attributes', () => {
       render(html`<div attribute="${null as any}"></div>`, container);
+      assertContent('<div attribute=""></div>');
+    });
+
+    test('renders noChange in attributes', () => {
+      render(html`<div attribute="${noChange as any}"></div>`, container);
       assertContent('<div attribute=""></div>');
     });
 
@@ -1027,6 +1032,14 @@ suite('lit-html', () => {
     test('noChange works on one of multiple expressions', () => {
       const go = (a: any, b: any) =>
         render(html`<div foo="${a}:${b}"></div>`, container);
+
+      go('A', noChange);
+      assert.equal(
+        stripExpressionComments(container.innerHTML),
+        '<div foo="A:"></div>',
+        'A'
+      );
+
       go('A', 'B');
       assert.equal(
         stripExpressionComments(container.innerHTML),
@@ -1509,10 +1522,11 @@ suite('lit-html', () => {
   });
 
   suite('compiled', () => {
-    const trustedTypes =
-        (globalThis as unknown as Partial<Window>).trustedTypes;
-    const policy = trustedTypes?.createPolicy(
-      'lit-html', { createHTML: (s) => s }) ?? {createHTML:(s) => s as unknown as TrustedHTML};
+    const trustedTypes = (globalThis as unknown as Partial<Window>)
+      .trustedTypes;
+    const policy = trustedTypes?.createPolicy('lit-html', {
+      createHTML: (s) => s,
+    }) ?? {createHTML: (s) => s as unknown as TrustedHTML};
 
     test('only text', () => {
       // A compiled template for html`${'A'}`


### PR DESCRIPTION
Fixes #1920

In attribute expressions `noChange` is now treated like `undefined` and `null` on first render, instead of like `nothing`. Previously the attribute was removed since we initialized attribute part values to `nothing`.