### PR TITLE
Remove unnecessary `attribute:false` assignment in `state` decorator

### DIFF
--- a/.changeset/cool-brooms-enjoy.md
+++ b/.changeset/cool-brooms-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@lit/reactive-element': patch
+---
+
+Remove unnecessary attribute:false assignment in @state decorator

--- a/packages/reactive-element/src/decorators/state.ts
+++ b/packages/reactive-element/src/decorators/state.ts
@@ -36,6 +36,5 @@ export function state(options?: InternalPropertyDeclaration) {
   return property({
     ...options,
     state: true,
-    attribute: false,
   });
 }


### PR DESCRIPTION
Setting `attribute:false` is unnecessary in the `state` decorator because `ReactiveElement` itself already sets it to `false` when `state` is `true`: https://github.com/lit/lit/blob/main/packages/reactive-element/src/reactive-element.ts#L468