### PR TITLE
Correct polyfill-support styling issues

### DIFF
--- a/.changeset/beige-rules-kneel.md
+++ b/.changeset/beige-rules-kneel.md
@@ -1,0 +1,6 @@
+---
+'lit-html': patch
+'@lit/reactive-element': patch
+---
+
+Fixes polyfill-support styling issues: styling should be fully applied by firstUpdated/update time; late added styles are now retained (matching Lit1 behavior)

--- a/packages/lit-html/src/polyfill-support.ts
+++ b/packages/lit-html/src/polyfill-support.ts
@@ -179,19 +179,23 @@ const ENABLE_SHADYDOM_NOPATCH = true;
       if (!extraGlobals.ShadyCSS!.nativeShadow) {
         extraGlobals.ShadyCSS!.prepareTemplateDom(element, scope);
       }
-      const scopeCss = cssForScope(scope);
-      // Remove styles and store textContent.
-      const styles = element.content.querySelectorAll(
-        'style'
-      ) as NodeListOf<HTMLStyleElement>;
-      // Store the css in this template in the scope css and remove the <style>
-      // from the template _before_ the node-walk captures part indices
-      scopeCss.push(
-        ...Array.from(styles).map((style) => {
-          style.parentNode?.removeChild(style);
-          return style.textContent!;
-        })
-      );
+      // Process styles only if this scope is being prepared. Otherwise,
+      // leave styles as is for back compat with Lit1.
+      if (needsPrepareStyles(scope)) {
+        const scopeCss = cssForScope(scope);
+        // Remove styles and store textContent.
+        const styles = element.content.querySelectorAll(
+          'style'
+        ) as NodeListOf<HTMLStyleElement>;
+        // Store the css in this template in the scope css and remove the <style>
+        // from the template _before_ the node-walk captures part indices
+        scopeCss.push(
+          ...Array.from(styles).map((style) => {
+            style.parentNode?.removeChild(style);
+            return style.textContent!;
+          })
+        );
+      }
     }
     return element;
   };

--- a/packages/lit-html/src/test/polyfill-support/lit-html_html-test.ts
+++ b/packages/lit-html/src/test/polyfill-support/lit-html_html-test.ts
@@ -84,6 +84,51 @@ suite('polyfill-support rendering', () => {
     wrap(document.body).removeChild(container);
   });
 
+  test('late added styles are retained and not scoped', () => {
+    const container = document.createElement('scope-late');
+    wrap(document.body).appendChild(container);
+    const getResult = (includeLate = false) => html`
+      <style>
+        div {
+          border: 4px solid orange;
+        }
+      </style>
+      <div>Testing...</div>
+      ${
+        includeLate
+          ? html`<style>div { border: 5px solid tomato; }</style>late`
+          : ''
+      }
+    `;
+    renderShadowRoot(getResult(), container);
+    const div = shadowRoot(container)!.querySelector('div');
+    assert.equal(
+      getComputedStyle(div!).getPropertyValue('border-top-width').trim(),
+      '4px'
+    );
+    renderShadowRoot(getResult(true), container);
+    // The late style applies but the rule has lower precedence so the the
+    // correctly scoped style still rules.
+    assert.equal(
+      getComputedStyle(div!).getPropertyValue('border-top-width').trim(),
+      '4px'
+    );
+    // if ShadyDOM is in use, the late added style should leak
+    if (extraGlobals.ShadyDOM?.inUse) {
+      // late added styles are retained
+      const styles = shadowRoot(container)!.querySelectorAll('style');
+      assert.equal(styles.length, 1);
+      const d = document.createElement('div');
+      document.body.appendChild(d);
+      assert.equal(
+        getComputedStyle(d).getPropertyValue('border-top-width').trim(),
+        '5px'
+      );
+      document.body.removeChild(d);
+    }
+    wrap(document.body).removeChild(container);
+  });
+
   test('results render to multiple containers', () => {
     const container1 = document.createElement('div');
     const container2 = document.createElement('div');

--- a/packages/reactive-element/src/polyfill-support.ts
+++ b/packages/reactive-element/src/polyfill-support.ts
@@ -145,12 +145,11 @@ interface PatchableReactiveElement extends HTMLElement {
     this: PatchableReactiveElement,
     changedProperties: unknown
   ) {
-    const isFirstUpdate = !this.hasUpdated;
-    didUpdate.call(this, changedProperties);
     // Note, must do first update here so rendering has completed before
     // calling this and styles are correct by updated/firstUpdated.
-    if (isFirstUpdate) {
+    if (!this.hasUpdated) {
       extraGlobals.ShadyCSS!.styleElement(this);
     }
+    didUpdate.call(this, changedProperties);
   };
 };

--- a/packages/reactive-element/src/test/test-helpers.ts
+++ b/packages/reactive-element/src/test/test-helpers.ts
@@ -40,12 +40,17 @@ export class RenderingElement extends ReactiveElement {
       // where `innerHTML` is not patched by CE on shadowRoot.
       // https://github.com/webcomponents/custom-elements/issues/73
       Array.from(this.renderRoot.childNodes).forEach((e) => {
-        this.renderRoot.removeChild(e);
+        // Leave any style elements that might be simulating
+        // adoptedStylesheets
+        if ((e as Element).localName !== 'style') {
+          this.renderRoot.removeChild(e);
+        }
       });
       const div = document.createElement('div');
       div.innerHTML = result;
+      const ref = this.renderRoot.firstChild;
       Array.from(div.childNodes).forEach((e) => {
-        this.renderRoot.appendChild(e);
+        this.renderRoot.insertBefore(e, ref);
       });
     }
   }

--- a/packages/reactive-element/src/test/test-helpers.ts
+++ b/packages/reactive-element/src/test/test-helpers.ts
@@ -36,11 +36,17 @@ export class RenderingElement extends ReactiveElement {
     const result = this.render();
     super.update(changedProperties);
     if (result !== undefined) {
-      // Save and replace any existing styles in root to simulate
-      // adoptedStylesheets.
-      const styles = this.renderRoot.querySelectorAll('style');
-      this.renderRoot.innerHTML = result;
-      this.renderRoot.append(...styles);
+      // Note, don't use `innerHTML` here to avoid a polyfill issue
+      // where `innerHTML` is not patched by CE on shadowRoot.
+      // https://github.com/webcomponents/custom-elements/issues/73
+      Array.from(this.renderRoot.childNodes).forEach((e) => {
+        this.renderRoot.removeChild(e);
+      });
+      const div = document.createElement('div');
+      div.innerHTML = result;
+      Array.from(div.childNodes).forEach((e) => {
+        this.renderRoot.appendChild(e);
+      });
     }
   }
 }


### PR DESCRIPTION
Fixes #2000: ShadyCSS's styleElement is now called before firstUpdate/update so that code in these methods can properly assume styling (including shimmed custom properties) has fully applied.

Fixes #2001: Late added styles are now retained in templates. This behavior is consistent with what happened in Lit 1 and we're electing not to change it so that users that may be relying on this (admittedly weird and not well supported) behavior are not broken.