### PR TITLE
[lit-html] Issue a DEV_MODE warning for setValue on a disconnected ChildPart

### DIFF
--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -1041,6 +1041,11 @@ class ChildPart implements Disconnectable {
   }
 
   _$setValue(value: unknown, directiveParent: DirectiveParent = this): void {
+    if (DEV_MODE && this.parentNode === null) {
+      throw new Error(
+        `This \`ChildPart\` has no \`parentNode\` and therefore cannot accept the value of ${value}. This likely means the element containing the part was manipulated in an unsupported way outside of Lit's control such that the part's marker nodes were ejected from DOM. For example, setting the element's \`innerHTML\` or \`textContent\` can do this.`
+      );
+    }
     value = resolveDirective(this, value, directiveParent);
     if (isPrimitive(value)) {
       // Non-rendering child values. It's important that these do not render

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -1043,7 +1043,7 @@ class ChildPart implements Disconnectable {
   _$setValue(value: unknown, directiveParent: DirectiveParent = this): void {
     if (DEV_MODE && this.parentNode === null) {
       throw new Error(
-        `This \`ChildPart\` has no \`parentNode\` and therefore cannot accept the value of ${value}. This likely means the element containing the part was manipulated in an unsupported way outside of Lit's control such that the part's marker nodes were ejected from DOM. For example, setting the element's \`innerHTML\` or \`textContent\` can do this.`
+        `This \`ChildPart\` has no \`parentNode\` and therefore cannot accept a value. This likely means the element containing the part was manipulated in an unsupported way outside of Lit's control such that the part's marker nodes were ejected from DOM. For example, setting the element's \`innerHTML\` or \`textContent\` can do this.`
       );
     }
     value = resolveDirective(this, value, directiveParent);

--- a/packages/lit-html/src/test/lit-html_test.ts
+++ b/packages/lit-html/src/test/lit-html_test.ts
@@ -1360,10 +1360,11 @@ suite('lit-html', () => {
       const text = container.querySelector('div')!;
       assert.equal(text.textContent, 'aaa');
 
-      // Set textContent manually. Since lit-html doesn't dirty check against
-      // actual DOM, but again previous part values, this modification should
-      // persist through the next render with the same value.
-      text.textContent = 'bbb';
+      // Set textContent manually (without disturbing the part marker node).
+      // Since lit-html doesn't dirty check against actual DOM, but again
+      // previous part values, this modification should persist through the
+      // next render with the same value.
+      text.lastChild!.textContent = 'bbb';
       assert.equal(text.textContent, 'bbb');
       assertContent('<div>bbb</div>');
 


### PR DESCRIPTION
Issues a DEV_MODE warning if a ChildPart cannot accept values because its marker nodes have been ejected from the part's `parentNode`.

Fixes #2063