### PR TITLE
Change `clearContainerForLit2MigrationOnly` behavior

### DIFF
--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -373,15 +373,21 @@ export const render = (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let part: ChildPart = (partOwnerNode as any)['_$litPart$'];
   if (part === undefined) {
+    const endNode = options?.renderBefore ?? null;
     // Internal modification: don't clear container to match lit-html 2.0
     if (
       INTERNAL &&
       (options as InternalRenderOptions)?.clearContainerForLit2MigrationOnly ===
         true
     ) {
-      container.childNodes.forEach((c) => c.remove());
+      let n = container.firstChild;
+      // Clear only up to the `endNode` aka `renderBefore` node.
+      while (n && n !== endNode) {
+        const next = n.nextSibling;
+        n.remove();
+        n = next;
+      }
     }
-    const endNode = options?.renderBefore ?? null;
     // This property needs to remain unminified.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (partOwnerNode as any)['_$litPart$'] = part = new ChildPart(

--- a/packages/lit-html/src/test/lit-html_test.ts
+++ b/packages/lit-html/src/test/lit-html_test.ts
@@ -2806,13 +2806,18 @@ suite('lit-html', () => {
 
   suite('internal', () => {
     test('clearContainerForLit2MigrationOnly', () => {
-      container.innerHTML = '<div>TEST</div>';
+      const clearedHtml = `<div>TEST 1</div><div>TEST 2</div>`;
+      const remainingHtml = `<div class="renderBefore">REMAIN 1</div><div>REMAIN 2</div>`;
+      container.innerHTML = `${clearedHtml}${remainingHtml}`;
       render(html`<p>HELLO</p>`, container, {
         clearContainerForLit2MigrationOnly: true,
+        renderBefore: container.querySelector('.renderBefore'),
       } as RenderOptions);
       assert.equal(
         stripExpressionComments(container.innerHTML),
-        INTERNAL ? '<p>HELLO</p>' : '<div>TEST</div><p>HELLO</p>'
+        INTERNAL
+          ? `<p>HELLO</p>${remainingHtml}`
+          : `${clearedHtml}<p>HELLO</p>${remainingHtml}`
       );
     });
   });


### PR DESCRIPTION
Change this behavior so that it removes nodes only to the given `renderBefore` node.

This should match the Lit1 behavior since `renderBefore` was not supported. Additionally, it's compatible with ReactiveElement's shimming of adoptedStyleSheets with `<style>` elements in the shadowRoot prior to rendering.