### PR TITLE
[lit-html] Re-export `PropertyPart` from 'directive.ts'

### DIFF
--- a/packages/lit-html/src/directive.ts
+++ b/packages/lit-html/src/directive.ts
@@ -13,6 +13,7 @@ export {
   ElementPart,
   EventPart,
   Part,
+  PropertyPart,
 } from './lit-html';
 
 export interface DirectiveClass {


### PR DESCRIPTION
This PR is to match the new `PropertyPart` in lit-html 1.x that's being added in #1869.