### PR TITLE
[monorepo] Add changeset to checks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,6 +3,21 @@ name: Tests
 on: [push, pull_request]
 
 jobs:
+
+  changeset:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 14
+
+      - run: npm ci
+
+      - run: npm run changeset status -- --since=main
+
   lint:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,8 @@ jobs:
         with:
           node-version: 14
 
+      - run: git fetch origin main:main
+
       - run: npm ci
 
       - run: npm run changeset status -- --since=main

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,12 +9,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-node@v1
         with:
           node-version: 14
+      
+      - run: git checkout main
 
-      - run: git fetch origin main:main
+      - run: git checkout ${{ github.ref }}
 
       - run: npm ci
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
       
       - run: git checkout main
 
-      - run: git checkout ${{ github.ref }}
+      - run: git checkout ${{ github.sha }}
 
       - run: npm ci
 

--- a/packages/lit-html/README.md
+++ b/packages/lit-html/README.md
@@ -1,7 +1,5 @@
 # lit-html 2.0 Release Candidate
 
-Test should cause changeset error
-
 Efficient, Expressive, Extensible HTML templates in JavaScript
 
 [![Build Status](https://github.com/lit/lit/workflows/Tests/badge.svg)](https://github.com/lit/lit/actions?query=workflow%3ATests)

--- a/packages/lit-html/README.md
+++ b/packages/lit-html/README.md
@@ -1,5 +1,7 @@
 # lit-html 2.0 Release Candidate
 
+Test should cause changeset error
+
 Efficient, Expressive, Extensible HTML templates in JavaScript
 
 [![Build Status](https://github.com/lit/lit/workflows/Tests/badge.svg)](https://github.com/lit/lit/actions?query=workflow%3ATests)


### PR DESCRIPTION
Adds enforcing that all PR's need changesets, to streamline releases.