### PR TITLE
[lit-html] Update optional method syntax so it's compatible with tsickle.

### DIFF
--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -925,11 +925,11 @@ class ChildPart {
   /** @internal */
   _$disconnectableChildren?: Set<Disconnectable> = undefined;
   /** @internal */
-  _$setChildPartConnected?(
+  _$setChildPartConnected?: (
     isConnected: boolean,
     removeFromParent?: boolean,
     from?: number
-  ): void;
+  ) => void;
   /** @internal */
   _$reparentDisconnectables?(parent: Disconnectable): void;
 


### PR DESCRIPTION
## Why

Done as part of the lit next burndown. For internal details see cl/379343684.

Lit-html is transpiled by tsickle, and this optional type syntax is unsupported. The optional method is marked as unknown leading to internal test failures. Filing a bug (b/191086442) in tsickle in parallel to possibly handle this syntax in the future.

This unblocks lit-next being used internally.

