### PR TITLE
[ts-transformers] Disable standard class fields in tests

### DIFF
--- a/packages/ts-transformers/src/tests/constructor-cleanup-test.ts
+++ b/packages/ts-transformers/src/tests/constructor-cleanup-test.ts
@@ -21,6 +21,9 @@ const cache = new CompilerHostCache();
 function checkTransform(inputTs: string, expectedJs: string) {
   const options = ts.getDefaultCompilerOptions();
   options.target = ts.ScriptTarget.ESNext;
+  // Don't emit standard class fields. They aren't compatible with Lit. Defaults
+  // to true when target = ESNext.
+  options.useDefineForClassFields = false;
   options.module = ts.ModuleKind.ESNext;
   // Don't automatically load typings from nodes_modules/@types, we're not using
   // them here, so it's a waste of time.
@@ -120,9 +123,9 @@ test('modified existing constructor is restored to original position', () => {
   const expected = `
     /* Class description */
     class MyClass {
-      a = 0;
       foo() { return 0; }
       constructor() {
+        this.a = 0;
         console.log(0);
       }
       static bar() { return 0; }
@@ -147,9 +150,9 @@ test('modified existing constructor was originally at the top', () => {
     /* Class description */
     class MyClass {
       constructor() {
+        this.a = 0;
         console.log(0);
       }
-      a = 0;
       foo() { return 0; }
       static bar() { return 0; }
     }
@@ -176,10 +179,13 @@ test('fully synthetic constructor moves below last static', () => {
     class MyClass {
       i1() { return 0; }
       static s1() { return 0; }
-      a = 0;
       static s2() { return 0; }
       i2() { return 0; }
       static s3() { return 0; }
+      //__BLANK_LINE_PLACEHOLDER_G1JVXUEBNCL6YN5NFE13MD1PT3H9OIHB__
+      constructor() {
+        this.a = 0;
+      }
       i3() { return 0; }
       i4() { return 0; }
     }
@@ -201,8 +207,10 @@ test('fully synthetic constructor stays at top if there are no statics', () => {
   const expected = `
     /* Class description */
     class MyClass {
+      constructor() {
+        this.a = 0;
+      }
       i1() { return 0; }
-      a = 0;
       i2() { return 0; }
       i3() { return 0; }
       i4() { return 0; }

--- a/packages/ts-transformers/src/tests/idiomatic-test.ts
+++ b/packages/ts-transformers/src/tests/idiomatic-test.ts
@@ -25,6 +25,9 @@ const cache = new CompilerHostCache();
 function checkTransform(inputTs: string, expectedJs: string) {
   const options = ts.getDefaultCompilerOptions();
   options.target = ts.ScriptTarget.ESNext;
+  // Don't emit standard class fields. They aren't compatible with Lit. Defaults
+  // to true when target = ESNext.
+  options.useDefineForClassFields = false;
   options.module = ts.ModuleKind.ESNext;
   options.moduleResolution = ts.ModuleResolutionKind.NodeJs;
   options.importHelpers = true;
@@ -116,8 +119,12 @@ test('@property', () => {
         num: {type: Number, attribute: false},
       };
     }
-    str = "foo";
-    num = 42;
+
+    constructor() {
+      super(...arguments);
+      this.str = "foo";
+      this.num = 42;
+    }
   }
   `;
   checkTransform(input, expected);
@@ -154,10 +161,10 @@ test('@property (merge with existing static properties)', () => {
         num: {type: Number},
       };
     }
-    num = 42;
 
     constructor() {
       super();
+      this.num = 42;
     }
   }
   `;
@@ -188,8 +195,12 @@ test('@state', () => {
         num2: {hasChanged: () => false, state: true},
       };
     }
-    num = 42;
-    num2 = 24;
+
+    constructor() {
+      super(...arguments);
+      this.num = 42;
+      this.num2 = 24;
+    }
   }
   `;
   checkTransform(input, expected);
@@ -731,9 +742,7 @@ test('ignore non-lit method decorator', () => {
   import {LitElement} from 'lit';
   import {property} from './not-lit.js';
 
-  class MyElement extends LitElement {
-    foo;
-  };
+  class MyElement extends LitElement {};
   __decorate([property()], MyElement.prototype, "foo", void 0);
   `;
   checkTransform(input, expected);
@@ -783,8 +792,12 @@ test('aliased property decorator import', () => {
         num: {type: Number, attribute: false},
       };
     }
-    str = "foo";
-    num = 42;
+
+    constructor() {
+      super(...arguments);
+      this.str = "foo";
+      this.num = 42;
+    }
   }
   `;
   checkTransform(input, expected);


### PR DESCRIPTION
This undoes the change to the ts-transformer tests in https://github.com/lit/lit/pull/2060 that enabled standard class field emit, because they are incompatible with Lit. TypeScript 3.5.X changed the default for `useDefineForClassFields` from `false` to `true` when `target: ESNext`.