### PR TITLE
Add localName for lit-labs/ssr

### DIFF
--- a/packages/labs/ssr/src/lib/dom-shim.ts
+++ b/packages/labs/ssr/src/lib/dom-shim.ts
@@ -109,6 +109,14 @@ export const getWindow = ({
         observedAttributes:
           (ctor as CustomHTMLElement).observedAttributes ?? [],
       });
+      function localName() {
+        return name;
+      }
+      Object.defineProperty(ctor.prototype, 'localName', {
+        configurable: true,
+        enumerable: true,
+        get: localName,
+      });
     }
 
     get(name: string) {


### PR DESCRIPTION
This adds the localName to an element when registering. This means if you have an element constructor function you can find the tag name in order to render it.

```js
let tag = new MyElement().localName;
let instance = new LitElementRenderer(tag);
// ...
```