### PR TITLE
@query and @queryAll return null or [] before first update

### DIFF
--- a/.changeset/twelve-moons-reply.md
+++ b/.changeset/twelve-moons-reply.md
@@ -1,0 +1,5 @@
+---
+'@lit/reactive-element': patch
+---
+
+Fixes #2062. To match Lit1 behavior, the @query decorator returns null (rather than undefined) if a decorated property is accessed before first update. Likewise, a @queryAll decorated property returns [] rather than undefined.

--- a/packages/reactive-element/src/decorators/query-all.ts
+++ b/packages/reactive-element/src/decorators/query-all.ts
@@ -43,7 +43,7 @@ export function queryAll(selector: string) {
   return decorateProperty({
     descriptor: (_name: PropertyKey) => ({
       get(this: ReactiveElement) {
-        return this.renderRoot?.querySelectorAll(selector);
+        return this.renderRoot?.querySelectorAll(selector) ?? [];
       },
       enumerable: true,
       configurable: true,

--- a/packages/reactive-element/src/decorators/query.ts
+++ b/packages/reactive-element/src/decorators/query.ts
@@ -61,13 +61,11 @@ export function query(selector: string, cache?: boolean) {
           ) {
             (this as unknown as {[key: string]: Element | null})[
               key as string
-            ] = this.renderRoot?.querySelector(selector);
+            ] = this.renderRoot?.querySelector(selector) ?? null;
           }
-          return (
-            (this as unknown as {[key: string]: Element | null})[
-              key as string
-            ] ?? null
-          );
+          return (this as unknown as {[key: string]: Element | null})[
+            key as string
+          ];
         };
       }
       return descriptor;

--- a/packages/reactive-element/src/decorators/query.ts
+++ b/packages/reactive-element/src/decorators/query.ts
@@ -46,7 +46,7 @@ export function query(selector: string, cache?: boolean) {
     descriptor: (name: PropertyKey) => {
       const descriptor = {
         get(this: ReactiveElement) {
-          return this.renderRoot?.querySelector(selector);
+          return this.renderRoot?.querySelector(selector) ?? null;
         },
         enumerable: true,
         configurable: true,
@@ -63,9 +63,11 @@ export function query(selector: string, cache?: boolean) {
               key as string
             ] = this.renderRoot?.querySelector(selector);
           }
-          return (this as unknown as {[key: string]: Element | null})[
-            key as string
-          ];
+          return (
+            (this as unknown as {[key: string]: Element | null})[
+              key as string
+            ] ?? null
+          );
         };
       }
       return descriptor;

--- a/packages/reactive-element/src/test/decorators/queryAll_test.ts
+++ b/packages/reactive-element/src/test/decorators/queryAll_test.ts
@@ -62,4 +62,10 @@ import {assert} from '@esm-bundle/chai';
       Array.from(el.renderRoot.querySelectorAll('span'))
     );
   });
+
+  test('returns empty array when no match and accessed before first update', () => {
+    const notYetUpdatedEl = new C();
+    assert.lengthOf(notYetUpdatedEl.spans, 0);
+    assert.deepEqual(Array.from(notYetUpdatedEl.spans), []);
+  });
 });

--- a/packages/reactive-element/src/test/decorators/query_test.ts
+++ b/packages/reactive-element/src/test/decorators/query_test.ts
@@ -90,14 +90,11 @@ import {assert} from '@esm-bundle/chai';
     assert.notEqual(el.span, el.renderRoot.querySelector('span'));
   });
 
-  test('returns cached value only after first update', async () => {
+  test('returns cached value when accessed before first update', async () => {
     const notYetUpdatedEl = new C();
     assert.equal(notYetUpdatedEl.divCached, null);
     container.appendChild(notYetUpdatedEl);
     await notYetUpdatedEl.updateComplete;
-    assert.equal(
-      notYetUpdatedEl.divCached,
-      notYetUpdatedEl.renderRoot.querySelector('#blah') as HTMLDivElement
-    );
+    assert.equal(notYetUpdatedEl.divCached, null);
   });
 });

--- a/packages/reactive-element/src/test/decorators/query_test.ts
+++ b/packages/reactive-element/src/test/decorators/query_test.ts
@@ -68,6 +68,11 @@ import {assert} from '@esm-bundle/chai';
     assert.isNull(el.span);
   });
 
+  test('returns null when no match and accessed before first update', () => {
+    const notYetUpdatedEl = new C();
+    assert.isNull(notYetUpdatedEl.span);
+  });
+
   test('returns cached value', async () => {
     el.condition = true;
     await el.updateComplete;
@@ -83,5 +88,16 @@ import {assert} from '@esm-bundle/chai';
     await el.updateComplete;
     assert.instanceOf(el.span, HTMLSpanElement);
     assert.notEqual(el.span, el.renderRoot.querySelector('span'));
+  });
+
+  test('returns cached value only after first update', async () => {
+    const notYetUpdatedEl = new C();
+    assert.equal(notYetUpdatedEl.divCached, null);
+    container.appendChild(notYetUpdatedEl);
+    await notYetUpdatedEl.updateComplete;
+    assert.equal(
+      notYetUpdatedEl.divCached,
+      notYetUpdatedEl.renderRoot.querySelector('#blah') as HTMLDivElement
+    );
   });
 });


### PR DESCRIPTION
Fixes #2062. To match Lit1 behavior, the `@query` decorator returns `null` (rather than `undefined`) if a decorated property is accessed before first update. Note, when the `cache` option is used, the first result is always cached and it must be either `null` or the found element. Likewise, a `@queryAll` decorated property returns `[]` rather than `undefined`.