### PR TITLE
[lit-html, lit-element] Add initialIsConnected to RenderOptions. Fixes #2051

### DIFF
--- a/packages/lit-element/src/lit-element.ts
+++ b/packages/lit-element/src/lit-element.ts
@@ -134,6 +134,7 @@ export class LitElement extends ReactiveElement {
    * @category lifecycle
    */
   connectedCallback() {
+    this.renderOptions.initialIsConnected = true;
     super.connectedCallback();
     this.__childPart?.setConnected(true);
   }
@@ -142,6 +143,7 @@ export class LitElement extends ReactiveElement {
    * @category lifecycle
    */
   disconnectedCallback() {
+    this.renderOptions.initialIsConnected = false;
     super.disconnectedCallback();
     this.__childPart?.setConnected(false);
   }

--- a/packages/lit-element/src/test/lit-element_test.ts
+++ b/packages/lit-element/src/test/lit-element_test.ts
@@ -515,17 +515,37 @@ import {createRef, ref} from 'lit-html/directives/ref.js';
         ]);
       });
 
-      // TODO(kschaaf): render does not currently support rendering to an
-      // initially disconnected ChildPart (https://github.com/lit/lit/issues/2051)
-      test.skip('directives render with isConnected: false if first render is while element is disconnected', async () => {
+      test('directives render with isConnected: false if first render is while element is disconnected', async () => {
         container.appendChild(host);
         container.remove();
         await nextFrame();
         assertRendering(host);
+        // Host directives render in an initially disconnected state.
+        // Note that child directives didn't render because by the time the
+        // host render happened, the child was not connected and is still
+        // pending
         assert.deepEqual(log, [
           'render-host-attr-false',
           'render-host-prop-false',
           'render-host-node-false',
+        ]);
+        log.length = 0;
+        document.body.appendChild(container);
+        assertRendering(host);
+        // Directive reconnection happens synchronous to connectedCallback
+        assert.deepEqual(log, [
+          'reconnect-host-attr',
+          'reconnect-host-prop',
+          'reconnect-host-node',
+        ]);
+        log.length = 0;
+        // The initial render of the child happens a microtask after the host
+        // reconnects, at which point its directives run in the connected state
+        await nextFrame();
+        assert.deepEqual(log, [
+          'render-child-attr-true',
+          'render-child-prop-true',
+          'render-child-node-true',
         ]);
       });
     });


### PR DESCRIPTION
Adds the ability to set the initial connected state for the top-level part being rendered. The `part.setConnected()` method must be used subsequent to initial render to change the connected state of the part. Set to `false` if the initial render occurs in a disconnected tree and `AsyncDirective`s should see `isConnected === false` for their initial render.

Updates `LitElement` to set this flag in `connected`/`disconnectedCallback`. I went with just adding it into the `renderOptions` bag at the connection edges, rather than tracking connection state via a separate flag and assigning it in every render, since the edges happen less frequently.

This change ticks up the lit-html size by about ~20 bytes. Code golf ideas appreciated. The name is unfortunately long, but couldn't come up with something significantly shorter and still meaningful.

```
lit-html.js                     7.56 KB   7.56 KB   3.14 KB   2.86 KB   
lit-html.js                     7.63 KB   7.63 KB   3.16 KB   2.88 KB   
```

Fixes #2051