### PR TITLE
Unify code examples by removing @example attribute.

### DIFF
--- a/packages/lit-html/src/directives/ref.ts
+++ b/packages/lit-html/src/directives/ref.ts
@@ -120,7 +120,6 @@ class RefDirective extends AsyncDirective {
  * removed in a subsequent render, it will first be called with `undefined`,
  * followed by another call with the new element it was rendered to (if any).
  *
- * @example
  * ```js
  * // Using Ref object
  * const inputRef = createRef();

--- a/packages/reactive-element/src/decorators/event-options.ts
+++ b/packages/reactive-element/src/decorators/event-options.ts
@@ -24,7 +24,6 @@ import {decorateProperty} from './base.js';
  * Current browsers support the `capture`, `passive`, and `once` options. See:
  * https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#Parameters
  *
- * @example
  * ```ts
  * class MyElement {
  *   clicked = false;

--- a/packages/reactive-element/src/decorators/property.ts
+++ b/packages/reactive-element/src/decorators/property.ts
@@ -94,7 +94,6 @@ const legacyProperty = (
  * state properties can be initialized via public properties to facilitate
  * complex interactions.
  *
- * @example
  * ```ts
  * class MyElement {
  *   @property({ type: Boolean })

--- a/packages/reactive-element/src/decorators/query-all.ts
+++ b/packages/reactive-element/src/decorators/query-all.ts
@@ -23,7 +23,6 @@ import {decorateProperty} from './base.js';
  * See:
  * https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelectorAll
  *
- * @example
  * ```ts
  * class MyElement {
  *   @queryAll('div')

--- a/packages/reactive-element/src/decorators/query-assigned-nodes.ts
+++ b/packages/reactive-element/src/decorators/query-assigned-nodes.ts
@@ -33,7 +33,6 @@ const legacyMatches =
  * @param selector A string which filters the results to elements that match
  *     the given css selector.
  *
- * @example
  * ```ts
  * class MyElement {
  *   @queryAssignedNodes('list', true, '.item')

--- a/packages/reactive-element/src/decorators/query-async.ts
+++ b/packages/reactive-element/src/decorators/query-async.ts
@@ -31,7 +31,6 @@ import {decorateProperty} from './base.js';
  *
  * See: https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector
  *
- * @example
  * ```ts
  * class MyElement {
  *   @queryAsync('#first')

--- a/packages/reactive-element/src/decorators/query.ts
+++ b/packages/reactive-element/src/decorators/query.ts
@@ -24,8 +24,6 @@ import {decorateProperty} from './base.js';
  *
  * See: https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector
  *
- * @example
- *
  * ```ts
  * class MyElement {
  *   @query('#first')


### PR DESCRIPTION
Issue: https://github.com/lit/lit.dev/issues/434

### Context

Lit.dev uses TypeDoc to generate documentation. While cleaning up the documentation in https://github.com/lit/lit/pull/2050 I noticed a few examples are annotated with `@example`. Unfortunately this attribute isn't understood by TypeDoc, and their documentation recommends using code blocks: https://typedoc.org/guides/doccomments/#code-blocks

Thus this PR removes the `@example` annotation which unifies our documentation to only use code fences. The vs code hover experience remains the same, but now the documentation appears on the lit.dev API pages where it was previously not rendered.

### Impact

Examples appear on lit.dev and get indexed in the lit.dev search. VS code example hover experience remains the same.

### Before and after screenshots:

Can be compared using the temporary lit.dev link which references this change ([lit.dev bump API docs](https://github.com/lit/lit.dev/pull/440)): https://pr440-247e8ac---lit-dev-5ftespv5na-uc.a.run.app/

(Left half is currently on production, right half is using test url).

#### ref directive documentation:

![Screen Shot 2021-08-17 at 4 30 29 PM](https://user-images.githubusercontent.com/15080861/129813772-98fb6de9-295f-4c2c-95fe-0fd0a9735f37.png)

#### queryAll directive documentation:

![Screen Shot 2021-08-17 at 4 33 08 PM](https://user-images.githubusercontent.com/15080861/129813913-3f5acee1-29e7-4743-abdc-0bbb07248fc6.png)

