### PR TITLE
Fix ChildPart parentNode for top-level parts

### DIFF
--- a/.changeset/bright-keys-kick.md
+++ b/.changeset/bright-keys-kick.md
@@ -1,0 +1,5 @@
+---
+'lit-html': patch
+---
+
+Fix ChildPart parentNode for top-level parts to return the parentNode they _will_ be inserted into, rather than the DocumentFragment they were cloned into. Fixes #2032.

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -1021,6 +1021,9 @@ class ChildPart implements Disconnectable {
    */
   get parentNode(): Node {
     const parent = wrap(this._$startNode).parentNode!;
+    // If the `_$litParent$` function exists, that means this is an initial
+    // render for the part and the DOM is still in the cloned document fragment,
+    // so retrieve the part's actual parent node rather than the fragment
     const parentFn = (parent as DocumentFragmentWithParent)._$litParent$;
     return parentFn?.() ?? parent;
   }
@@ -1159,6 +1162,10 @@ class ChildPart implements Disconnectable {
     } else {
       const instance = new TemplateInstance(template as Template, this);
       const fragment = instance._clone(this.options);
+      // Put a function to retrieve the parentNode for this part on the fragment
+      // so that directives can see their to-be parentNode rather than the
+      // DocumentFragment during initial render, which occurs before the fragment
+      // is inserted into the part's spot in the DOM
       (fragment as DocumentFragmentWithParent)._$litParent$ = () =>
         this.parentNode;
       instance._update(values);

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -1023,7 +1023,7 @@ class ChildPart implements Disconnectable {
   get parentNode(): Node {
     let parentNode: Node = wrap(this._$startNode).parentNode!;
     const parent = this._$parent;
-    if (parent && parentNode.nodeType === 11 /* Node.DOCUMENT_FRAGMENT */) {
+    if (parent !== undefined && parentNode.nodeType === 11 /* Node.DOCUMENT_FRAGMENT */) {
       // If the parentNode is a DocumentFragment, it may be because the DOM is
       // still in the cloned fragment during initial render; if so, get the real
       // parentNode the part will be committed into by asking the parent.

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -1159,7 +1159,8 @@ class ChildPart implements Disconnectable {
     } else {
       const instance = new TemplateInstance(template as Template, this);
       const fragment = instance._clone(this.options);
-      (fragment as DocumentFragmentWithParent)._$litParent$ = () => this.parentNode;
+      (fragment as DocumentFragmentWithParent)._$litParent$ = () =>
+        this.parentNode;
       instance._update(values);
       this._commitNode(fragment);
       this._$committedValue = instance;

--- a/packages/lit-html/src/test/lit-html_test.ts
+++ b/packages/lit-html/src/test/lit-html_test.ts
@@ -20,7 +20,13 @@ import {
 } from '../lit-html.js';
 import * as litHtmlLib from '../lit-html.js';
 
-import {directive, Directive, PartType, PartInfo, DirectiveParameters} from '../directive.js';
+import {
+  directive,
+  Directive,
+  PartType,
+  PartInfo,
+  DirectiveParameters,
+} from '../directive.js';
 import {assert} from '@esm-bundle/chai';
 import {
   stripExpressionComments,
@@ -52,6 +58,7 @@ suite('lit-html', () => {
 
   setup(() => {
     container = document.createElement('div');
+    container.id = 'container';
   });
 
   const assertRender = (
@@ -1646,7 +1653,10 @@ suite('lit-html', () => {
           return nothing;
         }
 
-        override update(part: ChildPart, [parentId]: DirectiveParameters<this>) {
+        override update(
+          part: ChildPart,
+          [parentId]: DirectiveParameters<this>
+        ) {
           const {parentNode, startNode, endNode} = part;
 
           if (endNode !== null) {
@@ -1703,24 +1713,21 @@ suite('lit-html', () => {
       });
 
       test('directive parent is the logical DOM parent', () => {
-        const makeTemplate = (content1: unknown, content2: unknown, content3: unknown) =>
+        const makeTemplate = () =>
           html`
-            <div id="parent1">${content1}</div>
-            <div id="parent2">${content2}</div>
-            <div id="parent3">${content3}</div>
+            ${checkNodePropertiesBehavior('container')}
+            <div id="parent1">${checkNodePropertiesBehavior('parent1')}/div>
+            <div id="parent2">${html`x ${checkNodePropertiesBehavior(
+              'parent2'
+            )} x`}</div>
+            <div id="parent3">${html`x ${html`x ${checkNodePropertiesBehavior(
+              'parent3'
+            )} x`} x`}</div>
           `;
 
         // Render twice so that `update` is called.
-        render(makeTemplate(
-          checkNodePropertiesBehavior('parent1'), 
-          html`x ${checkNodePropertiesBehavior('parent2')} x`,
-          html`x ${html`x ${checkNodePropertiesBehavior('parent3')} x`} x`
-        ), container);
-        render(makeTemplate(
-          checkNodePropertiesBehavior('parent1'), 
-          html`x ${checkNodePropertiesBehavior('parent2')} x`,
-          html`x ${html`x ${checkNodePropertiesBehavior('parent3')} x`} x`
-        ), container);
+        render(makeTemplate(), container);
+        render(makeTemplate(), container);
       });
     });
 

--- a/packages/lit-html/src/test/lit-html_test.ts
+++ b/packages/lit-html/src/test/lit-html_test.ts
@@ -1736,6 +1736,16 @@ suite('lit-html', () => {
         await asyncCheckDiv;
         render(makeTemplate(), container);
       });
+
+      test(`part's parentNode is correct when rendered into a document fragment`, async () => {
+        const fragment = document.createDocumentFragment();
+        (fragment as unknown as {id: string}).id = 'fragment';
+        const makeTemplate = () => html`${checkPart('fragment')}`;
+
+        // Render twice so that `update` is called.
+        render(makeTemplate(), fragment);
+        render(makeTemplate(), fragment);
+      });
     });
 
     test('directives are stateful', () => {

--- a/rollup-common.js
+++ b/rollup-common.js
@@ -73,6 +73,7 @@ const reservedProperties = [
   '_$litPart$',
   '_$litElement$',
   '_$litStatic$',
+  '_$litParent$',
   '_$cssResult$',
 ];
 

--- a/rollup-common.js
+++ b/rollup-common.js
@@ -73,7 +73,6 @@ const reservedProperties = [
   '_$litPart$',
   '_$litElement$',
   '_$litStatic$',
-  '_$litParent$',
   '_$cssResult$',
 ];
 


### PR DESCRIPTION
When we update a ChildPart for the very first time, the DOM is still in the DocumentFragment cloned from the template. However, sine we know where the fragment will be inserted, we can associate this information with the fragment so that the `parentNode` getter can look there instead.

Fixes #2032 