### PR TITLE
[ts-transformers] Return null or [] on query decorators before first update

### DIFF
--- a/packages/ts-transformers/README.md
+++ b/packages/ts-transformers/README.md
@@ -65,7 +65,7 @@ class MyElement extends LitElement {
   }
 
   get button() {
-    return this.renderRoot?.querySelector('#myButton');
+    return this.renderRoot?.querySelector('#myButton') ?? null;
   }
 
   constructor() {

--- a/packages/ts-transformers/src/idiomatic/query-all.ts
+++ b/packages/ts-transformers/src/idiomatic/query-all.ts
@@ -18,7 +18,7 @@ import type {MemberDecoratorVisitor} from '../visitor.js';
  * Into:
  *
  *   get inputs() {
- *     return this.renderRoot?.queryAll('.myInput');
+ *     return this.renderRoot?.queryAll('.myInput') ?? [];
  *   }
  */
 export class QueryAllVisitor implements MemberDecoratorVisitor {
@@ -68,18 +68,22 @@ export class QueryAllVisitor implements MemberDecoratorVisitor {
       f.createBlock(
         [
           f.createReturnStatement(
-            f.createCallChain(
-              f.createPropertyAccessChain(
-                f.createPropertyAccessExpression(
-                  f.createThis(),
-                  f.createIdentifier('renderRoot')
+            f.createBinaryExpression(
+              f.createCallChain(
+                f.createPropertyAccessChain(
+                  f.createPropertyAccessExpression(
+                    f.createThis(),
+                    f.createIdentifier('renderRoot')
+                  ),
+                  f.createToken(ts.SyntaxKind.QuestionDotToken),
+                  f.createIdentifier('querySelectorAll')
                 ),
-                f.createToken(ts.SyntaxKind.QuestionDotToken),
-                f.createIdentifier('querySelectorAll')
+                undefined,
+                undefined,
+                [f.createStringLiteral(selector)]
               ),
-              undefined,
-              undefined,
-              [f.createStringLiteral(selector)]
+              f.createToken(ts.SyntaxKind.QuestionQuestionToken),
+              f.createArrayLiteralExpression([], false)
             )
           ),
         ],

--- a/packages/ts-transformers/src/idiomatic/query-assigned-nodes.ts
+++ b/packages/ts-transformers/src/idiomatic/query-assigned-nodes.ts
@@ -20,7 +20,7 @@ import type {MemberDecoratorVisitor} from '../visitor.js';
  *   get listItems() {
  *     return this.renderRoot
  *       ?.querySelector('slot[name=list]')
- *       ?.assignedNodes();
+ *       ?.assignedNodes() ?? [];
  *   }
  */
 export class QueryAssignedNodesVisitor implements MemberDecoratorVisitor {
@@ -169,7 +169,15 @@ export class QueryAssignedNodesVisitor implements MemberDecoratorVisitor {
 
     // { return <returnExpression> }
     const getterBody = f.createBlock(
-      [f.createReturnStatement(returnExpression)],
+      [
+        f.createReturnStatement(
+          f.createBinaryExpression(
+            returnExpression,
+            f.createToken(ts.SyntaxKind.QuestionQuestionToken),
+            f.createArrayLiteralExpression([], false)
+          )
+        ),
+      ],
       true
     );
 

--- a/packages/ts-transformers/src/idiomatic/query.ts
+++ b/packages/ts-transformers/src/idiomatic/query.ts
@@ -25,7 +25,7 @@ import type {MemberDecoratorVisitor} from '../visitor.js';
  *   }
  *
  *   get span() {
- *     return this.__span ??= this.renderRoot?.querySelector('#myDiv');
+ *     return this.__span ??= this.renderRoot?.querySelector('#myDiv') ?? null;
  *   }
  */
 export class QueryVisitor implements MemberDecoratorVisitor {
@@ -67,18 +67,22 @@ export class QueryVisitor implements MemberDecoratorVisitor {
 
   private _createQueryGetter(name: string, selector: string, cache: boolean) {
     const f = this._factory;
-    const querySelectorCall = f.createCallChain(
-      f.createPropertyAccessChain(
-        f.createPropertyAccessExpression(
-          f.createThis(),
-          f.createIdentifier('renderRoot')
+    const querySelectorCall = f.createBinaryExpression(
+      f.createCallChain(
+        f.createPropertyAccessChain(
+          f.createPropertyAccessExpression(
+            f.createThis(),
+            f.createIdentifier('renderRoot')
+          ),
+          f.createToken(ts.SyntaxKind.QuestionDotToken),
+          f.createIdentifier('querySelector')
         ),
-        f.createToken(ts.SyntaxKind.QuestionDotToken),
-        f.createIdentifier('querySelector')
+        undefined,
+        undefined,
+        [f.createStringLiteral(selector)]
       ),
-      undefined,
-      undefined,
-      [f.createStringLiteral(selector)]
+      f.createToken(ts.SyntaxKind.QuestionQuestionToken),
+      f.createNull()
     );
     return f.createGetAccessorDeclaration(
       undefined,

--- a/packages/ts-transformers/src/lit-transformer.ts
+++ b/packages/ts-transformers/src/lit-transformer.ts
@@ -218,11 +218,16 @@ export class LitTransformer {
     const numBindingsAfter =
       (node.importClause?.namedBindings as ts.NamedImports).elements?.length ??
       0;
-    if (numBindingsBefore !== numBindingsAfter && numBindingsAfter === 0) {
-      // Remove the import altogether if we modified the import and there are
-      // none left. Note it's important we include the first part of this check,
-      // since otherwise we might remove no-binding imports from the original
-      // source (e.g. `import './my-custom-element.js'`).
+    if (
+      numBindingsAfter === 0 &&
+      numBindingsBefore !== numBindingsAfter &&
+      ts.isStringLiteral(node.moduleSpecifier) &&
+      isLitImport(node.moduleSpecifier.text)
+    ) {
+      // Remove the import altogether if there are no bindings left. But only if
+      // we acutally modified the import, and it's from an official Lit module.
+      // Otherwise we might remove imports that are still needed for their
+      // side-effects.
       return undefined;
     }
     return node;

--- a/packages/ts-transformers/src/tests/idiomatic-test.ts
+++ b/packages/ts-transformers/src/tests/idiomatic-test.ts
@@ -672,6 +672,27 @@ test('only remove imports that will be transformed', () => {
   checkTransform(input, expected);
 });
 
+test("don't remove existing no-binding import", () => {
+  const input = `
+  import {LitElement, customElement} from 'lit-element';
+  import './my-custom-element.js';
+
+  @customElement('my-element')
+  class MyElement extends LitElement {
+  }
+  `;
+
+  const expected = `
+  import {LitElement} from 'lit-element';
+  import './my-custom-element.js';
+
+  class MyElement extends LitElement {
+  }
+  customElements.define('my-element', MyElement);
+  `;
+  checkTransform(input, expected);
+});
+
 test('ignore non-lit class decorator', () => {
   const input = `
   import {LitElement} from 'lit';

--- a/packages/ts-transformers/src/tests/idiomatic-test.ts
+++ b/packages/ts-transformers/src/tests/idiomatic-test.ts
@@ -211,7 +211,7 @@ test('@query (non-caching)', () => {
 
   class MyElement extends LitElement {
     get div() {
-      return this.renderRoot?.querySelector('#myDiv');
+      return this.renderRoot?.querySelector('#myDiv') ?? null;
     }
   }
   `;
@@ -234,7 +234,7 @@ test('@query (caching)', () => {
 
   class MyElement extends LitElement {
     get span() {
-      return this.__span ??= this.renderRoot?.querySelector('#mySpan');
+      return this.__span ??= this.renderRoot?.querySelector('#mySpan') ?? null;
     }
   }
   `;
@@ -257,7 +257,7 @@ test('@queryAll', () => {
 
   class MyElement extends LitElement {
     get inputs() {
-      return this.renderRoot?.querySelectorAll('.myInput');
+      return this.renderRoot?.querySelectorAll('.myInput') ?? [];
     }
   }
   `;
@@ -306,7 +306,7 @@ test('@queryAssignedNodes (default slot)', () => {
     get listItems() {
       return this.renderRoot
         ?.querySelector('slot:not([name])')
-        ?.assignedNodes();
+        ?.assignedNodes() ?? [];
     }
   }
   `;
@@ -331,7 +331,7 @@ test('@queryAssignedNodes (with slot name)', () => {
     get listItems() {
       return this.renderRoot
         ?.querySelector('slot[name=list]')
-        ?.assignedNodes();
+        ?.assignedNodes() ?? [];
     }
   }
   `;
@@ -356,7 +356,7 @@ test('@queryAssignedNodes (with flatten)', () => {
     get listItems() {
       return this.renderRoot
         ?.querySelector('slot[name=list]')
-        ?.assignedNodes({flatten: true});
+        ?.assignedNodes({flatten: true}) ?? [];
     }
   }
   `;
@@ -385,7 +385,7 @@ test('@queryAssignedNodes (with selector)', () => {
         ?.filter((node) =>
           node.nodeType === Node.ELEMENT_NODE &&
             node.matches('.item')
-        );
+        ) ?? [];
     }
   }
   `;


### PR DESCRIPTION
Aligns transformer behavior to https://github.com/lit/lit/pull/2065 and https://github.com/lit/lit/pull/1980 by making the `@query`, `@queryAll`, and `@queryAssignedNodes` decorator return `null` / `[]` / `[]` respectively before first update, instead of `undefined`.

Also includes a fix where we were removing no-binding imports that already existed in the source. We only want to remove imports that we actually modified.