### PR TITLE
[all] Cleanup obsolete TODOs

### DIFF
--- a/.changeset/ten-jeans-hug.md
+++ b/.changeset/ten-jeans-hug.md
@@ -1,0 +1,8 @@
+---
+'lit': patch
+'lit-element': patch
+'lit-html': patch
+'@lit/reactive-element': patch
+---
+
+(Cleanup) Removed obsolete TODOs from codebase

--- a/packages/lit-element/src/lit-element.ts
+++ b/packages/lit-element/src/lit-element.ts
@@ -121,9 +121,6 @@ export class LitElement extends ReactiveElement {
     this.__childPart = render(value, this.renderRoot, this.renderOptions);
   }
 
-  // TODO(kschaaf): Consider debouncing directive disconnection so element moves
-  // do not thrash directive callbacks
-  // https://github.com/lit/lit/issues/1457
   /**
    * @category lifecycle
    */

--- a/packages/lit-element/src/test/lit-element_test.ts
+++ b/packages/lit-element/src/test/lit-element_test.ts
@@ -243,7 +243,7 @@ import {createRef, ref} from 'lit-html/directives/ref.js';
   });
 
   test('exceptions in `render` throw but do not prevent further updates', async () => {
-    // TODO(sorvell): console errors produced by wtr and upset it.
+    // console errors produced by wtr upset it, so no-op console.error
     const consoleError = console.error;
     console.error = () => {};
     let shouldThrow = false;
@@ -277,7 +277,7 @@ import {createRef, ref} from 'lit-html/directives/ref.js';
     assert.equal(a.shadowRoot!.textContent, '5');
     shouldThrow = false;
     a.foo = 20;
-    // TODO(sorvell): Make sure to wait beyond error timing or wtr is sad.
+    // Make sure to wait beyond error timing or wtr is sad.
     await new Promise((r) => setTimeout(r));
     assert.equal(a.foo, 20);
     assert.equal(a.shadowRoot!.textContent, '20');

--- a/packages/lit-element/src/test/polyfill-support/lit-element-ce-sd-noPatch_test.html
+++ b/packages/lit-element/src/test/polyfill-support/lit-element-ce-sd-noPatch_test.html
@@ -27,7 +27,7 @@
 
   <body>
     <script type="module">
-      // TODO(sorvell): node resolution doesn't seem to be working here.
+      // node resolution doesn't seem to be working here.
       import {
         mocha,
         sessionFinished,

--- a/packages/lit-element/src/test/polyfill-support/lit-element-sd-ce-cp_test.html
+++ b/packages/lit-element/src/test/polyfill-support/lit-element-sd-ce-cp_test.html
@@ -17,7 +17,7 @@
 
   <body>
     <script type="module">
-      // TODO(sorvell): node resolution doesn't seem to be working here.
+      // node resolution doesn't seem to be working here.
       import {
         mocha,
         sessionFinished,

--- a/packages/lit-element/src/test/polyfill-support/lit-element-sd-ce_test.html
+++ b/packages/lit-element/src/test/polyfill-support/lit-element-sd-ce_test.html
@@ -14,7 +14,7 @@
 
   <body>
     <script type="module">
-      // TODO(sorvell): node resolution doesn't seem to be working here.
+      // node resolution doesn't seem to be working here.
       import {
         mocha,
         sessionFinished,

--- a/packages/lit-element/src/test/polyfill-support/lit-element-sd_test.html
+++ b/packages/lit-element/src/test/polyfill-support/lit-element-sd_test.html
@@ -12,7 +12,7 @@
 
   <body>
     <script type="module">
-      // TODO(sorvell): node resolution doesn't seem to be working here.
+      // node resolution doesn't seem to be working here.
       import {
         mocha,
         sessionFinished,

--- a/packages/lit-element/src/test/polyfill-support/lit-element_test.html
+++ b/packages/lit-element/src/test/polyfill-support/lit-element_test.html
@@ -9,7 +9,7 @@
 
   <body>
     <script type="module">
-      // TODO(sorvell): node resolution doesn't seem to be working here.
+      // node resolution doesn't seem to be working here.
       import {
         mocha,
         sessionFinished,

--- a/packages/lit-html/src/directives/live.ts
+++ b/packages/lit-html/src/directives/live.ts
@@ -44,9 +44,6 @@ class LiveDirective extends Directive {
     const element = part.element;
     const name = part.name;
 
-    // TODO (justinfagnani): This is essentially implementing a getLiveValue()
-    // method for each part type. Should that be moved into the AttributePart
-    // interface?
     if (part.type === PartType.PROPERTY) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       if (value === (element as any)[name]) {

--- a/packages/lit-html/src/directives/repeat.ts
+++ b/packages/lit-html/src/directives/repeat.ts
@@ -85,8 +85,8 @@ class RepeatDirective extends Directive {
       ItemTemplate<T>
     ]
   ) {
-    // Old part & key lists are retrieved from the last update
-    // TODO: deal with directive being swapped out?
+    // Old part & key lists are retrieved from the last update (which may
+    // be primed by hydration)
     const oldParts = getCommittedValue(
       containerPart
     ) as Array<ChildPart | null>;
@@ -304,7 +304,7 @@ class RepeatDirective extends Directive {
     //   remaining clauses is is just a simple guess at which cases
     //   will be most common.
     //
-    // * TODO(kschaaf) Note, we could calculate the longest
+    // * Note, we could calculate the longest
     //   increasing subsequence (LIS) of old items in new position,
     //   and only move those not in the LIS set. However that costs
     //   O(nlogn) time and adds a bit more code, and only helps

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -241,10 +241,6 @@ const COMMENT_PART = 7;
 export type TemplateResult<T extends ResultType = ResultType> = {
   // This property needs to remain unminified.
   ['_$litType$']: T;
-  // TODO (justinfagnani): consider shorter names, like `s` and `v`. This is a
-  // semi-public API though. We can't just let Terser rename them for us,
-  // because we need TemplateResults to work between compatible versions of
-  // lit-html.
   strings: TemplateStringsArray;
   values: unknown[];
 };
@@ -706,7 +702,8 @@ class Template {
             // Generate a new text node for each literal section
             // These nodes are also used as the markers for node parts
             // We can't use empty text nodes as markers because they're
-            // normalized in some browsers (TODO: check)
+            // normalized when cloning in IE (could simplify when
+            // IE is no longer supported)
             for (let i = 0; i < lastIndex; i++) {
               (node as Element).append(strings[i], createMarker());
               // Walk past the marker node we just added
@@ -728,8 +725,6 @@ class Template {
           while ((i = (node as Comment).data.indexOf(marker, i + 1)) !== -1) {
             // Comment node has a binding marker inside, make an inactive part
             // The binding won't work, but subsequent bindings will
-            // TODO (justinfagnani): consider whether it's even worth it to
-            // make bindings in comments work
             parts.push({type: COMMENT_PART, index: nodeIndex});
             // Move to the end of the match
             i += marker.length - 1;
@@ -1551,8 +1546,6 @@ class EventPart extends AttributePart {
 
   handleEvent(event: Event) {
     if (typeof this._$committedValue === 'function') {
-      // TODO (justinfagnani): do we need to default to this.element?
-      // It'll always be the same as `e.currentTarget`.
       this._$committedValue.call(this.options?.host ?? this.element, event);
     } else {
       (this._$committedValue as EventListenerObject).handleEvent(event);

--- a/packages/lit-html/src/test/directives/template-content_test.ts
+++ b/packages/lit-html/src/test/directives/template-content_test.ts
@@ -59,10 +59,7 @@ suite('templateContent', () => {
     );
   });
 
-  // TODO (justinfagnani): lit-html core has a bug/limitiation around swapping
-  // a directive with a non-directive.
-  // See https://github.com/lit/lit/issues/1286
-  test.skip('re-renders a template over a non-templateContent value', () => {
+  test('re-renders a template over a non-templateContent value', () => {
     const go = (v: unknown) => render(html`<div>${v}</div>`, container);
     go(templateContent(template));
     assert.equal(

--- a/packages/lit-html/src/test/polyfill-support/lit-html-apply-force-polyfill_test.html
+++ b/packages/lit-html/src/test/polyfill-support/lit-html-apply-force-polyfill_test.html
@@ -18,7 +18,7 @@
 
   <body>
     <script type="module">
-      // TODO(sorvell): node resolution doesn't seem to be working here.
+      // node resolution doesn't seem to be working here.
       import {
         mocha,
         sessionFinished,

--- a/packages/lit-html/src/test/polyfill-support/lit-html-apply_test.html
+++ b/packages/lit-html/src/test/polyfill-support/lit-html-apply_test.html
@@ -8,7 +8,7 @@
 
   <body>
     <script type="module">
-      // TODO(sorvell): node resolution doesn't seem to be working here.
+      // node resolution doesn't seem to be working here.
       import {
         mocha,
         sessionFinished,

--- a/packages/lit-html/src/test/polyfill-support/lit-html-no-wc_test.html
+++ b/packages/lit-html/src/test/polyfill-support/lit-html-no-wc_test.html
@@ -20,7 +20,7 @@
 
   <body>
     <script type="module">
-      // TODO(sorvell): node resolution doesn't seem to be working here.
+      // node resolution doesn't seem to be working here.
       import {
         mocha,
         sessionFinished,

--- a/packages/lit-html/src/test/polyfill-support/lit-html-noPatch_test.html
+++ b/packages/lit-html/src/test/polyfill-support/lit-html-noPatch_test.html
@@ -27,7 +27,7 @@
 
   <body>
     <script type="module">
-      // TODO(sorvell): node resolution doesn't seem to be working here.
+      // node resolution doesn't seem to be working here.
       import {
         mocha,
         sessionFinished,

--- a/packages/lit-html/src/test/polyfill-support/lit-html-scoping-shim_test.html
+++ b/packages/lit-html/src/test/polyfill-support/lit-html-scoping-shim_test.html
@@ -15,7 +15,7 @@
 
   <body>
     <script type="module">
-      // TODO(sorvell): node resolution doesn't seem to be working here.
+      // node resolution doesn't seem to be working here.
       import {
         mocha,
         sessionFinished,

--- a/packages/lit-html/src/test/polyfill-support/lit-html_test.html
+++ b/packages/lit-html/src/test/polyfill-support/lit-html_test.html
@@ -14,7 +14,7 @@
 
   <body>
     <script type="module">
-      // TODO(sorvell): node resolution doesn't seem to be working here.
+      // node resolution doesn't seem to be working here.
       import {
         mocha,
         sessionFinished,

--- a/packages/lit/src/test/lit-element-bundle_test.html
+++ b/packages/lit/src/test/lit-element-bundle_test.html
@@ -10,7 +10,7 @@
 
   <body>
     <script type="module">
-      // TODO(sorvell): node resolution doesn't seem to be working here.
+      // node resolution doesn't seem to be working here.
       import {
         mocha,
         sessionFinished,

--- a/packages/reactive-element/src/reactive-element.ts
+++ b/packages/reactive-element/src/reactive-element.ts
@@ -647,7 +647,7 @@ export abstract class ReactiveElement
     const elementStyles = [];
     if (Array.isArray(styles)) {
       // Dedupe the flattened array in reverse order to preserve the last items.
-      // TODO(sorvell): casting to Array<unknown> works around TS error that
+      // Casting to Array<unknown> works around TS error that
       // appears to come from trying to flatten a type CSSResultArray.
       const set = new Set((styles as Array<unknown>).flat(Infinity).reverse());
       // Then preserve original order by adding the set items in reverse order.

--- a/packages/reactive-element/src/test/polyfill-support/reactive-element-ce-sd-noPatch_test.html
+++ b/packages/reactive-element/src/test/polyfill-support/reactive-element-ce-sd-noPatch_test.html
@@ -27,7 +27,7 @@
 
   <body>
     <script type="module">
-      // TODO(sorvell): node resolution doesn't seem to be working here.
+      // node resolution doesn't seem to be working here.
       import {
         mocha,
         sessionFinished,

--- a/packages/reactive-element/src/test/polyfill-support/reactive-element-sd-ce-cp_test.html
+++ b/packages/reactive-element/src/test/polyfill-support/reactive-element-sd-ce-cp_test.html
@@ -17,7 +17,7 @@
 
   <body>
     <script type="module">
-      // TODO(sorvell): node resolution doesn't seem to be working here.
+      // node resolution doesn't seem to be working here.
       import {
         mocha,
         sessionFinished,

--- a/packages/reactive-element/src/test/polyfill-support/reactive-element-sd-ce_test.html
+++ b/packages/reactive-element/src/test/polyfill-support/reactive-element-sd-ce_test.html
@@ -14,7 +14,7 @@
 
   <body>
     <script type="module">
-      // TODO(sorvell): node resolution doesn't seem to be working here.
+      // node resolution doesn't seem to be working here.
       import {
         mocha,
         sessionFinished,

--- a/packages/reactive-element/src/test/polyfill-support/reactive-element-sd_test.html
+++ b/packages/reactive-element/src/test/polyfill-support/reactive-element-sd_test.html
@@ -12,7 +12,7 @@
 
   <body>
     <script type="module">
-      // TODO(sorvell): node resolution doesn't seem to be working here.
+      // node resolution doesn't seem to be working here.
       import {
         mocha,
         sessionFinished,

--- a/packages/reactive-element/src/test/polyfill-support/reactive-element_test.html
+++ b/packages/reactive-element/src/test/polyfill-support/reactive-element_test.html
@@ -9,7 +9,7 @@
 
   <body>
     <script type="module">
-      // TODO(sorvell): node resolution doesn't seem to be working here.
+      // node resolution doesn't seem to be working here.
       import {
         mocha,
         sessionFinished,


### PR DESCRIPTION
In preparation for Lit 2 GA release, this PR cleans up old TODOs after an IRL scrub of them. 

The TODOs remove here were either things that are no longer applicable (i.e. bugs that were fixed), notes that should just be comments (notes to reader, but do not require follow-up action), or ideas we decided against doing/changing.