### PR TITLE
Prototype: Benchmark classMap

### DIFF
--- a/packages/lit-html/src/directives/class-map.ts
+++ b/packages/lit-html/src/directives/class-map.ts
@@ -4,14 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {AttributePart, noChange} from '../lit-html.js';
-import {
-  directive,
-  Directive,
-  DirectiveParameters,
-  PartInfo,
-  PartType,
-} from '../directive.js';
+import {directive, Directive} from '../directive.js';
 
 /**
  * A key-value set of class names to truthy values.
@@ -21,72 +14,10 @@ export interface ClassInfo {
 }
 
 class ClassMapDirective extends Directive {
-  /**
-   * Stores the ClassInfo object applied to a given AttributePart.
-   * Used to unset existing values when a new ClassInfo object is applied.
-   */
-  private _previousClasses?: Set<string>;
-
-  constructor(partInfo: PartInfo) {
-    super(partInfo);
-    if (
-      partInfo.type !== PartType.ATTRIBUTE ||
-      partInfo.name !== 'class' ||
-      (partInfo.strings?.length as number) > 2
-    ) {
-      throw new Error(
-        '`classMap()` can only be used in the `class` attribute ' +
-          'and must be the only part in the attribute.'
-      );
-    }
-  }
-
   render(classInfo: ClassInfo) {
     return Object.keys(classInfo)
       .filter((key) => classInfo[key])
       .join(' ');
-  }
-
-  update(part: AttributePart, [classInfo]: DirectiveParameters<this>) {
-    // Remember dynamic classes on the first render
-    if (this._previousClasses === undefined) {
-      this._previousClasses = new Set();
-      for (const name in classInfo) {
-        if (classInfo[name]) {
-          this._previousClasses.add(name);
-        }
-      }
-      return this.render(classInfo);
-    }
-
-    const classList = part.element.classList;
-
-    // Remove old classes that no longer apply
-    // We use forEach() instead of for-of so that we don't require down-level
-    // iteration.
-    this._previousClasses.forEach((name) => {
-      if (!(name in classInfo)) {
-        classList.remove(name);
-        this._previousClasses!.delete(name);
-      }
-    });
-
-    // Add or remove classes based on their classMap value
-    for (const name in classInfo) {
-      // We explicitly want a loose truthy check of `value` because it seems
-      // more convenient that '' and 0 are skipped.
-      const value = !!classInfo[name];
-      if (value !== this._previousClasses.has(name)) {
-        if (value) {
-          classList.add(name);
-          this._previousClasses.add(name);
-        } else {
-          classList.remove(name);
-          this._previousClasses.delete(name);
-        }
-      }
-    }
-    return noChange;
   }
 }
 


### PR DESCRIPTION
### Context

This PR is a draft change removing the classMap directive implementation to see the impact on benchmarks. It was prompted by #2010. We measure classMap performance in the kitchen-sink benchmark so this draft can be used as a comparison.

### How

I simplified the classMap directive to behave very naively and just concat together strings. From local benchmarking this seems equivalent to inlining the classMap `render` logic directly into the `class` attribute.

### Why

I am not very familiar with this repo or benchmarking. The objective is to prototype a really rough simplified classMap that passes tests and see the benchmark results.

### Tests

Tested by running `npm run test` on the lerna repo. There are 6 failed tests, but I can reproduce them failing on main without this change. They seem related to polyfill-suppport.