### PR TITLE
[ts-transformers] Rewrite static styles and properties class fields as getters

### DIFF
--- a/packages/ts-transformers/src/constructor-cleanup.ts
+++ b/packages/ts-transformers/src/constructor-cleanup.ts
@@ -6,6 +6,7 @@
 
 import * as ts from 'typescript';
 import {BLANK_LINE_PLACEHOLDER_COMMENT} from './preserve-blank-lines';
+import {isStatic} from './util';
 
 /**
  * TypeScript transformer which improves the readability of the default
@@ -88,11 +89,7 @@ const cleanupClassConstructor = (
     // common style.
     newCtorIdx = 0;
     for (let i = class_.members.length - 1; i >= 0; i--) {
-      const isStatic =
-        class_.members[i].modifiers?.find(
-          (modifier) => modifier.kind === ts.SyntaxKind.StaticKeyword
-        ) !== undefined;
-      if (isStatic) {
+      if (isStatic(class_.members[i])) {
         newCtorIdx = i;
         break;
       }

--- a/packages/ts-transformers/src/idiomatic.ts
+++ b/packages/ts-transformers/src/idiomatic.ts
@@ -16,6 +16,7 @@ import {QueryAsyncVisitor} from './idiomatic/query-async.js';
 import {QueryAssignedNodesVisitor} from './idiomatic/query-assigned-nodes.js';
 import {EventOptionsVisitor} from './idiomatic/event-options.js';
 import {StaticStylesVisitor} from './idiomatic/static-styles.js';
+import {StaticPropertiesVisitor} from './idiomatic/static-properties.js';
 
 /**
  * TypeScript transformer which transforms all Lit decorators to their idiomatic
@@ -71,6 +72,7 @@ export default function idiomaticLitDecoratorTransformer(
       new QueryAssignedNodesVisitor(context),
       new EventOptionsVisitor(context, program),
       new StaticStylesVisitor(context, program),
+      new StaticPropertiesVisitor(context, program),
     ]);
     return (file) => {
       return ts.visitNode(file, transformer.visitFile);

--- a/packages/ts-transformers/src/idiomatic.ts
+++ b/packages/ts-transformers/src/idiomatic.ts
@@ -15,6 +15,7 @@ import {QueryAllVisitor} from './idiomatic/query-all.js';
 import {QueryAsyncVisitor} from './idiomatic/query-async.js';
 import {QueryAssignedNodesVisitor} from './idiomatic/query-assigned-nodes.js';
 import {EventOptionsVisitor} from './idiomatic/event-options.js';
+import {StaticStylesVisitor} from './idiomatic/static-styles.js';
 
 /**
  * TypeScript transformer which transforms all Lit decorators to their idiomatic
@@ -69,6 +70,7 @@ export default function idiomaticLitDecoratorTransformer(
       new QueryAsyncVisitor(context),
       new QueryAssignedNodesVisitor(context),
       new EventOptionsVisitor(context, program),
+      new StaticStylesVisitor(context, program),
     ]);
     return (file) => {
       return ts.visitNode(file, transformer.visitFile);

--- a/packages/ts-transformers/src/idiomatic/static-properties.ts
+++ b/packages/ts-transformers/src/idiomatic/static-properties.ts
@@ -1,0 +1,70 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import * as ts from 'typescript';
+import {isStatic, extendsReactiveElement} from '../util.js';
+
+import type {LitFileContext} from '../lit-file-context.js';
+import type {GenericVisitor} from '../visitor.js';
+
+/**
+ * Transform:
+ *
+ *   static properties = {foo: {type: Number}};
+ *
+ * Into:
+ *
+ *   static get properties() {
+ *     return {foo: {type: Number}};
+ *   }
+ *
+ * This transform is useful because Lit is not compatible with standard class
+ * fields, so standard class field emit needs to be disabled
+ * (useDefineForClassFields: false). However, this means statics turn into
+ * `MyClass.foo = ...` assignments following the class declaration, which has
+ * poor readability compared to a getter.
+ */
+export class StaticPropertiesVisitor implements GenericVisitor {
+  readonly kind = 'generic';
+
+  private readonly _factory: ts.NodeFactory;
+  private readonly _program: ts.Program;
+
+  constructor({factory}: ts.TransformationContext, program: ts.Program) {
+    this._factory = factory;
+    this._program = program;
+  }
+
+  visit(_litFileContext: LitFileContext, node: ts.Node): ts.Node {
+    if (
+      !(
+        ts.isPropertyDeclaration(node) &&
+        isStatic(node) &&
+        node.name?.getText() === 'properties' &&
+        node.initializer !== undefined &&
+        ts.isClassDeclaration(node.parent) &&
+        extendsReactiveElement(node.parent, this._program.getTypeChecker())
+      )
+    ) {
+      return node;
+    }
+    return this._createPropertiesGetter(node.initializer);
+  }
+
+  private _createPropertiesGetter(
+    initializer: ts.Expression
+  ): ts.GetAccessorDeclaration {
+    const f = this._factory;
+    return f.createGetAccessorDeclaration(
+      undefined,
+      [f.createModifier(ts.SyntaxKind.StaticKeyword)],
+      f.createIdentifier('properties'),
+      [],
+      undefined,
+      f.createBlock([f.createReturnStatement(initializer)], true)
+    );
+  }
+}

