### PR TITLE
Change `CSSResult`'s `styleSheet` type to `CSSStyleSheet | null` to match Lit 1.

### DIFF
--- a/packages/reactive-element/src/css-tag.ts
+++ b/packages/reactive-element/src/css-tag.ts
@@ -58,7 +58,7 @@ export class CSSResult {
 
   // Note, this is a getter so that it's lazy. In practice, this means
   // stylesheets are not created until the first element instance is made.
-  get styleSheet(): CSSStyleSheet | undefined {
+  get styleSheet(): CSSStyleSheet | null {
     // Note, if `supportsAdoptingStyleSheets` is true then we assume
     // CSSStyleSheet is constructable.
     let styleSheet = styleSheetCache.get(this.cssText);
@@ -66,7 +66,7 @@ export class CSSResult {
       styleSheetCache.set(this.cssText, (styleSheet = new CSSStyleSheet()));
       styleSheet.replaceSync(this.cssText);
     }
-    return styleSheet;
+    return styleSheet ?? null;
   }
 
   toString(): string {


### PR DESCRIPTION
In Lit 1, [`CSSResult`'s `styleSheet` property had a type of `CSSStyleSheet | null`](https://github.com/lit/lit-element/blob/2b398727dacb7694fbf38816824675d20838704f/src/lib/css-tag.ts#L38). This PR changes the type in Lit 2 to match.