### PR TITLE
[localize] Escape markup characters when generating HTML text content

### DIFF
--- a/packages/localize-tools/CHANGELOG.md
+++ b/packages/localize-tools/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+## Fixed
+
+- Escaped `<`, `>`, and `&` characters in HTML text content are now preserved
+  when generating runtime & transform mode output. Previously they sometimes
+  were emitted unescaped, generating invalid markup.
 
 ## [0.3.5] - 2021-07-14
 

--- a/packages/localize-tools/src/locales.ts
+++ b/packages/localize-tools/src/locales.ts
@@ -8,7 +8,7 @@ import fsExtra from 'fs-extra';
 import * as pathLib from 'path';
 import {KnownError} from './error.js';
 import type {Locale} from './types/locale.js';
-import {escapeStringToEmbedInTemplateLiteral} from './typescript.js';
+import {escapeTextContentToEmbedInTemplateLiteral} from './typescript.js';
 
 /**
  * Return whether the given string is formatted like a BCP 47 language tag. Note
@@ -19,7 +19,7 @@ export function isLocale(x: string): x is Locale {
 }
 
 const templateLit = (str: string) =>
-  '`' + escapeStringToEmbedInTemplateLiteral(str) + '`';
+  '`' + escapeTextContentToEmbedInTemplateLiteral(str) + '`';
 
 /**
  * Generate a TypeScript module that exports a project's source and target

--- a/packages/localize-tools/src/modes/runtime.ts
+++ b/packages/localize-tools/src/modes/runtime.ts
@@ -11,7 +11,7 @@ import type {Config} from '../types/config.js';
 import type {RuntimeOutputConfig} from '../types/modes.js';
 import {KnownError} from '../error.js';
 import {
-  escapeStringToEmbedInTemplateLiteral,
+  escapeTextContentToEmbedInTemplateLiteral,
   parseStringAsTemplateLiteral,
 } from '../typescript.js';
 import fsExtra from 'fs-extra';
@@ -242,7 +242,7 @@ function makeMessageString(
   const fragments = [];
   for (const content of contents) {
     if (typeof content === 'string') {
-      fragments.push(escapeStringToEmbedInTemplateLiteral(content));
+      fragments.push(escapeTextContentToEmbedInTemplateLiteral(content));
     } else {
       const template = parseStringAsTemplateLiteral(content.untranslatable);
       if (ts.isNoSubstitutionTemplateLiteral(template)) {

--- a/packages/localize-tools/src/modes/transform.ts
+++ b/packages/localize-tools/src/modes/transform.ts
@@ -19,7 +19,7 @@ import {
 } from '../program-analysis.js';
 import {KnownError} from '../error.js';
 import {
-  escapeStringToEmbedInTemplateLiteral,
+  escapeTextContentToEmbedInTemplateLiteral,
   stringifyDiagnostics,
   parseStringAsTemplateLiteral,
 } from '../typescript.js';
@@ -356,7 +356,7 @@ class Transformer {
         const templateLiteralBody = translation.contents
           .map((content) =>
             typeof content === 'string'
-              ? escapeStringToEmbedInTemplateLiteral(content)
+              ? escapeTextContentToEmbedInTemplateLiteral(content)
               : content.untranslatable
           )
           .join('');

--- a/packages/localize-tools/src/typescript.ts
+++ b/packages/localize-tools/src/typescript.ts
@@ -78,16 +78,19 @@ export function printDiagnostics(diagnostics: ts.Diagnostic[]): void {
 }
 
 /**
- * Escape a string such that it can be safely embedded in a JavaScript template
- * literal (backtick string).
+ * Escape an HTML text content string such that it can be safely embedded in a
+ * JavaScript template literal (backtick string).
  */