--- a/packages/ts-transformers/src/idiomatic/static-styles.ts
+++ b/packages/ts-transformers/src/idiomatic/static-styles.ts
@@ -1,0 +1,70 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import * as ts from 'typescript';
+import {isStatic, extendsReactiveElement} from '../util.js';
+
+import type {LitFileContext} from '../lit-file-context.js';
+import type {GenericVisitor} from '../visitor.js';
+
+/**
+ * Transform:
+ *
+ *   static styles = css`p { color: red; }`
+ *
+ * Into:
+ *
+ *   static get styles() {
+ *     return css`p { color: red; }`;
+ *   }
+ *
+ * This transform is useful because Lit is not compatible with standard class
+ * fields, so standard class field emit needs to be disabled
+ * (useDefineForClassFields: false). However, this means statics turn into
+ * `MyClass.foo = ...` assignments following the class declaration, which has
+ * poor readability compared to a getter.
+ */
+export class StaticStylesVisitor implements GenericVisitor {
+  readonly kind = 'generic';
+
+  private readonly _factory: ts.NodeFactory;
+  private readonly _program: ts.Program;
+
+  constructor({factory}: ts.TransformationContext, program: ts.Program) {
+    this._factory = factory;
+    this._program = program;
+  }
+
+  visit(_litFileContext: LitFileContext, node: ts.Node): ts.Node {
+    if (
+      !(
+        ts.isPropertyDeclaration(node) &&
+        isStatic(node) &&
+        node.name?.getText() === 'styles' &&
+        node.initializer !== undefined &&
+        ts.isClassDeclaration(node.parent) &&
+        extendsReactiveElement(node.parent, this._program.getTypeChecker())
+      )
+    ) {
+      return node;
+    }
+    return this._createStylesGetter(node.initializer);
+  }
+
+  private _createStylesGetter(
+    initializer: ts.Expression
+  ): ts.GetAccessorDeclaration {
+    const f = this._factory;
+    return f.createGetAccessorDeclaration(
+      undefined,
+      [f.createModifier(ts.SyntaxKind.StaticKeyword)],
+      f.createIdentifier('styles'),
+      [],
+      undefined,
+      f.createBlock([f.createReturnStatement(initializer)], true)
+    );
+  }
+}

