### PR TITLE
fix(ifDefined): treat type as lit-analyzer in Lit 1 would

### DIFF
--- a/packages/lit-html/src/directives/if-defined.ts
+++ b/packages/lit-html/src/directives/if-defined.ts
@@ -12,4 +12,4 @@ import {nothing} from '../lit-html.js';
  *
  * For other part types, this directive is a no-op.
  */
- export const ifDefined = <T>(value: T) => (value ?? nothing) as NonNullable<T>;
+export const ifDefined = <T>(value: T) => (value ?? nothing) as NonNullable<T>;

--- a/packages/lit-html/src/directives/if-defined.ts
+++ b/packages/lit-html/src/directives/if-defined.ts
@@ -12,4 +12,4 @@ import {nothing} from '../lit-html.js';
  *
  * For other part types, this directive is a no-op.
  */
-export const ifDefined = <T>(value: T) => value ?? nothing;
+ export const ifDefined = <T>(value: T) => (value ?? nothing) as NonNullable<T>;


### PR DESCRIPTION
Lit analyzer would see ifDefined function name and simply calculate the type as if it were the value without `undefined`. This fixes an issue where passing in a `DirectiveResult|undefined` was being calculated instead as `DirectiveResult | typeof nothing`. This meant lit-analyzer could not understand that this was a directive and meant to be ignored by the type checker.

externalization of cl/378967428