### PR TITLE
[lit-html] Add missing tests to close out TODOs in code

### DIFF
--- a/.changeset/clever-rockets-care.md
+++ b/.changeset/clever-rockets-care.md
@@ -1,0 +1,5 @@
+---
+'lit-html': patch
+---
+
+(Cleanup) Added missing tests to close out TODOs in the code.

--- a/packages/lit-html/src/directives/unsafe-html.ts
+++ b/packages/lit-html/src/directives/unsafe-html.ts
@@ -28,7 +28,6 @@ export class UnsafeHTMLDirective extends Directive {
   }
 
   render(value: string | typeof nothing | typeof noChange) {
-    // TODO: add tests for nothing and noChange
     if (value === nothing) {
       this._templateResult = undefined;
       return (this._value = value);

--- a/packages/lit-html/src/test/directives/unsafe-html_test.ts
+++ b/packages/lit-html/src/test/directives/unsafe-html_test.ts
@@ -5,7 +5,7 @@
  */
 
 import {unsafeHTML} from '../../directives/unsafe-html.js';
-import {render, html} from '../../lit-html.js';
+import {render, html, nothing, noChange} from '../../lit-html.js';
 import {stripExpressionMarkers} from '../test-utils/strip-markers.js';
 import {assert} from '@esm-bundle/chai';
 
@@ -24,6 +24,22 @@ suite('unsafeHTML directive', () => {
     assert.equal(
       stripExpressionMarkers(container.innerHTML),
       '<div>before<span>inner</span>after</div>'
+    );
+  });
+
+  test('renders nothing', () => {
+    render(html`<div>before${unsafeHTML(nothing)}after</div>`, container);
+    assert.equal(
+      stripExpressionMarkers(container.innerHTML),
+      '<div>beforeafter</div>'
+    );
+  });
+
+  test('renders noChange', () => {
+    render(html`<div>before${unsafeHTML(noChange)}after</div>`, container);
+    assert.equal(
+      stripExpressionMarkers(container.innerHTML),
+      '<div>beforeafter</div>'
     );
   });
 

--- a/packages/lit-html/src/test/directives/unsafe-svg_test.ts
+++ b/packages/lit-html/src/test/directives/unsafe-svg_test.ts
@@ -5,7 +5,7 @@
  */
 
 import {unsafeSVG} from '../../directives/unsafe-svg.js';
-import {render, html} from '../../lit-html.js';
+import {render, html, nothing, noChange} from '../../lit-html.js';
 import {stripExpressionMarkers} from '../test-utils/strip-markers.js';
 import {assert} from '@esm-bundle/chai';
 
@@ -31,6 +31,22 @@ suite('unsafeSVG', () => {
     ]);
     const lineElement = container.querySelector('line')!;
     assert.equal(lineElement.namespaceURI, 'http://www.w3.org/2000/svg');
+  });
+
+  test('renders nothing', () => {
+    render(html`<svg>before${unsafeSVG(nothing)}after</svg>`, container);
+    assert.equal(
+      stripExpressionMarkers(container.innerHTML),
+      '<svg>beforeafter</svg>'
+    );
+  });
+
+  test('renders noChange', () => {
+    render(html`<svg>before${unsafeSVG(noChange)}after</svg>`, container);
+    assert.equal(
+      stripExpressionMarkers(container.innerHTML),
+      '<svg>beforeafter</svg>'
+    );
   });
 
   test('dirty checks primitive values', () => {

--- a/packages/lit-html/src/test/lit-html_test.ts
+++ b/packages/lit-html/src/test/lit-html_test.ts
@@ -47,7 +47,6 @@ const DEV_MODE = render.setSanitizer != null;
  */
 const INTERNAL = litHtmlLib.INTERNAL === true;
 
-
 class FireEventDirective extends Directive {
   render() {
     return nothing;

--- a/packages/lit-html/src/test/lit-html_test.ts
+++ b/packages/lit-html/src/test/lit-html_test.ts
@@ -47,6 +47,22 @@ const DEV_MODE = render.setSanitizer != null;
  */
 const INTERNAL = litHtmlLib.INTERNAL === true;
 
+
+class FireEventDirective extends Directive {
+  render() {
+    return nothing;
+  }
+  update(part: AttributePart) {
+    part.element.dispatchEvent(
+      new CustomEvent('test-event', {
+        bubbles: true,
+      })
+    );
+    return nothing;
+  }
+}
+const fireEvent = directive(FireEventDirective);
+
 suite('lit-html', () => {
   let container: HTMLDivElement;
 
@@ -1849,27 +1865,24 @@ suite('lit-html', () => {
     });
 
     test('event listeners can see events fired in attribute directives', () => {
-      class FireEventDirective extends Directive {
-        render() {
-          return nothing;
-        }
-        // TODO (justinfagnani): make this work on SpreadPart
-        update(part: AttributePart) {
-          part.element.dispatchEvent(
-            new CustomEvent('test-event', {
-              bubbles: true,
-            })
-          );
-          return nothing;
-        }
-      }
-      const fireEvent = directive(FireEventDirective);
       let event = undefined;
       const listener = (e: Event) => {
         event = e;
       };
       render(
         html`<div @test-event=${listener} b=${fireEvent()}></div>`,
+        container
+      );
+      assert.isOk(event);
+    });
+
+    test('event listeners can see events fired in element directives', () => {
+      let event = undefined;
+      const listener = (e: Event) => {
+        event = e;
+      };
+      render(
+        html`<div @test-event=${listener} ${fireEvent()}></div>`,
         container
       );
       assert.isOk(event);


### PR DESCRIPTION
* Test that events fired from element-position bindings can be caught on an event listener on the part's element
* Test that `unsafeHTML` and `unsafeSVG` can accept `nothing` and `noChange` values