### PR TITLE
[ts-transformers] Transform `@localized` decorator to `updateWhenLocaleChanges()`

### DIFF
--- a/packages/ts-transformers/package.json
+++ b/packages/ts-transformers/package.json
@@ -25,6 +25,7 @@
     "typescript": "^4.3.5"
   },
   "devDependencies": {
+    "@lit/localize": "^0.10.3",
     "@lit/reactive-element": "^1.0.0-rc.2",
     "@types/prettier": "^2.2.3",
     "lit": "^2.0.0-rc.2",

--- a/packages/ts-transformers/src/idiomatic.ts
+++ b/packages/ts-transformers/src/idiomatic.ts
@@ -15,6 +15,7 @@ import {QueryAllVisitor} from './idiomatic/query-all.js';
 import {QueryAsyncVisitor} from './idiomatic/query-async.js';
 import {QueryAssignedNodesVisitor} from './idiomatic/query-assigned-nodes.js';
 import {EventOptionsVisitor} from './idiomatic/event-options.js';
+import {LocalizedVisitor} from './idiomatic/localized.js';
 
 /**
  * TypeScript transformer which transforms all Lit decorators to their idiomatic
@@ -69,6 +70,7 @@ export default function idiomaticLitDecoratorTransformer(
       new QueryAsyncVisitor(context),
       new QueryAssignedNodesVisitor(context),
       new EventOptionsVisitor(context, program),
+      new LocalizedVisitor(context),
     ]);
     return (file) => {
       return ts.visitNode(file, transformer.visitFile);

--- a/packages/ts-transformers/src/idiomatic/localized.ts
+++ b/packages/ts-transformers/src/idiomatic/localized.ts
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import * as ts from 'typescript';
+
+import type {LitClassContext} from '../lit-class-context.js';
+import type {ClassDecoratorVisitor} from '../visitor.js';
+
+/**
+ * Transform:
+ *
+ *   import {localized} from '@lit/localize';
+ *
+ *   @localized()
+ *   class MyElement extends LitElement {}
+ *
+ * Into:
+ *
+ *   import {updateWhenLocaleChanges} from '@lit/localize';
+ *
+ *   class MyElement extends LitElement {
+ *     constructor() {
+ *       super(...arguments);
+ *       updateWhenLocaleChanges(this);
+ *     }
+ *   }
+ */
+export class LocalizedVisitor implements ClassDecoratorVisitor {
+  readonly kind = 'classDecorator';
+  readonly decoratorName = 'localized';
+  readonly importBindingReplacement = 'updateWhenLocaleChanges';
+
+  private readonly _factory: ts.NodeFactory;
+
+  constructor({factory}: ts.TransformationContext) {
+    this._factory = factory;
+  }
+
+  visit(litClassContext: LitClassContext, decorator: ts.Decorator) {
+    litClassContext.litFileContext.nodeReplacements.set(decorator, undefined);
+
+    const f = this._factory;
+    const updateCall = f.createExpressionStatement(
+      f.createCallExpression(
+        f.createIdentifier(this.importBindingReplacement),
+        undefined,
+        [f.createThis()]
+      )
+    );
+    litClassContext.extraConstructorStatements.push(updateCall);
+  }
+}

--- a/packages/ts-transformers/src/lit-transformer.ts
+++ b/packages/ts-transformers/src/lit-transformer.ts
@@ -467,8 +467,7 @@ const isLitImport = (specifier: string) =>
   specifier.startsWith('lit/') ||
   specifier === 'lit-element' ||
   specifier.startsWith('lit-element/') ||
-  specifier === '@lit/reactive-element' ||
-  specifier.startsWith('@lit/reactive-element/');
+  specifier.startsWith('@lit/');
 
 /**
  * Returns true for:

--- a/packages/ts-transformers/src/lit-transformer.ts
+++ b/packages/ts-transformers/src/lit-transformer.ts
@@ -206,17 +206,25 @@ export class LitTransformer {
         // associated with a decorator. If that changed, visitors should
         // probably have a static field to declare which imports they care
         // about.
-      } else if (
+      } else {
         // Only handle the decorators we're configured to transform.
-        this._classDecoratorVisitors.has(realName) ||
-        this._memberDecoratorVisitors.has(realName)
-      ) {
-        this._litFileContext.litImports.set(importSpecifier, realName);
-        // Assume if there's a visitor for a decorator, it's always going to
-        // remove any uses of that decorator, and hence we should remove the
-        // import too.
-        this._litFileContext.nodeReplacements.set(importSpecifier, undefined);
-        traversalNeeded = true;
+        const visitor =
+          this._classDecoratorVisitors.get(realName) ??
+          this._memberDecoratorVisitors.get(realName);
+        if (visitor !== undefined) {
+          this._litFileContext.litImports.set(importSpecifier, realName);
+          // Either remove the binding or replace it with another identifier.
+          const replacement = visitor.importBindingReplacement
+            ? this._context.factory.createIdentifier(
+                visitor.importBindingReplacement
+              )
+            : undefined;
+          this._litFileContext.nodeReplacements.set(
+            importSpecifier,
+            replacement
+          );
+          traversalNeeded = true;
+        }
       }
     }
     return traversalNeeded;

--- a/packages/ts-transformers/src/tests/idiomatic-test.ts
+++ b/packages/ts-transformers/src/tests/idiomatic-test.ts
@@ -942,6 +942,64 @@ const tests = (test: uvu.Test<uvu.Context>, options: ts.CompilerOptions) => {
     checkTransform(input, expected, options);
   });
 
+  test('@localized', () => {
+    const input = `
+    import {LitElement} from 'lit';
+    import {localized} from '@lit/localize';
+
+    @localized()
+    class MyElement extends LitElement {
+    }
+    `;
+
+    const expected = `
+    import {LitElement} from 'lit';
+    import {updateWhenLocaleChanges} from '@lit/localize';
+
+    class MyElement extends LitElement {
+      constructor() {
+        super(...arguments);
+        updateWhenLocaleChanges(this);
+      }
+    }
+    `;
+    checkTransform(input, expected, options);
+  });
+
+  test('@localized (with property)', () => {
+    const input = `
+    import {LitElement} from 'lit';
+    import {property} from 'lit/decorators.js';
+    import {localized} from '@lit/localize';
+
+    @localized()
+    class MyElement extends LitElement {
+      @property()
+      foo = 123;
+    }
+    `;
+
+    const expected = `
+    import {LitElement} from 'lit';
+    import {updateWhenLocaleChanges} from '@lit/localize';
+
+    class MyElement extends LitElement {
+      static get properties() {
+        return {
+          foo: {},
+        };
+      }
+
+      constructor() {
+        super(...arguments);
+        updateWhenLocaleChanges(this);
+        this.foo = 123;
+      }
+    }
+    `;
+    checkTransform(input, expected, options);
+  });
+
   test.run();
 };
 

--- a/packages/ts-transformers/src/visitor.ts
+++ b/packages/ts-transformers/src/visitor.ts
@@ -18,6 +18,7 @@ export type Visitor =
 export interface ClassDecoratorVisitor {
   kind: 'classDecorator';
   decoratorName: string;
+  importBindingReplacement?: string;
 
   visit(classContext: LitClassContext, decorator: ts.Decorator): void;
 }
@@ -26,6 +27,7 @@ export interface ClassDecoratorVisitor {
 export interface MemberDecoratorVisitor {
   kind: 'memberDecorator';
   decoratorName: string;
+  importBindingReplacement?: string;
 
   visit(
     classContext: LitClassContext,


### PR DESCRIPTION
**Note to reviewer**: I recommend looking at each commit separately. There's a little refactoring here too.

Transforms:

```ts
import {LitElement} from 'lit';
import {localized} from '@lit/localize';

@localized()
class MyElement extends LitElement {
}
```

Into:

```ts
import {LitElement} from 'lit';
import {updateWhenLocaleChanges} from '@lit/localize';

class MyElement extends LitElement {
  constructor() {
    super(...arguments);
    updateWhenLocaleChanges(this);
  }
}
```