### PR TITLE
[ts-transformers] Clean up unnecessary `super(...arguments)` calls

### DIFF
--- a/packages/ts-transformers/src/constructor-cleanup.ts
+++ b/packages/ts-transformers/src/constructor-cleanup.ts
@@ -5,7 +5,8 @@
  */
 
 import * as ts from 'typescript';
-import {BLANK_LINE_PLACEHOLDER_COMMENT} from './preserve-blank-lines';
+import {BLANK_LINE_PLACEHOLDER_COMMENT} from './preserve-blank-lines.js';
+import {getHeritage} from './util.js';
 
 /**
  * TypeScript transformer which improves the readability of the default
@@ -24,11 +25,17 @@ import {BLANK_LINE_PLACEHOLDER_COMMENT} from './preserve-blank-lines';
  * "before" transformer, it won't have access to synthesized constructors, and
  * will have no efect.
  */
-export default function constructorCleanupTransformer(): ts.TransformerFactory<ts.SourceFile> {
+export default function constructorCleanupTransformer(
+  program: ts.Program
+): ts.TransformerFactory<ts.SourceFile> {
   return (context) => {
+    const toDelete = new WeakSet<ts.Node>();
     const visit = (node: ts.Node): ts.VisitResult<ts.Node> => {
+      if (toDelete.has(node)) {
+        return undefined;
+      }
       if (ts.isClassDeclaration(node)) {
-        node = cleanupClassConstructor(node, context);
+        node = cleanupClassConstructor(node, context, program, toDelete);
       }
       return ts.visitEachChild(node, visit, context);
     };
@@ -40,7 +47,9 @@ export default function constructorCleanupTransformer(): ts.TransformerFactory<t
 
 const cleanupClassConstructor = (
   class_: ts.ClassDeclaration,
-  context: ts.TransformationContext
+  context: ts.TransformationContext,
+  program: ts.Program,
+  toDelete: WeakSet<ts.Node>
 ): ts.Node => {
   let ctor: ts.ConstructorDeclaration | undefined;
   let ctorIdx = -1;
@@ -107,6 +116,23 @@ const cleanupClassConstructor = (
         /* trailing newline */ true
       );
     }
+    // Since this constructor was fully synthesized, it will always have a
+    // `super(...arguments)` call. Often we don't actually need the
+    // `...arguments` argument. Remove it if none of our ancestor classes have
+    // any constructor parameters. Note this fails in the case that an ancestor
+    // constructor directly uses `arguments` in its body, but that should be
+    // rare.
+    if (
+      !anyAncestorConstructorHasParameters(class_, program.getTypeChecker())
+    ) {
+      const superSpreadArgument = findSuperSpreadArgument(ctor);
+      if (superSpreadArgument !== undefined) {
+        // Note that we can't just empty the call's argument list, since we
+        // can't mutate the AST directly. We're going to visit it anyway since
+        // we walk the whole program, so we'll delete it then.
+        toDelete.add(superSpreadArgument);
+      }
+    }
   }
 
   if (newCtorIdx === ctorIdx) {
@@ -134,4 +160,48 @@ const cleanupClassConstructor = (
   );
 
   return newClass;
+};
+
+/**
+ * Return whether the given class or any of its ancestor classes have a
+ * constructor with one or more parameters.
+ */
+const anyAncestorConstructorHasParameters = (
+  class_: ts.ClassDeclaration,
+  checker: ts.TypeChecker
+) => {
+  for (const c of getHeritage(class_, checker)) {
+    for (const member of c.members) {
+      if (ts.isConstructorDeclaration(member)) {
+        if (member.parameters && member.parameters.length > 0) {
+          return true;
+        }
+        break;
+      }
+    }
+  }
+  return false;
+};
+
+/**
+ * If the given constructor has a `super(...arguments)` call, return the
+ * `...arguments` argument.
+ */
+const findSuperSpreadArgument = (
+  ctor: ts.ConstructorDeclaration
+): ts.Expression | undefined => {
+  const superCall = ctor.body?.statements?.[0];
+  if (
+    superCall &&
+    ts.isExpressionStatement(superCall) &&
+    ts.isCallExpression(superCall.expression) &&
+    superCall.expression.expression.kind === ts.SyntaxKind.SuperKeyword &&
+    superCall.expression.arguments?.length === 1 &&
+    ts.isSpreadElement(superCall.expression.arguments[0]) &&
+    ts.isIdentifier(superCall.expression.arguments[0].expression) &&
+    superCall.expression.arguments[0].expression.text === 'arguments'
+  ) {
+    return superCall.expression.arguments[0];
+  }
+  return undefined;
 };

--- a/packages/ts-transformers/src/tests/constructor-cleanup-test.ts
+++ b/packages/ts-transformers/src/tests/constructor-cleanup-test.ts
@@ -28,9 +28,15 @@ function checkTransform(inputTs: string, expectedJs: string) {
   // Don't automatically load typings from nodes_modules/@types, we're not using
   // them here, so it's a waste of time.
   options.typeRoots = [];
-  const result = compileTsFragment(inputTs, __dirname, options, cache, () => ({
-    after: [constructorCleanupTransformer()],
-  }));
+  const result = compileTsFragment(
+    inputTs,
+    __dirname,
+    options,
+    cache,
+    (program) => ({
+      after: [constructorCleanupTransformer(program)],
+    })
+  );
 
   let formattedExpected = prettier.format(expectedJs, {parser: 'typescript'});
   // TypeScript >= 4 will add an empty export statement if there are no imports
@@ -214,6 +220,58 @@ test('fully synthetic constructor stays at top if there are no statics', () => {
       i2() { return 0; }
       i3() { return 0; }
       i4() { return 0; }
+    }
+  `;
+  checkTransform(input, expected);
+});
+
+test('remove unnecessary synthetic super(...arguments) argument', () => {
+  const input = `
+    class C1 {}
+    class C2 extends C1 {}
+    class C3 extends C2 {
+      foo = 0;
+    }
+    `;
+  const expected = `
+    class C1 {}
+    class C2 extends C1 {}
+    class C3 extends C2 {
+      constructor() {
+        super();
+        this.foo = 0;
+      }
+    }
+  `;
+  checkTransform(input, expected);
+});
+
+test('preserve necessary synthetic super(...arguments) argument', () => {
+  const input = `
+    class C1 {
+      constructor(x) {
+        console.log(x);
+      }
+    }
+    class C2 extends C1 {
+    }
+    class C3 extends C2 {
+      foo = 0;
+    }
+    `;
+  const expected = `
+    class C1 {
+      constructor(x) {
+        console.log(x);
+      }
+    }
+    class C2 extends C1 {
+    }
+    class C3 extends C2 {
+      constructor() {
+        super(...arguments);
+        this.foo = 0;
+      }
     }
   `;
   checkTransform(input, expected);

--- a/packages/ts-transformers/src/tests/idiomatic-test.ts
+++ b/packages/ts-transformers/src/tests/idiomatic-test.ts
@@ -43,7 +43,7 @@ function checkTransform(
         preserveBlankLinesTransformer(),
         idiomaticLitDecoratorTransformer(program),
       ],
-      after: [constructorCleanupTransformer()],
+      after: [constructorCleanupTransformer(program)],
     })
   );
 
@@ -134,7 +134,7 @@ const tests = (test: uvu.Test<uvu.Context>, options: ts.CompilerOptions) => {
         }
 
         constructor() {
-          super(...arguments);
+          super();
           this.reactiveInitializedStr = "foo";
           this.reactiveInitializedNum = 42;
           this.reactiveInitializedBool = false;
@@ -160,7 +160,7 @@ const tests = (test: uvu.Test<uvu.Context>, options: ts.CompilerOptions) => {
         }
 
         constructor() {
-          super(...arguments);
+          super();
           this.nonReactiveInitialized = 123;
           this.reactiveInitializedStr = "foo";
           this.reactiveInitializedNum = 42;
@@ -321,7 +321,7 @@ const tests = (test: uvu.Test<uvu.Context>, options: ts.CompilerOptions) => {
       }
 
       constructor() {
-        super(...arguments);
+        super();
         this.num = 42;
         this.num2 = 24;
       }
@@ -933,7 +933,7 @@ const tests = (test: uvu.Test<uvu.Context>, options: ts.CompilerOptions) => {
       }
 
       constructor() {
-        super(...arguments);
+        super();
         this.str = "foo";
         this.num = 42;
       }
@@ -958,7 +958,7 @@ const tests = (test: uvu.Test<uvu.Context>, options: ts.CompilerOptions) => {
 
     class MyElement extends LitElement {
       constructor() {
-        super(...arguments);
+        super();
         updateWhenLocaleChanges(this);
       }
     }
@@ -991,7 +991,7 @@ const tests = (test: uvu.Test<uvu.Context>, options: ts.CompilerOptions) => {
       }
 
       constructor() {
-        super(...arguments);
+        super();
         updateWhenLocaleChanges(this);
         this.foo = 123;
       }

--- a/packages/ts-transformers/src/util.ts
+++ b/packages/ts-transformers/src/util.ts
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import * as ts from 'typescript';
+
+/**
+ * Return each class declaration in the given nodes lineage, including the given
+ * node. Use the given type checker for resolving parent class names.
+ */
+export function* getHeritage(
+  node: ts.ClassDeclaration,
+  checker: ts.TypeChecker
+): IterableIterator<ts.ClassDeclaration> {
+  yield node;
+  const parentTypedExpression = getSuperClassTypeExpression(node);
+
+  if (parentTypedExpression === undefined) {
+    // No more inheritance.
+    return;
+  }
+
+  const parentExpression = parentTypedExpression.expression;
+  if (!ts.isIdentifier(parentExpression)) {
+    // We do not yet support non-identifier expressions in the extends clause.
+    return;
+  }
+
+  const parentTypeSymbol = checker.getTypeFromTypeNode(
+    parentTypedExpression
+  ).symbol;
+  if (
+    parentTypeSymbol === undefined ||
+    parentTypeSymbol.declarations === undefined
+  ) {
+    // Can't resolve symbol for parent type because we don't have access to its
+    // source file.
+    return;
+  }
+
+  const parentDeclaration = parentTypeSymbol
+    .declarations[0] as ts.ClassDeclaration;
+  yield* getHeritage(parentDeclaration, checker);
+}
+
+/**
+ * Get the type node for the superclass of the given class declaration.
+ */
+function getSuperClassTypeExpression(
+  classDeclaration: ts.ClassDeclaration
+): ts.ExpressionWithTypeArguments | undefined {
+  if (classDeclaration.heritageClauses === undefined) {
+    return;
+  }
+  const extendsClause = classDeclaration.heritageClauses.find(
+    (clause) => clause.token === ts.SyntaxKind.ExtendsKeyword
+  );
+  if (extendsClause === undefined) {
+    return;
+  }
+  // Classes can only extend a single expression, so it is safe to get the first
+  // type.
+  const parentExpression = extendsClause.types[0];
+  return parentExpression;
+}


### PR DESCRIPTION
When synthesizing a subclass constructor, TypeScript always includes a `super(...arguments)` call.

However, it is often unnecessary to include the `...arguments` argument.

This PR updates the `constructor-cleanup` transformer to remove the `...arguments` argument when none of the ancestor classes have any parameters in their constructor.

Note this is not 100% safe, since an ancestor constructor could directly use `arguments` in its body (which we may not be able to detect because we don't have access to bodies via `.d.ts` files) but that should be fairly rare. For the main use case we're targeting (generating lit.dev samples), it seems like a reasonable readability/correctness tradeoff.