-export function escapeStringToEmbedInTemplateLiteral(
+export function escapeTextContentToEmbedInTemplateLiteral(
   unescaped: string
 ): string {
   return unescaped
     .replace(/\\/g, `\\\\`)
     .replace(/`/g, '\\`')
-    .replace(/\$/g, '\\$');
+    .replace(/\$/g, '\\$')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
 }
 
 /**

--- a/packages/localize-tools/testdata/build-runtime-xliff/goldens/foo.ts
+++ b/packages/localize-tools/testdata/build-runtime-xliff/goldens/foo.ts
@@ -55,3 +55,6 @@ msg('described 0', {desc: 'Description of 0'});
 const urlBase = 'http://example.com/';
 const urlPath = 'foo';
 msg(html`<b>Hello</b>! Click <a href="${urlBase}/${urlPath}">here</a>!`);
+
+// Escaped markup characters should remain escaped
+msg(html`&lt;Hello<b>&lt;World &amp; Friends&gt;</b>!&gt;`);

--- a/packages/localize-tools/testdata/build-runtime-xliff/goldens/tsout/es-419.ts
+++ b/packages/localize-tools/testdata/build-runtime-xliff/goldens/tsout/es-419.ts
@@ -8,6 +8,7 @@ import {str} from '@lit/localize';
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 export const templates = {
+  h02c268d9b1fcb031: html`&lt;Hola<b>&lt;Mundo &amp; Amigos&gt;</b>!&gt;`,
   h349c3c4777670217: html`[SALT] Hola <b>${0}</b>!`,
   h3c44aff2d5f5ef6b: html`Hola <b>Mundo</b>!`,
   h82ccc38d4d46eaa9: html`Hola <b>${0}</b>!`,

--- a/packages/localize-tools/testdata/build-runtime-xliff/goldens/tsout/zh_CN.ts
+++ b/packages/localize-tools/testdata/build-runtime-xliff/goldens/tsout/zh_CN.ts
@@ -21,4 +21,5 @@ export const templates = {
   myId: `Hello World`,
   s03c68d79ad36e8d4: `described 0`,
   h8d70dfec810d1eae: html`<b>Hello</b>! Click <a href="${0}/${1}">here</a>!`,
+  h02c268d9b1fcb031: html`&lt;Hello<b>&lt;World &amp; Friends&gt;</b>!&gt;`,
 };

--- a/packages/localize-tools/testdata/build-runtime-xliff/goldens/xliff/es-419.xlf
+++ b/packages/localize-tools/testdata/build-runtime-xliff/goldens/xliff/es-419.xlf
@@ -55,6 +55,10 @@
   <source>described 0</source>
   <target>described 0</target>
 </trans-unit>
+<trans-unit id="h02c268d9b1fcb031">
+  <source>&lt;Hello<ph id="0">&lt;b></ph>&lt;World &amp; Friends><ph id="1">&lt;/b></ph>!></source>
+  <target>&lt;Hola<ph id="0">&lt;b></ph>&lt;Mundo &amp; Amigos><ph id="1">&lt;/b></ph>!></target>
+</trans-unit>
 </body>
 </file>
 </xliff>

--- a/packages/localize-tools/testdata/build-runtime-xliff/input/foo.ts
+++ b/packages/localize-tools/testdata/build-runtime-xliff/input/foo.ts
@@ -55,3 +55,6 @@ msg('described 0', {desc: 'Description of 0'});
 const urlBase = 'http://example.com/';
 const urlPath= 'foo';
 msg(html`<b>Hello</b>! Click <a href="${urlBase}/${urlPath}">here</a>!`);
+
+// Escaped markup characters should remain escaped
+msg(html`&lt;Hello<b>&lt;World &amp; Friends&gt;</b>!&gt;`);

--- a/packages/localize-tools/testdata/build-runtime-xliff/input/xliff/es-419.xlf
+++ b/packages/localize-tools/testdata/build-runtime-xliff/input/xliff/es-419.xlf
@@ -55,6 +55,10 @@
   <source>described 0</source>
   <target>described 0</target>
 </trans-unit>
+<trans-unit id="h02c268d9b1fcb031">
+  <source>&lt;Hello<ph id="0">&lt;b></ph>&lt;World &amp; Friends><ph id="1">&lt;/b></ph>!></source>
+  <target>&lt;Hola<ph id="0">&lt;b></ph>&lt;Mundo &amp; Amigos><ph id="1">&lt;/b></ph>!></target>
+</trans-unit>
 </body>
 </file>
 </xliff>

--- a/packages/localize-tools/testdata/build-transform-xliff/goldens/foo.ts
+++ b/packages/localize-tools/testdata/build-transform-xliff/goldens/foo.ts
@@ -76,3 +76,6 @@ export class MyElement2 extends LitElement {
     return html`<p>${msg(html`Hello <b>World</b>!`)} (${getLocale()})</p>`;
   }
 }
+
+// Escaped markup characters should remain escaped
+msg(html`&lt;Hello<b>&lt;World &amp; Friends&gt;</b>!&gt;`);

--- a/packages/localize-tools/testdata/build-transform-xliff/goldens/tsout/en/foo.js
+++ b/packages/localize-tools/testdata/build-transform-xliff/goldens/tsout/en/foo.js
@@ -52,3 +52,5 @@ export class MyElement2 extends LitElement {
     return html`<p>Hello <b>World</b>! (${getLocale()})</p>`;
   }
 }
+// Escaped markup characters should remain escaped
+html`&lt;Hello<b>&lt;World &amp; Friends&gt;</b>!&gt;`;

--- a/packages/localize-tools/testdata/build-transform-xliff/goldens/tsout/es-419/foo.js
+++ b/packages/localize-tools/testdata/build-transform-xliff/goldens/tsout/es-419/foo.js
@@ -52,3 +52,5 @@ export class MyElement2 extends LitElement {
     return html`<p>Hola <b>Mundo</b>! (${getLocale()})</p>`;
   }
 }
+// Escaped markup characters should remain escaped
+html`&lt;Hola<b>&lt;Mundo &amp; Amigos&gt;</b>!&gt;`;

--- a/packages/localize-tools/testdata/build-transform-xliff/goldens/tsout/zh_CN/foo.js
+++ b/packages/localize-tools/testdata/build-transform-xliff/goldens/tsout/zh_CN/foo.js
@@ -52,3 +52,5 @@ export class MyElement2 extends LitElement {
     return html`<p>你好 <b>世界</b>! (${getLocale()})</p>`;
   }
 }
+// Escaped markup characters should remain escaped
+html`&lt;Hello<b>&lt;World &amp; Friends&gt;</b>!&gt;`;

--- a/packages/localize-tools/testdata/build-transform-xliff/goldens/xliff/es-419.xlf
+++ b/packages/localize-tools/testdata/build-transform-xliff/goldens/xliff/es-419.xlf
@@ -42,6 +42,10 @@
   <source>Hello World</source>
   <target>Hola Mundo</target>
 </trans-unit>
+<trans-unit id="h02c268d9b1fcb031">
+  <source>&lt;Hello<ph id="0">&lt;b></ph>&lt;World &amp; Friends><ph id="1">&lt;/b></ph>!></source>
+  <target>&lt;Hola<ph id="0">&lt;b></ph>&lt;Mundo &amp; Amigos><ph id="1">&lt;/b></ph>!></target>
+</trans-unit>
 </body>
 </file>
 </xliff>

--- a/packages/localize-tools/testdata/build-transform-xliff/input/foo.ts
+++ b/packages/localize-tools/testdata/build-transform-xliff/input/foo.ts
@@ -76,3 +76,6 @@ export class MyElement2 extends LitElement {
     return html`<p>${msg(html`Hello <b>World</b>!`)} (${getLocale()})</p>`;
   }
 }
+
+// Escaped markup characters should remain escaped
+msg(html`&lt;Hello<b>&lt;World &amp; Friends&gt;</b>!&gt;`);

--- a/packages/localize-tools/testdata/build-transform-xliff/input/xliff/es-419.xlf
+++ b/packages/localize-tools/testdata/build-transform-xliff/input/xliff/es-419.xlf
@@ -42,6 +42,10 @@
   <source>Hello World</source>
   <target>Hola Mundo</target>
 </trans-unit>
+<trans-unit id="h02c268d9b1fcb031">
+  <source>&lt;Hello<ph id="0">&lt;b></ph>&lt;World &amp; Friends><ph id="1">&lt;/b></ph>!></source>
+  <target>&lt;Hola<ph id="0">&lt;b></ph>&lt;Mundo &amp; Amigos><ph id="1">&lt;/b></ph>!></target>
+</trans-unit>
 </body>
 </file>
 </xliff>

--- a/packages/localize-tools/testdata/extract-xliff-fresh/goldens/data/xliff/es-419.xlf
+++ b/packages/localize-tools/testdata/extract-xliff-fresh/goldens/data/xliff/es-419.xlf
@@ -2,6 +2,9 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
 <file target-language="es-419" source-language="en" original="lit-localize-inputs" datatype="plaintext">
 <body>
+<trans-unit id="h02c268d9b1fcb031">
+  <source>&lt;Hello<ph id="0">&lt;b></ph>&lt;World &amp; Friends><ph id="1">&lt;/b></ph>!></source>
+</trans-unit>
 <trans-unit id="he7b474847636149b">
   <note>Description of Hello $(name)</note>
   <source>Hello <ph id="0">&lt;b>${name}</ph>!<ph id="1">&lt;/b></ph></source>

--- a/packages/localize-tools/testdata/extract-xliff-fresh/goldens/data/xliff/zh_CN.xlf
+++ b/packages/localize-tools/testdata/extract-xliff-fresh/goldens/data/xliff/zh_CN.xlf
@@ -2,6 +2,9 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
 <file target-language="zh_CN" source-language="en" original="lit-localize-inputs" datatype="plaintext">
 <body>
+<trans-unit id="h02c268d9b1fcb031">
+  <source>&lt;Hello<ph id="0">&lt;b></ph>&lt;World &amp; Friends><ph id="1">&lt;/b></ph>!></source>
+</trans-unit>
 <trans-unit id="he7b474847636149b">
   <note>Description of Hello $(name)</note>
   <source>Hello <ph id="0">&lt;b>${name}</ph>!<ph id="1">&lt;/b></ph></source>

--- a/packages/localize-tools/testdata/extract-xliff-fresh/goldens/foo.ts
+++ b/packages/localize-tools/testdata/extract-xliff-fresh/goldens/foo.ts
@@ -11,3 +11,6 @@ msg('Hello World!', {desc: 'Description of Hello World'});
 
 const name = 'friend';
 msg(html`Hello <b>${name}!</b>`, {desc: 'Description of Hello $(name)'});
+
+// Escaped markup characters should remain escaped
+msg(html`&lt;Hello<b>&lt;World &amp; Friends&gt;</b>!&gt;`);

--- a/packages/localize-tools/testdata/extract-xliff-fresh/input/foo.ts
+++ b/packages/localize-tools/testdata/extract-xliff-fresh/input/foo.ts
@@ -11,3 +11,6 @@ msg('Hello World!', {desc: 'Description of Hello World'});
 
 const name = 'friend';
 msg(html`Hello <b>${name}!</b>`, {desc: 'Description of Hello $(name)'});
+
+// Escaped markup characters should remain escaped
+msg(html`&lt;Hello<b>&lt;World &amp; Friends&gt;</b>!&gt;`);


### PR DESCRIPTION
Fixes a bug where we were not escaping `<`, `>`, and `&` characters to HTML entities when generating HTML text content in both runtime and transform mode.

cc @fetherston