--- a/packages/ts-transformers/src/tests/constructor-cleanup-test.ts
+++ b/packages/ts-transformers/src/tests/constructor-cleanup-test.ts
@@ -21,6 +21,9 @@ const cache = new CompilerHostCache();
 function checkTransform(inputTs: string, expectedJs: string) {
   const options = ts.getDefaultCompilerOptions();
   options.target = ts.ScriptTarget.ESNext;
+  // Don't emit standard class fields. They aren't compatible with Lit. Defaults
+  // to true when target = ESNext.
+  options.useDefineForClassFields = false;
   options.module = ts.ModuleKind.ESNext;
   // Don't automatically load typings from nodes_modules/@types, we're not using
   // them here, so it's a waste of time.
@@ -120,9 +123,9 @@ test('modified existing constructor is restored to original position', () => {
   const expected = `
     /* Class description */
     class MyClass {
-      a = 0;
       foo() { return 0; }
       constructor() {
+        this.a = 0;
         console.log(0);
       }
       static bar() { return 0; }
@@ -147,9 +150,9 @@ test('modified existing constructor was originally at the top', () => {
     /* Class description */
     class MyClass {
       constructor() {
+        this.a = 0;
         console.log(0);
       }
-      a = 0;
       foo() { return 0; }
       static bar() { return 0; }
     }
@@ -176,10 +179,13 @@ test('fully synthetic constructor moves below last static', () => {
     class MyClass {
       i1() { return 0; }
       static s1() { return 0; }
-      a = 0;
       static s2() { return 0; }
       i2() { return 0; }
       static s3() { return 0; }
+      //__BLANK_LINE_PLACEHOLDER_G1JVXUEBNCL6YN5NFE13MD1PT3H9OIHB__
+      constructor() {
+        this.a = 0;
+      }
       i3() { return 0; }
       i4() { return 0; }
     }
@@ -201,8 +207,10 @@ test('fully synthetic constructor stays at top if there are no statics', () => {
   const expected = `
     /* Class description */
     class MyClass {
+      constructor() {
+        this.a = 0;
+      }
       i1() { return 0; }
-      a = 0;
       i2() { return 0; }
       i3() { return 0; }
       i4() { return 0; }

--- a/packages/ts-transformers/src/tests/idiomatic-test.ts
+++ b/packages/ts-transformers/src/tests/idiomatic-test.ts
@@ -25,6 +25,9 @@ const cache = new CompilerHostCache();
 function checkTransform(inputTs: string, expectedJs: string) {
   const options = ts.getDefaultCompilerOptions();
   options.target = ts.ScriptTarget.ESNext;
+  // Don't emit standard class fields. They aren't compatible with Lit. Defaults
+  // to true when target = ESNext.
+  options.useDefineForClassFields = false;
   options.module = ts.ModuleKind.ESNext;
   options.moduleResolution = ts.ModuleResolutionKind.NodeJs;
   options.importHelpers = true;
@@ -116,8 +119,12 @@ test('@property', () => {
         num: {type: Number, attribute: false},
       };
     }
-    str = "foo";
-    num = 42;
+
+    constructor() {
+      super(...arguments);
+      this.str = "foo";
+      this.num = 42;
+    }
   }
   `;
   checkTransform(input, expected);
@@ -154,10 +161,10 @@ test('@property (merge with existing static properties)', () => {
         num: {type: Number},
       };
     }
-    num = 42;
 
     constructor() {
       super();
+      this.num = 42;
     }
   }
   `;
@@ -188,8 +195,12 @@ test('@state', () => {
         num2: {hasChanged: () => false, state: true},
       };
     }
-    num = 42;
-    num2 = 24;
+
+    constructor() {
+      super(...arguments);
+      this.num = 42;
+      this.num2 = 24;
+    }
   }
   `;
   checkTransform(input, expected);
@@ -731,9 +742,7 @@ test('ignore non-lit method decorator', () => {
   import {LitElement} from 'lit';
   import {property} from './not-lit.js';
 
-  class MyElement extends LitElement {
-    foo;
-  };
+  class MyElement extends LitElement {};
   __decorate([property()], MyElement.prototype, "foo", void 0);
   `;
   checkTransform(input, expected);
@@ -783,8 +792,12 @@ test('aliased property decorator import', () => {
         num: {type: Number, attribute: false},
       };
     }
-    str = "foo";
-    num = 42;
+
+    constructor() {
+      super(...arguments);
+      this.str = "foo";
+      this.num = 42;
+    }
   }
   `;
   checkTransform(input, expected);

--- a/packages/ts-transformers/src/tests/idiomatic-test.ts
+++ b/packages/ts-transformers/src/tests/idiomatic-test.ts
@@ -803,4 +803,68 @@ test('aliased property decorator import', () => {
   checkTransform(input, expected);
 });
 
+test('static styles property declaration', () => {
+  const input = `
+  import {LitElement, css} from 'lit';
+
+  class MyElement extends LitElement {
+    static styles = css\`p { color: red; }\`;
+  }
+  `;
+
+  const expected = `
+  import {LitElement, css} from 'lit';
+
+  class MyElement extends LitElement {
+    static get styles() {
+      return css\`p { color: red; }\`;
+    }
+  }
+  `;
+  checkTransform(input, expected);
+});
+
+test('static styles declaration with aliased ReactiveElement', () => {
+  const input = `
+  import {css} from 'lit';
+  import {ReactiveElement as Potato} from 'lit';
+
+  class MyElement extends Potato {
+    static styles = css\`p { color: red; }\`;
+  }
+  `;
+
+  const expected = `
+  import {css} from 'lit';
+  import {ReactiveElement as Potato} from 'lit';
+
+  class MyElement extends Potato {
+    static get styles() {
+      return css\`p { color: red; }\`;
+    }
+  }
+  `;
+  checkTransform(input, expected);
+});
+
+test('ignore static styles on non-Lit class', () => {
+  const input = `
+  import {css} from 'lit';
+  import {ReactiveElement} from './not-lit.js';
+
+  class MyElement extends ReactiveElement {
+    static styles = css\`p { color: red; }\`;
+  }
+  `;
+
+  const expected = `
+  import {css} from 'lit';
+  import {ReactiveElement} from './not-lit.js';
+
+  class MyElement extends ReactiveElement {}
+  MyElement.styles = css\`p { color: red; }\`;
+  `;
+  checkTransform(input, expected);
+});
+
 test.run();

--- a/packages/ts-transformers/src/tests/idiomatic-test.ts
+++ b/packages/ts-transformers/src/tests/idiomatic-test.ts
@@ -906,4 +906,77 @@ test('ignore static properties on non-Lit class', () => {
   checkTransform(input, expected);
 });
 
+test('static styles and properties and multiple classes', () => {
+  // This test makes sure we have good coverage for the extendsReactiveElement
+  // caching logic.
+  const input = `
+  import {LitElement, ReactiveElement, css} from 'lit';
+  import {ReactiveElement as NotReactiveElement} from './not-lit.js';
+
+  class C1 extends ReactiveElement {
+    static styles = css\`p { color: red; }\`;
+    static properties = {foo: {type: Number}};
+  }
+
+  class C2 extends NotReactiveElement {
+    static styles = css\`p { color: red; }\`;
+    static properties = {foo: {type: Number}};
+  }
+
+  class C3 extends LitElement {
+    static styles = css\`p { color: red; }\`;
+    static properties = {foo: {type: Number}};
+  }
+
+  class C4 extends LitElement {}
+
+  class C5 extends C4 {
+    static styles = css\`p { color: red; }\`;
+    static properties = {foo: {type: Number}};
+  }
+
+  `;
+
+  const expected = `
+  import {LitElement, ReactiveElement, css} from 'lit';
+  import {ReactiveElement as NotReactiveElement} from './not-lit.js';
+
+  class C1 extends ReactiveElement {
+    static get styles() {
+      return css\`p { color: red; }\`;
+    }
+    static get properties() {
+      return {foo: {type: Number}};
+    }
+  }
+
+  class C2 extends NotReactiveElement {
+  }
+  C2.styles = css\`p { color: red; }\`;
+  C2.properties = {foo: {type: Number}};
+
+  class C3 extends LitElement {
+    static get styles() {
+      return css\`p { color: red; }\`;
+    }
+    static get properties() {
+      return {foo: {type: Number}};
+    }
+  }
+
+  class C4 extends LitElement {
+  }
+
+  class C5 extends C4 {
+    static get styles() {
+      return css\`p { color: red; }\`;
+    }
+    static get properties() {
+      return {foo: {type: Number}};
+    }
+  }
+  `;
+  checkTransform(input, expected);
+});
+
 test.run();

--- a/packages/ts-transformers/src/tests/idiomatic-test.ts
+++ b/packages/ts-transformers/src/tests/idiomatic-test.ts
@@ -867,4 +867,43 @@ test('ignore static styles on non-Lit class', () => {
   checkTransform(input, expected);
 });
 
+test('static properties declaration', () => {
+  const input = `
+  import {LitElement} from 'lit';
+
+  class MyElement extends LitElement {
+    static properties = {foo: {type: Number}};
+  }
+  `;
+
+  const expected = `
+  import {LitElement} from 'lit';
+
+  class MyElement extends LitElement {
+    static get properties() {
+      return {foo: {type: Number}};
+    }
+  }
+  `;
+  checkTransform(input, expected);
+});
+
+test('ignore static properties on non-Lit class', () => {
+  const input = `
+  import {ReactiveElement} from './not-lit.js';
+
+  class MyElement extends ReactiveElement {
+    static properties = {foo: {type: Number}};
+  }
+  `;
+
+  const expected = `
+  import {ReactiveElement} from './not-lit.js';
+
+  class MyElement extends ReactiveElement {}
+  MyElement.properties = {foo: {type: Number}};
+  `;
+  checkTransform(input, expected);
+});
+
 test.run();

--- a/packages/ts-transformers/src/tests/not-lit.ts
+++ b/packages/ts-transformers/src/tests/not-lit.ts
@@ -29,3 +29,8 @@ export const property =
  */
 export const html = (_strings: TemplateStringsArray, ..._values: unknown[]) =>
   '';
+
+/**
+ * Not the official Lit ReactiveElement.
+ */
+export class ReactiveElement extends HTMLElement {}

--- a/packages/ts-transformers/src/util.ts
+++ b/packages/ts-transformers/src/util.ts
@@ -5,6 +5,8 @@
  */
 
 import * as ts from 'typescript';
+import * as pathLib from 'path';
+import * as fs from 'fs';
 
 /**
  * Return whether the given node is annotated with the `static` keyword.
@@ -13,3 +15,117 @@ export const isStatic = (node: ts.Node): boolean =>
   node.modifiers?.find(
     (modifier) => modifier.kind === ts.SyntaxKind.StaticKeyword
   ) !== undefined;
+
+/**
+ * Return each class declaration in the given nodes lineage, including the given
+ * node. Use the given type checker for resolving parent class names.
+ */
+export function* getHeritage(
+  node: ts.ClassDeclaration,
+  checker: ts.TypeChecker
+): IterableIterator<ts.ClassDeclaration> {
+  yield node;
+  const parentTypedExpression = getSuperClassTypeExpression(node);
+
+  if (parentTypedExpression === undefined) {
+    // No more inheritance.
+    return;
+  }
+
+  const parentExpression = parentTypedExpression.expression;
+  if (!ts.isIdentifier(parentExpression)) {
+    // We do not yet support non-identifier expressions in the extends clause.
+    return;
+  }
+
+  const parentTypeSymbol = checker.getTypeFromTypeNode(
+    parentTypedExpression
+  ).symbol;
+  if (
+    parentTypeSymbol === undefined ||
+    parentTypeSymbol.declarations === undefined
+  ) {
+    // Can't resolve symbol for parent type because we don't have access to its
+    // source file.
+    return;
+  }
+
+  const parentDeclaration = parentTypeSymbol
+    .declarations[0] as ts.ClassDeclaration;
+  yield* getHeritage(parentDeclaration, checker);
+}
+
+/**
+ * Get the type node for the superclass of the given class declaration.
+ */
+export function getSuperClassTypeExpression(
+  classDeclaration: ts.ClassDeclaration
+): ts.ExpressionWithTypeArguments | undefined {
+  if (classDeclaration.heritageClauses === undefined) {
+    return;
+  }
+  const extendsClause = classDeclaration.heritageClauses.find(
+    (clause) => clause.token === ts.SyntaxKind.ExtendsKeyword
+  );
+  if (extendsClause === undefined) {
+    return;
+  }
+  // Classes can only extend a single expression, so it is safe to get the first
+  // type.
+  const parentExpression = extendsClause.types[0];
+  return parentExpression;
+}
+
+/**
+ * Walk up the filesystem directory tree starting from the given path until a
+ * `package.json` file is found, and return the "name" field from it.
+ *
+ * @throws If an unexpected filesystem error occured, or if a `package.json`
+ * file contained invalid JSON.
+ */
+export function getOwningNpmPackageOfFile(path: string): string | undefined {
+  let packageJsonStr: string | undefined;
+  let dir = path;
+  for (;;) {
+    const possiblePackageJsonPath = pathLib.join(dir, 'package.json');
+    try {
+      packageJsonStr = fs.readFileSync(possiblePackageJsonPath, 'utf8');
+      break;
+    } catch (e) {
+      if (!(e.code === 'ENOTDIR' || e.code == 'ENOENT')) {
+        throw e;
+      }
+    }
+    const parent = pathLib.dirname(dir);
+    if (parent === dir) {
+      // This happens when we hit the root.
+      break;
+    }
+    dir = parent;
+  }
+  if (!packageJsonStr) {
+    return undefined;
+  }
+  const packageJson = JSON.parse(packageJsonStr) as {name?: string};
+  return packageJson.name;
+}
+
+/**
+ * Return whether this class extends the official Lit ReactiveElement base
+ * class.
+ */
+export const extendsReactiveElement = (
+  class_: ts.ClassDeclaration,
+  checker: ts.TypeChecker
+): boolean => {
+  for (const ancestorClass of getHeritage(class_, checker)) {
+    if (
+      ancestorClass.name?.getText() === 'ReactiveElement' &&
+      getOwningNpmPackageOfFile(ancestorClass.getSourceFile().fileName) ===
+        '@lit/reactive-element'
+    ) {
+      return true;
+    }
+  }
+  return false;
+};

--- a/packages/ts-transformers/src/util.ts
+++ b/packages/ts-transformers/src/util.ts
@@ -1,0 +1,15 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import * as ts from 'typescript';
+
+/**
+ * Return whether the given node is annotated with the `static` keyword.
+ */
+export const isStatic = (node: ts.Node): boolean =>
+  node.modifiers?.find(
+    (modifier) => modifier.kind === ts.SyntaxKind.StaticKeyword
+  ) !== undefined;


### PR DESCRIPTION
**Note to reviewer**: I recommend looking at each commit separately, I tried to break it up for readability.

Transforms:

```ts
class MyElement extends LitElement {
  static styles = css\`p { color: red; }\`;
  static properties = {foo: {type: Number}};
}
```

Into:

```ts
class MyElement extends LitElement {
  static get styles() {
    return css\`p { color: red; }\`;
  }
  static get properties() {
    return {foo: {type: Number}};
  }
}
```

Instead of:

```ts
class MyElement extends LitElement {
}
MyElement.styles = css\`p { color: red; }\`;
MyElement.properties = {foo: {type: Number}};
```

This transform is useful because Lit is not compatible with standard class fields, so standard class field emit needs to be disabled (`useDefineForClassFields: false`). However, this means statics turn into `MyClass.foo = ...` assignments following the class declaration, which has poor readability compared to a getter.