### PR TITLE
Remove unused type declarations and remove `LitExtendedWindow` and `LitExtraGlobals`.

### DIFF
--- a/.changeset/four-pianos-marry.md
+++ b/.changeset/four-pianos-marry.md
@@ -1,0 +1,7 @@
+---
+'lit-element': patch
+'lit-html': patch
+'@lit/reactive-element': patch
+---
+
+Remove some unnecessary internal type declarations.

--- a/packages/lit-element/src/env.d.ts
+++ b/packages/lit-element/src/env.d.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-interface LitExtendedWindow extends Window {
+interface Window {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   reactiveElementPlatformSupport: (options: {[index: string]: any}) => void;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -12,5 +12,3 @@ interface LitExtendedWindow extends Window {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   litHtmlPlatformSupport: (template: unknown, childPart: unknown) => void;
 }
-
-type LitExtraGlobals = typeof globalThis & LitExtendedWindow;

--- a/packages/lit-element/src/env.d.ts
+++ b/packages/lit-element/src/env.d.ts
@@ -14,16 +14,3 @@ interface LitExtendedWindow extends Window {
 }
 
 type LitExtraGlobals = typeof globalThis & LitExtendedWindow;
-
-// Augment existing types with styling API
-interface ShadowRoot {
-  adoptedStyleSheets: CSSStyleSheet[];
-}
-
-// eslint-disable-next-line no-var
-declare var ShadowRoot: {prototype: ShadowRoot; new (): ShadowRoot};
-
-interface CSSStyleSheet {
-  replaceSync(cssText: string): void;
-  replace(cssText: string): Promise<unknown>;
-}

--- a/packages/lit-element/src/env.d.ts
+++ b/packages/lit-element/src/env.d.ts
@@ -6,9 +6,5 @@
 
 interface Window {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  reactiveElementPlatformSupport: (options: {[index: string]: any}) => void;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   litElementPlatformSupport: (options: {[index: string]: any}) => void;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  litHtmlPlatformSupport: (template: unknown, childPart: unknown) => void;
 }

--- a/packages/lit-element/src/polyfill-support.ts
+++ b/packages/lit-element/src/polyfill-support.ts
@@ -48,14 +48,12 @@ interface PatchableLitElement extends HTMLElement {
 }: {
   LitElement: PatchableLitElement;
 }) => {
-  const extraGlobals = window as LitExtraGlobals;
-
   // polyfill-support is only needed if ShadyCSS or the ApplyShim is in use
   // We test at the point of patching, which makes it safe to load
   // webcomponentsjs and polyfill-support in either order
   if (
-    extraGlobals.ShadyCSS === undefined ||
-    (extraGlobals.ShadyCSS.nativeShadow && !extraGlobals.ShadyCSS.ApplyShim)
+    window.ShadyCSS === undefined ||
+    (window.ShadyCSS.nativeShadow && !window.ShadyCSS.ApplyShim)
   ) {
     return;
   }

--- a/packages/lit-element/src/test/lit-element_styling_test.ts
+++ b/packages/lit-element/src/test/lit-element_styling_test.ts
@@ -13,8 +13,6 @@ import {
 } from './test-helpers.js';
 import {assert} from '@esm-bundle/chai';
 
-const extraGlobals = window as LitExtraGlobals;
-
 (canTestLitElement ? suite : suite.skip)('Styling', () => {
   suite('Basic styling', () => {
     let container: HTMLElement;
@@ -309,7 +307,7 @@ const extraGlobals = window as LitExtraGlobals;
         '3px'
       );
       // Verify there is one scoping style under ShadyDOM
-      if (extraGlobals.ShadyDOM?.inUse) {
+      if (window.ShadyDOM?.inUse) {
         assert.equal(
           document.querySelectorAll(`style[scope=${name}`).length,
           1
@@ -322,7 +320,7 @@ const extraGlobals = window as LitExtraGlobals;
     let container: HTMLElement;
 
     setup(function () {
-      if (!extraGlobals.ShadyDOM) {
+      if (!window.ShadyDOM) {
         this.skip();
       } else {
         container = document.createElement('div');

--- a/packages/lit-element/src/test/lit-element_test.ts
+++ b/packages/lit-element/src/test/lit-element_test.ts
@@ -23,8 +23,6 @@ import {assert} from '@esm-bundle/chai';
 
 import {createRef, ref} from 'lit-html/directives/ref.js';
 
-const extraGlobals = window as LitExtraGlobals;
-
 (canTestLitElement ? suite : suite.skip)('LitElement', () => {
   let container: HTMLElement;
 
@@ -324,7 +322,7 @@ const extraGlobals = window as LitExtraGlobals;
     assert.ok(a.hasUpdated);
   });
 
-  (extraGlobals.ShadyDOM && extraGlobals.ShadyDOM.inUse ? test.skip : test)(
+  (window.ShadyDOM && window.ShadyDOM.inUse ? test.skip : test)(
     'can customize shadowRootOptions',
     async () => {
       class A extends LitElement {

--- a/packages/lit-element/src/test/test-helpers.ts
+++ b/packages/lit-element/src/test/test-helpers.ts
@@ -12,11 +12,9 @@ export const generateElementName = () => `x-${count++}`;
 export const nextFrame = () =>
   new Promise((resolve) => requestAnimationFrame(resolve));
 
-const extraGlobals = window as LitExtraGlobals;
-
 export const getComputedStyleValue = (element: Element, property: string) =>
-  extraGlobals.ShadyCSS
-    ? extraGlobals.ShadyCSS.getComputedStyleValue(element, property)
+  window.ShadyCSS
+    ? window.ShadyCSS.getComputedStyleValue(element, property)
     : getComputedStyle(element).getPropertyValue(property);
 
 export const stripExpressionComments = (html: string) =>
@@ -25,8 +23,8 @@ export const stripExpressionComments = (html: string) =>
 // Only test LitElement if ShadowRoot is available and either ShadyDOM is not
 // in use or it is and LitElement platform support is available.
 export const canTestLitElement =
-  (window.ShadowRoot && !extraGlobals.ShadyDOM?.inUse) ||
-  extraGlobals.litElementPlatformSupport;
+  (window.ShadowRoot && !window.ShadyDOM?.inUse) ||
+  window.litElementPlatformSupport;
 
 export interface ShadyRenderOptions extends RenderOptions {
   scope?: string;

--- a/packages/lit-html/src/directive-helpers.ts
+++ b/packages/lit-html/src/directive-helpers.ts
@@ -19,13 +19,11 @@ type ChildPart = InstanceType<typeof ChildPart>;
 
 const ENABLE_SHADYDOM_NOPATCH = true;
 
-const extraGlobals = window as LitExtraGlobals;
-
 const wrap =
   ENABLE_SHADYDOM_NOPATCH &&
-  extraGlobals.ShadyDOM?.inUse &&
-  extraGlobals.ShadyDOM?.noPatch === true
-    ? extraGlobals.ShadyDOM!.wrap
+  window.ShadyDOM?.inUse &&
+  window.ShadyDOM?.noPatch === true
+    ? window.ShadyDOM!.wrap
     : (node: Node) => node;
 
 /**

--- a/packages/lit-html/src/env.d.ts
+++ b/packages/lit-html/src/env.d.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-interface LitExtendedWindow extends Window {
+interface Window {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   reactiveElementPlatformSupport: (options: {[index: string]: any}) => void;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -12,5 +12,3 @@ interface LitExtendedWindow extends Window {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   litHtmlPlatformSupport: (template: unknown, childPart: unknown) => void;
 }
-
-type LitExtraGlobals = typeof globalThis & LitExtendedWindow;

--- a/packages/lit-html/src/env.d.ts
+++ b/packages/lit-html/src/env.d.ts
@@ -14,16 +14,3 @@ interface LitExtendedWindow extends Window {
 }
 
 type LitExtraGlobals = typeof globalThis & LitExtendedWindow;
-
-// Augment existing types with styling API
-interface ShadowRoot {
-  adoptedStyleSheets: CSSStyleSheet[];
-}
-
-// eslint-disable-next-line no-var
-declare var ShadowRoot: {prototype: ShadowRoot; new (): ShadowRoot};
-
-interface CSSStyleSheet {
-  replaceSync(cssText: string): void;
-  replace(cssText: string): Promise<unknown>;
-}

--- a/packages/lit-html/src/env.d.ts
+++ b/packages/lit-html/src/env.d.ts
@@ -6,9 +6,5 @@
 
 interface Window {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  reactiveElementPlatformSupport: (options: {[index: string]: any}) => void;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  litElementPlatformSupport: (options: {[index: string]: any}) => void;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   litHtmlPlatformSupport: (template: unknown, childPart: unknown) => void;
 }

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -22,13 +22,11 @@ if (DEV_MODE) {
   console.warn('lit-html is in dev mode. Not recommended for production!');
 }
 
-const extraGlobals = window as LitExtraGlobals;
-
 const wrap =
   ENABLE_SHADYDOM_NOPATCH &&
-  extraGlobals.ShadyDOM?.inUse &&
-  extraGlobals.ShadyDOM?.noPatch === true
-    ? extraGlobals.ShadyDOM!.wrap
+  window.ShadyDOM?.inUse &&
+  window.ShadyDOM?.noPatch === true
+    ? window.ShadyDOM!.wrap
     : (node: Node) => node;
 
 const trustedTypes = (globalThis as unknown as Partial<Window>).trustedTypes;

--- a/packages/lit-html/src/polyfill-support.ts
+++ b/packages/lit-html/src/polyfill-support.ts
@@ -95,14 +95,12 @@ const ENABLE_SHADYDOM_NOPATCH = true;
   Template: PatchableTemplateConstructor,
   ChildPart: PatchableChildPartConstructor
 ) => {
-  const extraGlobals = window as LitExtraGlobals;
-
   // polyfill-support is only needed if ShadyCSS or the ApplyShim is in use
   // We test at the point of patching, which makes it safe to load
   // webcomponentsjs and polyfill-support in either order
   if (
-    extraGlobals.ShadyCSS === undefined ||
-    (extraGlobals.ShadyCSS.nativeShadow && !extraGlobals.ShadyCSS.ApplyShim)
+    window.ShadyCSS === undefined ||
+    (window.ShadyCSS.nativeShadow && !window.ShadyCSS.ApplyShim)
   ) {
     return;
   }
@@ -114,9 +112,9 @@ const ENABLE_SHADYDOM_NOPATCH = true;
 
   const wrap =
     ENABLE_SHADYDOM_NOPATCH &&
-    extraGlobals.ShadyDOM?.inUse &&
-    extraGlobals.ShadyDOM?.noPatch === true
-      ? extraGlobals.ShadyDOM!.wrap
+    window.ShadyDOM?.inUse &&
+    window.ShadyDOM?.noPatch === true
+      ? window.ShadyDOM!.wrap
       : (node: Node) => node;
 
   const needsPrepareStyles = (name: string | undefined) =>
@@ -147,11 +145,11 @@ const ENABLE_SHADYDOM_NOPATCH = true;
     scopeCssStore.delete(name);
     // ShadyCSS removes scopes and removes the style under ShadyDOM and leaves
     // it under native Shadow DOM
-    extraGlobals.ShadyCSS!.prepareTemplateStyles(template, name);
+    window.ShadyCSS!.prepareTemplateStyles(template, name);
     // Note, under native Shadow DOM, the style is added to the beginning of the
     // template. It must be moved to the *end* of the template so it doesn't
     // mess up part indices.
-    if (hasScopeCss && extraGlobals.ShadyCSS!.nativeShadow) {
+    if (hasScopeCss && window.ShadyCSS!.nativeShadow) {
       // If there were styles but the CSS text was empty, ShadyCSS will
       // eliminate the style altogether, so the style here could be null
       const style = template.content.querySelector('style');
@@ -176,8 +174,8 @@ const ENABLE_SHADYDOM_NOPATCH = true;
     const element = originalCreateElement.call(Template, html, options);
     const scope = options?.scope;
     if (scope !== undefined) {
-      if (!extraGlobals.ShadyCSS!.nativeShadow) {
-        extraGlobals.ShadyCSS!.prepareTemplateDom(element, scope);
+      if (!window.ShadyCSS!.nativeShadow) {
+        window.ShadyCSS!.prepareTemplateDom(element, scope);
       }
       // Process styles only if this scope is being prepared. Otherwise,
       // leave styles as is for back compat with Lit1.
@@ -247,7 +245,7 @@ const ENABLE_SHADYDOM_NOPATCH = true;
       // Note, this is the temporary startNode.
       renderContainer.removeChild(renderContainerMarker);
       // When using native Shadow DOM, include prepared style in shadowRoot.
-      if (extraGlobals.ShadyCSS?.nativeShadow) {
+      if (window.ShadyCSS?.nativeShadow) {
         const style = template.content.querySelector('style');
         if (style !== null) {
           renderContainer.appendChild(style.cloneNode(true));

--- a/packages/lit-html/src/test/polyfill-support/lit-html-apply_html-test.ts
+++ b/packages/lit-html/src/test/polyfill-support/lit-html-apply_html-test.ts
@@ -10,8 +10,6 @@ import {html as htmlWithApply} from '../../lit-html.js';
 import {renderShadowRoot} from '../test-utils/shadow-root.js';
 import {assert} from '@esm-bundle/chai';
 
-const extraGlobals = window as LitExtraGlobals;
-
 suite('@apply', () => {
   test('styles with css custom properties using @apply render', function () {
     const container = document.createElement('scope-5');
@@ -31,7 +29,7 @@ suite('@apply', () => {
       <div>Testing...</div>
     `;
     renderShadowRoot(result, container);
-    extraGlobals.ShadyCSS?.styleElement(container);
+    window.ShadyCSS?.styleElement(container);
     const div = container.shadowRoot!.querySelector('div');
     const computedStyle = getComputedStyle(div!);
     assert.equal(
@@ -61,7 +59,7 @@ suite('@apply', () => {
       const applyUser = document.createElement('apply-user');
       document.body.appendChild(applyUser);
       renderShadowRoot(applyUserContent, applyUser);
-      extraGlobals.ShadyCSS?.styleElement(applyUser);
+      window.ShadyCSS?.styleElement(applyUser);
       const applyUserDiv = applyUser.shadowRoot!.querySelector('div');
       const applyUserStyle = getComputedStyle(applyUserDiv!);
       assert.equal(
@@ -101,13 +99,13 @@ suite('@apply', () => {
       const div = applyProducer.shadowRoot!.querySelector('#test');
       assert.ok(div?.hasAttribute('some-attr'));
       assert.ok(div?.textContent, 'test');
-      extraGlobals.ShadyCSS?.styleElement(applyProducer);
+      window.ShadyCSS?.styleElement(applyProducer);
       const usersInProducer =
         applyProducer.shadowRoot!.querySelectorAll('apply-user');
       renderShadowRoot(applyUserContent, usersInProducer[0]);
-      extraGlobals.ShadyCSS?.styleElement(usersInProducer[0] as HTMLElement);
+      window.ShadyCSS?.styleElement(usersInProducer[0] as HTMLElement);
       renderShadowRoot(applyUserContent, usersInProducer[1]);
-      extraGlobals.ShadyCSS?.styleElement(usersInProducer[1] as HTMLElement);
+      window.ShadyCSS?.styleElement(usersInProducer[1] as HTMLElement);
       const userInProducerStyle1 = getComputedStyle(
         usersInProducer[0].shadowRoot!.querySelector('div')!
       );
@@ -151,7 +149,7 @@ suite('@apply', () => {
             </style>
             <div>Testing...</div>`;
         renderShadowRoot(result, this);
-        extraGlobals.ShadyCSS?.styleElement(this);
+        window.ShadyCSS?.styleElement(this);
       }
     }
     customElements.define('apply-user-ce1', E);
@@ -214,7 +212,7 @@ suite('@apply', () => {
       <div>Testing...</div>
     `;
     renderShadowRoot(result, container);
-    extraGlobals.ShadyCSS?.styleElement(container);
+    window.ShadyCSS?.styleElement(container);
     document.body.removeChild(container);
   });
 });

--- a/packages/lit-html/src/test/polyfill-support/lit-html-scoping-shim_html-test.ts
+++ b/packages/lit-html/src/test/polyfill-support/lit-html-scoping-shim_html-test.ts
@@ -8,16 +8,14 @@ import {renderShadowRoot} from '../test-utils/shadow-root.js';
 import {html} from '../../lit-html.js';
 import {assert} from '@esm-bundle/chai';
 
-const extraGlobals = window as LitExtraGlobals;
-
 suite('ShadyCSS scoping shim', () => {
   setup(function () {
     if (
-      typeof extraGlobals.ShadyDOM === 'undefined' ||
-      !extraGlobals.ShadyDOM.inUse ||
-      typeof extraGlobals.ShadyCSS === 'undefined' ||
-      extraGlobals.ShadyCSS.nativeShadow ||
-      extraGlobals.ShadyCSS.ScopingShim === undefined
+      typeof window.ShadyDOM === 'undefined' ||
+      !window.ShadyDOM.inUse ||
+      typeof window.ShadyCSS === 'undefined' ||
+      window.ShadyCSS.nativeShadow ||
+      window.ShadyCSS.ScopingShim === undefined
     ) {
       this.skip();
       return;
@@ -26,7 +24,7 @@ suite('ShadyCSS scoping shim', () => {
 
   test('scoped styles are applied for non-TemplateResult values', function () {
     const container = document.createElement('scope-1');
-    extraGlobals.ShadyCSS!.ScopingShim!.prepareAdoptedCssText(
+    window.ShadyCSS!.ScopingShim!.prepareAdoptedCssText(
       [':host { border-top: 2px solid black; }'],
       'scope-1'
     );
@@ -41,7 +39,7 @@ suite('ShadyCSS scoping shim', () => {
 
   test('adopted CSS remains when rendering a TemplateResult after an initial non-TemplateResult', function () {
     const container = document.createElement('scope-2');
-    extraGlobals.ShadyCSS!.ScopingShim!.prepareAdoptedCssText(
+    window.ShadyCSS!.ScopingShim!.prepareAdoptedCssText(
       [':host { border-top: 2px solid black; } button { font-size: 7px; } '],
       'scope-2'
     );

--- a/packages/lit-html/src/test/polyfill-support/lit-html_html-test.ts
+++ b/packages/lit-html/src/test/polyfill-support/lit-html_html-test.ts
@@ -21,8 +21,6 @@ import '../directives/repeat_test.js';
 import '../directives/template-content_test.js';
 import '../directives/unsafe-html_test.js';
 
-const extraGlobals = window as LitExtraGlobals;
-
 suite('polyfill-support rendering', () => {
   test('style elements apply in shadowRoots', () => {
     const container = document.createElement('scope-1');
@@ -78,7 +76,7 @@ suite('polyfill-support rendering', () => {
     // all styles are removed
     const styles = shadowRoot(container)!.querySelectorAll('style');
     // if ShadyDOM is in use, all styles should be removed from the template.
-    if (extraGlobals.ShadyDOM?.inUse) {
+    if (window.ShadyDOM?.inUse) {
       assert.equal(styles.length, 0);
     }
     wrap(document.body).removeChild(container);
@@ -114,7 +112,7 @@ suite('polyfill-support rendering', () => {
       '4px'
     );
     // if ShadyDOM is in use, the late added style should leak
-    if (extraGlobals.ShadyDOM?.inUse) {
+    if (window.ShadyDOM?.inUse) {
       // late added styles are retained
       const styles = shadowRoot(container)!.querySelectorAll('style');
       assert.equal(styles.length, 1);
@@ -177,8 +175,8 @@ suite('polyfill-support rendering', () => {
       <div>Testing...</div>
     `;
     renderShadowRoot(result, container);
-    if (extraGlobals.ShadyCSS) {
-      extraGlobals.ShadyCSS.styleElement(container);
+    if (window.ShadyCSS) {
+      window.ShadyCSS.styleElement(container);
     }
     const div = shadowRoot(container)!.querySelector('div');
     assert.equal(
@@ -210,13 +208,13 @@ suite('polyfill-support rendering', () => {
       <scope-4a-sub></scope-4a-sub>
     `;
     renderShadowRoot(result, container);
-    if (extraGlobals.ShadyCSS) {
-      extraGlobals.ShadyCSS.styleElement(container);
+    if (window.ShadyCSS) {
+      window.ShadyCSS.styleElement(container);
     }
     const e = shadowRoot(container)!.querySelector('scope-4a-sub')!;
     renderShadowRoot(shadowContent, e);
-    if (extraGlobals.ShadyCSS) {
-      extraGlobals.ShadyCSS.styleElement(e as HTMLElement);
+    if (window.ShadyCSS) {
+      window.ShadyCSS.styleElement(e as HTMLElement);
     }
     assert.equal(
       getComputedStyle(e).getPropertyValue('border-top-width').trim(),
@@ -252,12 +250,12 @@ suite('polyfill-support rendering', () => {
     );
     const elements = shadowRoot(container)!.querySelectorAll('scope-4b-sub');
     renderShadowRoot(nestedContent, elements[0]);
-    if (extraGlobals.ShadyCSS) {
-      extraGlobals.ShadyCSS.styleSubtree(elements[0] as HTMLElement);
+    if (window.ShadyCSS) {
+      window.ShadyCSS.styleSubtree(elements[0] as HTMLElement);
     }
     renderShadowRoot(nestedContent, elements[1]);
-    if (extraGlobals.ShadyCSS) {
-      extraGlobals.ShadyCSS.styleSubtree(elements[1] as HTMLElement);
+    if (window.ShadyCSS) {
+      window.ShadyCSS.styleSubtree(elements[1] as HTMLElement);
     }
     assert.equal(
       getComputedStyle(elements[0]).getPropertyValue('border-top-width').trim(),
@@ -391,10 +389,7 @@ suite('polyfill-support rendering', () => {
 
   // TODO(sorvell): This will only be supported via static bindings.
   test.skip('part values render into styles once per scope', function () {
-    if (
-      typeof extraGlobals.ShadyDOM === 'undefined' ||
-      !extraGlobals.ShadyDOM.inUse
-    ) {
+    if (typeof window.ShadyDOM === 'undefined' || !window.ShadyDOM.inUse) {
       this.skip();
       return;
     }

--- a/packages/lit-html/src/test/test-utils/shadow-root.ts
+++ b/packages/lit-html/src/test/test-utils/shadow-root.ts
@@ -10,13 +10,9 @@ export interface ShadyRenderOptions extends RenderOptions {
   scope?: string;
 }
 
-const extraGlobals = window as LitExtraGlobals;
-
 export const wrap =
-  extraGlobals.ShadyDOM &&
-  extraGlobals.ShadyDOM.inUse &&
-  extraGlobals.ShadyDOM.noPatch === true
-    ? extraGlobals.ShadyDOM!.wrap
+  window.ShadyDOM && window.ShadyDOM.inUse && window.ShadyDOM.noPatch === true
+    ? window.ShadyDOM!.wrap
     : (node: Node) => node;
 
 export const shadowRoot = (element: Node) =>

--- a/packages/reactive-element/src/css-tag.ts
+++ b/packages/reactive-element/src/css-tag.ts
@@ -4,14 +4,12 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-const extraGlobals = window as LitExtraGlobals;
-
 /**
  * Whether the current browser supports `adoptedStyleSheets`.
  */
 export const supportsAdoptingStyleSheets =
   window.ShadowRoot &&
-  (extraGlobals.ShadyCSS === undefined || extraGlobals.ShadyCSS.nativeShadow) &&
+  (window.ShadyCSS === undefined || window.ShadyCSS.nativeShadow) &&
   'adoptedStyleSheets' in Document.prototype &&
   'replace' in CSSStyleSheet.prototype;
 

--- a/packages/reactive-element/src/env.d.ts
+++ b/packages/reactive-element/src/env.d.ts
@@ -20,10 +20,6 @@ interface ShadowRoot {
   adoptedStyleSheets: CSSStyleSheet[];
 }
 
-// eslint-disable-next-line no-var
-declare var ShadowRoot: {prototype: ShadowRoot; new (): ShadowRoot};
-
 interface CSSStyleSheet {
   replaceSync(cssText: string): void;
-  replace(cssText: string): Promise<unknown>;
 }

--- a/packages/reactive-element/src/env.d.ts
+++ b/packages/reactive-element/src/env.d.ts
@@ -7,10 +7,6 @@
 interface Window {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   reactiveElementPlatformSupport: (options: {[index: string]: any}) => void;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  litElementPlatformSupport: (options: {[index: string]: any}) => void;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  litHtmlPlatformSupport: (template: unknown, childPart: unknown) => void;
 }
 
 // Augment existing types with styling API

--- a/packages/reactive-element/src/env.d.ts
+++ b/packages/reactive-element/src/env.d.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-interface LitExtendedWindow extends Window {
+interface Window {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   reactiveElementPlatformSupport: (options: {[index: string]: any}) => void;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -12,8 +12,6 @@ interface LitExtendedWindow extends Window {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   litHtmlPlatformSupport: (template: unknown, childPart: unknown) => void;
 }
-
-type LitExtraGlobals = typeof globalThis & LitExtendedWindow;
 
 // Augment existing types with styling API
 interface ShadowRoot {

--- a/packages/reactive-element/src/polyfill-support.ts
+++ b/packages/reactive-element/src/polyfill-support.ts
@@ -49,14 +49,12 @@ interface PatchableReactiveElement extends HTMLElement {
 }: {
   ReactiveElement: PatchableReactiveElement;
 }) => {
-  const extraGlobals = window as LitExtraGlobals;
-
   // polyfill-support is only needed if ShadyCSS or the ApplyShim is in use
   // We test at the point of patching, which makes it safe to load
   // webcomponentsjs and polyfill-support in either order
   if (
-    extraGlobals.ShadyCSS === undefined ||
-    (extraGlobals.ShadyCSS.nativeShadow && !extraGlobals.ShadyCSS.ApplyShim)
+    window.ShadyCSS === undefined ||
+    (window.ShadyCSS.nativeShadow && !window.ShadyCSS.ApplyShim)
   ) {
     return;
   }
@@ -71,11 +69,11 @@ interface PatchableReactiveElement extends HTMLElement {
   // In noPatch mode, patch the ReactiveElement prototype so that no
   // ReactiveElements must be wrapped.
   if (
-    extraGlobals.ShadyDOM &&
-    extraGlobals.ShadyDOM.inUse &&
-    extraGlobals.ShadyDOM.noPatch === true
+    window.ShadyDOM &&
+    window.ShadyDOM.inUse &&
+    window.ShadyDOM.noPatch === true
   ) {
-    extraGlobals.ShadyDOM.patchElementProto(elementProto);
+    window.ShadyDOM.patchElementProto(elementProto);
   }
 
   /**
@@ -88,7 +86,7 @@ interface PatchableReactiveElement extends HTMLElement {
     const name = this.localName;
     // If using native Shadow DOM must adoptStyles normally,
     // otherwise do nothing.
-    if (extraGlobals.ShadyCSS!.nativeShadow) {
+    if (window.ShadyCSS!.nativeShadow) {
       return createRenderRoot.call(this);
     } else {
       if (!this.constructor.hasOwnProperty(SCOPED)) {
@@ -105,9 +103,9 @@ interface PatchableReactiveElement extends HTMLElement {
               )
             : v.cssText
         );
-        extraGlobals.ShadyCSS?.ScopingShim?.prepareAdoptedCssText(css, name);
+        window.ShadyCSS?.ScopingShim?.prepareAdoptedCssText(css, name);
         if (this.constructor._$handlesPrepareStyles === undefined) {
-          extraGlobals.ShadyCSS!.prepareTemplateStyles(
+          window.ShadyCSS!.prepareTemplateStyles(
             document.createElement('template'),
             name
           );
@@ -132,7 +130,7 @@ interface PatchableReactiveElement extends HTMLElement {
     // Note, must do first update separately so that we're ensured
     // that rendering has completed before calling this.
     if (this.hasUpdated) {
-      extraGlobals.ShadyCSS!.styleElement(this);
+      window.ShadyCSS!.styleElement(this);
     }
   };
 
@@ -148,7 +146,7 @@ interface PatchableReactiveElement extends HTMLElement {
     // Note, must do first update here so rendering has completed before
     // calling this and styles are correct by updated/firstUpdated.
     if (!this.hasUpdated) {
-      extraGlobals.ShadyCSS!.styleElement(this);
+      window.ShadyCSS!.styleElement(this);
     }
     didUpdate.call(this, changedProperties);
   };

--- a/packages/reactive-element/src/reactive-element.ts
+++ b/packages/reactive-element/src/reactive-element.ts
@@ -42,7 +42,7 @@ if (DEV_MODE) {
 
   // Issue platform support warning.
   if (
-    (window as LitExtraGlobals).ShadyDOM?.inUse &&
+    window.ShadyDOM?.inUse &&
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (globalThis as any)['reactiveElementPlatformSupport'] === undefined
   ) {

--- a/packages/reactive-element/src/test/decorators/queryAssignedNodes_test.ts
+++ b/packages/reactive-element/src/test/decorators/queryAssignedNodes_test.ts
@@ -13,12 +13,8 @@ import {
 } from '../test-helpers.js';
 import {assert} from '@esm-bundle/chai';
 
-const extraGlobals = window as LitExtraGlobals;
-
 const flush =
-  extraGlobals.ShadyDOM && extraGlobals.ShadyDOM.flush
-    ? extraGlobals.ShadyDOM.flush
-    : () => {};
+  window.ShadyDOM && window.ShadyDOM.flush ? window.ShadyDOM.flush : () => {};
 
 (canTestReactiveElement ? suite : suite.skip)('@queryAssignedNodes', () => {
   let container: HTMLElement;

--- a/packages/reactive-element/src/test/reactive-element_dev_mode_test.ts
+++ b/packages/reactive-element/src/test/reactive-element_dev_mode_test.ts
@@ -18,7 +18,7 @@ if (DEV_MODE) {
     let warnings: string[] = [];
 
     const missingPlatformSupport =
-      (window as LitExtraGlobals).ShadyDOM?.inUse &&
+      window.ShadyDOM?.inUse &&
       !(globalThis as any)['reactiveElementPlatformSupport'];
 
     const consoleWarn = console.warn;

--- a/packages/reactive-element/src/test/reactive-element_styling_test.ts
+++ b/packages/reactive-element/src/test/reactive-element_styling_test.ts
@@ -20,8 +20,6 @@ import {
 } from './test-helpers.js';
 import {assert} from '@esm-bundle/chai';
 
-const extraGlobals = window as LitExtraGlobals;
-
 (canTestReactiveElement ? suite : suite.skip)('Styling', () => {
   suite('Static get styles', () => {
     let container: HTMLElement;
@@ -88,7 +86,7 @@ const extraGlobals = window as LitExtraGlobals;
     // Test this in Shadow DOM without `adoptedStyleSheets` only since it's easily
     // detectable in that case.
     const testShadowDOMStyleCount =
-      (!extraGlobals.ShadyDOM || !extraGlobals.ShadyDOM.inUse) &&
+      (!window.ShadyDOM || !window.ShadyDOM.inUse) &&
       !('adoptedStyleSheets' in Document.prototype);
     (testShadowDOMStyleCount ? test : test.skip)(
       'when an array is returned from `static get styles`, one style is generated per array item',
@@ -732,8 +730,7 @@ const extraGlobals = window as LitExtraGlobals;
         // our styles as they're already flattened (so expect 4px). Otherwise,
         // look for the updated value.
         const usesAdoptedStyleSheet =
-          extraGlobals.ShadyCSS === undefined ||
-          extraGlobals.ShadyCSS.nativeShadow;
+          window.ShadyCSS === undefined || window.ShadyCSS.nativeShadow;
         const expectedValue = usesAdoptedStyleSheet ? '2px' : '4px';
         sheet.replaceSync('div { border: 2px solid red; }');
 
@@ -750,8 +747,8 @@ const extraGlobals = window as LitExtraGlobals;
     const testShadyCSSWithAdoptedStyleSheetSupport =
       window.ShadowRoot &&
       'replace' in CSSStyleSheet.prototype &&
-      extraGlobals.ShadyCSS !== undefined &&
-      !extraGlobals.ShadyCSS.nativeShadow;
+      window.ShadyCSS !== undefined &&
+      !window.ShadyCSS.nativeShadow;
     (testShadyCSSWithAdoptedStyleSheetSupport ? test : test.skip)(
       'CSSStyleSheet is flattened where ShadyCSS is enabled yet adoptedStyleSheets are supported',
       async () => {

--- a/packages/reactive-element/src/test/test-helpers.ts
+++ b/packages/reactive-element/src/test/test-helpers.ts
@@ -12,11 +12,9 @@ export const generateElementName = () => `x-${count++}`;
 export const nextFrame = () =>
   new Promise((resolve) => requestAnimationFrame(resolve));
 
-const extraGlobals = window as LitExtraGlobals;
-
 export const getComputedStyleValue = (element: Element, property: string) =>
-  extraGlobals.ShadyCSS
-    ? extraGlobals.ShadyCSS.getComputedStyleValue(element, property)
+  window.ShadyCSS
+    ? window.ShadyCSS.getComputedStyleValue(element, property)
     : getComputedStyle(element).getPropertyValue(property);
 
 export const stripExpressionComments = (html: string) =>
@@ -25,8 +23,8 @@ export const stripExpressionComments = (html: string) =>
 // Only test if ShadowRoot is available and either ShadyDOM is not
 // in use or it is and platform support is available.
 export const canTestReactiveElement =
-  (window.ShadowRoot && !extraGlobals.ShadyDOM?.inUse) ||
-  extraGlobals.reactiveElementPlatformSupport;
+  (window.ShadowRoot && !window.ShadyDOM?.inUse) ||
+  window.reactiveElementPlatformSupport;
 
 export class RenderingElement extends ReactiveElement {
   render(): string | undefined {


### PR DESCRIPTION
In this PR, I've removed as many declarations as I could from the `.d.ts` files as well as reverted (w/ conflict resolution) https://github.com/lit/lit/pull/1904. I think in https://github.com/lit/lit/pull/1904 I was trying to work around collisions with the polyfills' JS externs internally but, now that that is fixed, I think it was a mistake to not leave the other types (`litHtmlPlatformSupport`, etc.) on the global `Window` interface.