### PR TITLE
[ts-transformers] Transform reactive properties to constructor assignments even with `useDefineForClassFields`

### DIFF
--- a/packages/ts-transformers/src/constructor-cleanup.ts
+++ b/packages/ts-transformers/src/constructor-cleanup.ts
@@ -69,9 +69,10 @@ const cleanupClassConstructor = (
   // regardless of its original source order. Let's move it somewhere more sane.
   let newCtorIdx;
 
-  // When TypeScript synthesizes a constructor from scratch, it gives it the
-  // position of its class.
-  const hasOriginalSourcePosition = ctor.pos !== class_.pos;
+  // When the built-in TypeScript class field transformer synthesizes a
+  // constructor, it gives it the position of its class. Other transformers
+  // might not set a position at all, so it will default to -1.
+  const hasOriginalSourcePosition = ctor.pos !== class_.pos && ctor.pos !== -1;
 
   if (hasOriginalSourcePosition) {
     // The constructor existed in the original source. Move it back.
@@ -93,7 +94,7 @@ const cleanupClassConstructor = (
           (modifier) => modifier.kind === ts.SyntaxKind.StaticKeyword
         ) !== undefined;
       if (isStatic) {
-        newCtorIdx = i;
+        newCtorIdx = ctorIdx > i ? i + 1 : i;
         break;
       }
     }

--- a/packages/ts-transformers/src/idiomatic/custom-element.ts
+++ b/packages/ts-transformers/src/idiomatic/custom-element.ts
@@ -43,7 +43,7 @@ export class CustomElementVisitor implements ClassDecoratorVisitor {
     }
     const elementName = arg0.text;
     const className = litClassContext.class.name.text;
-    litClassContext.litFileContext.nodesToRemove.add(decorator);
+    litClassContext.litFileContext.nodeReplacements.set(decorator, undefined);
     litClassContext.adjacentStatements.push(
       this._createCustomElementsDefineCall(elementName, className)
     );

--- a/packages/ts-transformers/src/idiomatic/event-options.ts
+++ b/packages/ts-transformers/src/idiomatic/event-options.ts
@@ -98,7 +98,7 @@ export class EventOptionsVisitor implements MemberDecoratorVisitor {
       return;
     }
 
-    litClassContext.litFileContext.nodesToRemove.add(decorator);
+    litClassContext.litFileContext.nodeReplacements.set(decorator, undefined);
 
     // If private, assume no outside access is possible, and transform any
     // references to this function inside template event bindings to

--- a/packages/ts-transformers/src/idiomatic/property.ts
+++ b/packages/ts-transformers/src/idiomatic/property.ts
@@ -25,9 +25,12 @@ import type {MemberDecoratorVisitor} from '../visitor.js';
  */
 export class PropertyVisitor implements MemberDecoratorVisitor {
   readonly kind = 'memberDecorator';
-  readonly decoratorName = 'property';
+  decoratorName = 'property';
+  protected readonly _factory: ts.NodeFactory;
 
-  constructor(_context: ts.TransformationContext) {}
+  constructor({factory}: ts.TransformationContext) {
+    this._factory = factory;
+  }
 
   visit(
     litClassContext: LitClassContext,
@@ -37,18 +40,25 @@ export class PropertyVisitor implements MemberDecoratorVisitor {
     if (!ts.isPropertyDeclaration(property)) {
       return;
     }
-    if (!ts.isCallExpression(decorator.expression)) {
-      return;
-    }
-    const [options] = decorator.expression.arguments;
-    if (!(options === undefined || ts.isObjectLiteralExpression(options))) {
-      return;
-    }
     if (!ts.isIdentifier(property.name)) {
       return;
     }
+    if (!ts.isCallExpression(decorator.expression)) {
+      return;
+    }
+    const [arg0] = decorator.expression.arguments;
+    if (!(arg0 === undefined || ts.isObjectLiteralExpression(arg0))) {
+      return;
+    }
+    const options = this._augmentOptions(arg0);
     const name = property.name.text;
     litClassContext.litFileContext.nodeReplacements.set(decorator, undefined);
     litClassContext.reactiveProperties.push({name, options});
+  }
+
+  protected _augmentOptions(
+    options: ts.ObjectLiteralExpression
+  ): ts.ObjectLiteralExpression {
+    return options;
   }
 }

--- a/packages/ts-transformers/src/idiomatic/property.ts
+++ b/packages/ts-transformers/src/idiomatic/property.ts
@@ -48,7 +48,7 @@ export class PropertyVisitor implements MemberDecoratorVisitor {
       return;
     }
     const name = property.name.text;
-    litClassContext.litFileContext.nodesToRemove.add(decorator);
+    litClassContext.litFileContext.nodeReplacements.set(decorator, undefined);
     litClassContext.reactiveProperties.push({name, options});
   }
 }

--- a/packages/ts-transformers/src/idiomatic/property.ts
+++ b/packages/ts-transformers/src/idiomatic/property.ts
@@ -13,7 +13,7 @@ import type {MemberDecoratorVisitor} from '../visitor.js';
  * Transform:
  *
  *   @property({type: Number})
- *   foo
+ *   foo = 123;
  *
  * Into:
  *
@@ -21,6 +21,11 @@ import type {MemberDecoratorVisitor} from '../visitor.js';
  *     return {
  *       foo: {type: Number}
  *     }
+ *   }
+ *
+ *   constructor() {
+ *     super(...arguments);
+ *     this.foo = 123;
  *   }
  */
 export class PropertyVisitor implements MemberDecoratorVisitor {

--- a/packages/ts-transformers/src/idiomatic/property.ts
+++ b/packages/ts-transformers/src/idiomatic/property.ts
@@ -52,8 +52,23 @@ export class PropertyVisitor implements MemberDecoratorVisitor {
     }
     const options = this._augmentOptions(arg0);
     const name = property.name.text;
-    litClassContext.litFileContext.nodeReplacements.set(decorator, undefined);
+    litClassContext.litFileContext.nodeReplacements.set(property, undefined);
     litClassContext.reactiveProperties.push({name, options});
+
+    if (property.initializer !== undefined) {
+      const f = this._factory;
+      const initializer = f.createExpressionStatement(
+        f.createBinaryExpression(
+          f.createPropertyAccessExpression(
+            f.createThis(),
+            f.createIdentifier(name)
+          ),
+          f.createToken(ts.SyntaxKind.EqualsToken),
+          property.initializer
+        )
+      );
+      litClassContext.extraConstructorStatements.push(initializer);
+    }
   }
 
   protected _augmentOptions(

--- a/packages/ts-transformers/src/idiomatic/query-all.ts
+++ b/packages/ts-transformers/src/idiomatic/query-all.ts
@@ -51,7 +51,7 @@ export class QueryAllVisitor implements MemberDecoratorVisitor {
     }
     const name = property.name.text;
     const selector = arg0.text;
-    litClassContext.litFileContext.nodesToRemove.add(property);
+    litClassContext.litFileContext.nodeReplacements.set(property, undefined);
     litClassContext.classMembers.push(
       this._createQueryAllGetter(name, selector)
     );

--- a/packages/ts-transformers/src/idiomatic/query-assigned-nodes.ts
+++ b/packages/ts-transformers/src/idiomatic/query-assigned-nodes.ts
@@ -54,7 +54,7 @@ export class QueryAssignedNodesVisitor implements MemberDecoratorVisitor {
     const flatten = arg1?.kind === ts.SyntaxKind.TrueKeyword;
     const selector =
       arg2 !== undefined && ts.isStringLiteral(arg2) ? arg2.text : '';
-    litClassContext.litFileContext.nodesToRemove.add(property);
+    litClassContext.litFileContext.nodeReplacements.set(property, undefined);
     litClassContext.classMembers.push(
       this._createQueryAssignedNodesGetter(name, slotName, flatten, selector)
     );

--- a/packages/ts-transformers/src/idiomatic/query-async.ts
+++ b/packages/ts-transformers/src/idiomatic/query-async.ts
@@ -52,7 +52,7 @@ export class QueryAsyncVisitor implements MemberDecoratorVisitor {
       return;
     }
     const selector = arg0.text;
-    litClassContext.litFileContext.nodesToRemove.add(property);
+    litClassContext.litFileContext.nodeReplacements.set(property, undefined);
     litClassContext.classMembers.push(
       this._createQueryAsyncGetter({name, selector})
     );

--- a/packages/ts-transformers/src/idiomatic/query.ts
+++ b/packages/ts-transformers/src/idiomatic/query.ts
@@ -59,7 +59,7 @@ export class QueryVisitor implements MemberDecoratorVisitor {
     const name = property.name.text;
     const selector = arg0.text;
     const cache = arg1?.kind === ts.SyntaxKind.TrueKeyword;
-    litClassContext.litFileContext.nodesToRemove.add(property);
+    litClassContext.litFileContext.nodeReplacements.set(property, undefined);
     litClassContext.classMembers.push(
       this._createQueryGetter(name, selector, cache)
     );

--- a/packages/ts-transformers/src/lit-class-context.ts
+++ b/packages/ts-transformers/src/lit-class-context.ts
@@ -28,6 +28,12 @@ export class LitClassContext {
   readonly classMembers: ts.ClassElement[] = [];
 
   /**
+   * Additional statements to append to the class constructor body. A new
+   * constructor will be created if one doesn't already exist.
+   */
+  readonly extraConstructorStatements: ts.ExpressionStatement[] = [];
+
+  /**
    * Add a new property to the `static get properties` block of this element.
    */
   readonly reactiveProperties: Array<{

--- a/packages/ts-transformers/src/lit-file-context.ts
+++ b/packages/ts-transformers/src/lit-file-context.ts
@@ -17,10 +17,10 @@ export class LitFileContext {
   readonly litImports = new Map<ts.ImportSpecifier, string>();
 
   /**
-   * Nodes that are to be removed from the AST if they are encountered in
-   * subsequent traversal.
+   * Nodes that are to be replaced with another node (or removed when undefined)
+   * when they are encountered in subsequent traversal.
    */
-  readonly nodesToRemove = new Set<ts.Node>();
+  readonly nodeReplacements = new Map<ts.Node, ts.Node | undefined>();
 
   private readonly _program: ts.Program;
 
@@ -30,7 +30,7 @@ export class LitFileContext {
 
   clear() {
     this.litImports.clear();
-    this.nodesToRemove.clear();
+    this.nodeReplacements.clear();
   }
 
   /**

--- a/packages/ts-transformers/src/lit-transformer.ts
+++ b/packages/ts-transformers/src/lit-transformer.ts
@@ -126,9 +126,9 @@ export class LitTransformer {
   };
 
   visit = (node: ts.Node): ts.VisitResult<ts.Node> => {
-    if (this._litFileContext.nodesToRemove.has(node)) {
-      // A node that some previous visitor has requested to remove from the AST.
-      return undefined;
+    if (this._litFileContext.nodeReplacements.has(node)) {
+      // A node that some previous visitor has requested to be replaced.
+      return this._litFileContext.nodeReplacements.get(node);
     }
     for (const visitor of this._genericVisitors) {
       node = visitor.visit(this._litFileContext, node);
@@ -203,7 +203,7 @@ export class LitTransformer {
         // Assume if there's a visitor for a decorator, it's always going to
         // remove any uses of that decorator, and hence we should remove the
         // import too.
-        this._litFileContext.nodesToRemove.add(importSpecifier);
+        this._litFileContext.nodeReplacements.set(importSpecifier, undefined);
         traversalNeeded = true;
       }
     }
@@ -275,7 +275,7 @@ export class LitTransformer {
     if (litClassContext.reactiveProperties.length > 0) {
       const existing = this._findExistingStaticProperties(class_);
       if (existing !== undefined) {
-        this._litFileContext.nodesToRemove.add(existing.getter);
+        this._litFileContext.nodeReplacements.set(existing.getter, undefined);
       }
       litClassContext.classMembers.unshift(
         this._createStaticProperties(

--- a/packages/ts-transformers/src/tests/constructor-cleanup-test.ts
+++ b/packages/ts-transformers/src/tests/constructor-cleanup-test.ts
@@ -21,8 +21,8 @@ const cache = new CompilerHostCache();
 function checkTransform(inputTs: string, expectedJs: string) {
   const options = ts.getDefaultCompilerOptions();
   options.target = ts.ScriptTarget.ESNext;
-  // Don't emit standard class fields. They aren't compatible with Lit. Defaults
-  // to true when target = ESNext.
+  // Disable standard class field emit so that we see synthetic constructors
+  // from the built-in legacy class field transform.
   options.useDefineForClassFields = false;
   options.module = ts.ModuleKind.ESNext;
   // Don't automatically load typings from nodes_modules/@types, we're not using

--- a/packages/ts-transformers/src/tests/idiomatic-test.ts
+++ b/packages/ts-transformers/src/tests/idiomatic-test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {test} from 'uvu';
+import {suite} from 'uvu';
 import {compileTsFragment, CompilerHostCache} from './compile-ts-fragment.js';
 import * as ts from 'typescript';
 import * as assert from 'uvu/assert';
@@ -15,6 +15,8 @@ import preserveBlankLinesTransformer, {
 } from '../preserve-blank-lines.js';
 import constructorCleanupTransformer from '../constructor-cleanup.js';
 
+import type * as uvu from 'uvu';
+
 const cache = new CompilerHostCache();
 
 /**
@@ -22,12 +24,11 @@ const cache = new CompilerHostCache();
  * decorator transform. Check that there are no errors and that the output
  * matches (prettier-formatted).
  */
-function checkTransform(inputTs: string, expectedJs: string) {
-  const options = ts.getDefaultCompilerOptions();
-  options.target = ts.ScriptTarget.ESNext;
-  options.module = ts.ModuleKind.ESNext;
-  options.moduleResolution = ts.ModuleResolutionKind.NodeJs;
-  options.importHelpers = true;
+function checkTransform(
+  inputTs: string,
+  expectedJs: string,
+  options: ts.CompilerOptions
+) {
   // Don't automatically load typings from nodes_modules/@types, we're not using
   // them here, so it's a waste of time.
   options.typeRoots = [];
@@ -72,628 +73,11 @@ function checkTransform(inputTs: string, expectedJs: string) {
   );
 }
 
-test('@customElement', () => {
-  const input = `
-  import {LitElement} from 'lit';
-  import {customElement} from 'lit/decorators.js';
-
-  @customElement('my-element')
-  class MyElement extends LitElement {
-  }
-  `;
-
-  const expected = `
-  import {LitElement} from 'lit';
-
-  class MyElement extends LitElement {
-  }
-  customElements.define('my-element', MyElement);
-  `;
-  checkTransform(input, expected);
-});
-
-test('@property (no existing constructor)', () => {
-  const input = `
-  import {LitElement} from 'lit';
-  import {property} from 'lit/decorators.js';
-
-  class MyElement extends LitElement {
-    @property()
-    reactiveInitializedStr = "foo";
-
-    nonReactiveInitialized = 123;
-
-    @property({type: Object})
-    reactiveUninitializedObj;
-
-    @property({type: Number, attribute: false})
-    reactiveInitializedNum = 42;
-
-    nonReactiveUninitialized: string;
-
-    @property({type: Boolean, reflect: true})
-    reactiveInitializedBool = false;
-
-  }
-  `;
-
-  const expected = `
-  import {LitElement} from 'lit';
-
-  class MyElement extends LitElement {
-    static get properties() {
-      return {
-        reactiveInitializedStr: {},
-        reactiveUninitializedObj: {type: Object},
-        reactiveInitializedNum: {type: Number, attribute: false},
-        reactiveInitializedBool: {type: Boolean, reflect: true},
-      };
-    }
-
-    constructor() {
-      super(...arguments);
-      this.reactiveInitializedStr = "foo";
-      this.reactiveInitializedNum = 42;
-      this.reactiveInitializedBool = false;
-    }
-
-    nonReactiveInitialized = 123;
-
-    nonReactiveUninitialized;
-  }
-  `;
-  checkTransform(input, expected);
-});
-
-test('@property (existing constructor)', () => {
-  const input = `
-  import {LitElement} from 'lit';
-  import {property} from 'lit/decorators.js';
-
-  class MyElement extends LitElement {
-    @property()
-    reactiveInitializedStr = "foo";
-
-    nonReactiveInitialized = 123;
-
-    @property({type: Object})
-    reactiveUninitializedObj;
-
-    @property({type: Number, attribute: false})
-    reactiveInitializedNum = 42;
-
-    nonReactiveUninitialized: string;
-
-    @property({type: Boolean, reflect: true})
-    reactiveInitializedBool = false;
-
-    constructor() {
-      super();
-    }
-  }
-  `;
-
-  const expected = `
-  import {LitElement} from 'lit';
-
-  class MyElement extends LitElement {
-    static get properties() {
-      return {
-        reactiveInitializedStr: {},
-        reactiveUninitializedObj: {type: Object},
-        reactiveInitializedNum: {type: Number, attribute: false},
-        reactiveInitializedBool: {type: Boolean, reflect: true},
-      };
-    }
-
-    nonReactiveInitialized = 123;
-
-    nonReactiveUninitialized;
-
-    constructor() {
-      super();
-      this.reactiveInitializedStr = "foo";
-      this.reactiveInitializedNum = 42;
-      this.reactiveInitializedBool = false;
-    }
-  }
-  `;
-  checkTransform(input, expected);
-});
-
-test('@property (merge with existing static properties)', () => {
-  const input = `
-  import {LitElement} from 'lit';
-  import {property} from 'lit/decorators.js';
-
-  class MyElement extends LitElement {
-    static get properties() {
-      return {
-        str: {},
-      };
-    }
-
-    @property({type: Number})
-    num = 42;
-
-    constructor() {
-      super();
-    }
-  }
-  `;
-
-  const expected = `
-  import {LitElement} from 'lit';
-
-  class MyElement extends LitElement {
-    static get properties() {
-      return {
-        str: {},
-        num: {type: Number},
-      };
-    }
-
-    constructor() {
-      super();
-      this.num = 42;
-    }
-  }
-  `;
-  checkTransform(input, expected);
-});
-
-test('@state', () => {
-  const input = `
-  import {LitElement} from 'lit';
-  import {state} from 'lit/decorators.js';
-
-  class MyElement extends LitElement {
-    @state()
-    num = 42;
-
-    @state({hasChanged: () => false})
-    num2 = 24;
-  }
-  `;
-
-  const expected = `
-  import {LitElement} from 'lit';
-
-  class MyElement extends LitElement {
-    static get properties() {
-      return {
-        num: {state: true},
-        num2: {hasChanged: () => false, state: true},
-      };
-    }
-
-    constructor() {
-      super(...arguments);
-      this.num = 42;
-      this.num2 = 24;
-    }
-  }
-  `;
-  checkTransform(input, expected);
-});
-
-test('@query (non-caching)', () => {
-  const input = `
-  import {LitElement} from 'lit';
-  import {query} from 'lit/decorators.js';
-
-  class MyElement extends LitElement {
-    @query('#myDiv')
-    div?: HTMLDivElement;
-  }
-  `;
-
-  const expected = `
-  import {LitElement} from 'lit';
-
-  class MyElement extends LitElement {
-    get div() {
-      return this.renderRoot?.querySelector('#myDiv') ?? null;
-    }
-  }
-  `;
-  checkTransform(input, expected);
-});
-
-test('@query (caching)', () => {
-  const input = `
-  import {LitElement} from 'lit';
-  import {query} from 'lit/decorators.js';
-
-  class MyElement extends LitElement {
-    @query('#mySpan', true)
-    span?: HTMLSpanElement;
-  }
-  `;
-
-  const expected = `
-  import {LitElement} from 'lit';
-
-  class MyElement extends LitElement {
-    get span() {
-      return this.__span ??= this.renderRoot?.querySelector('#mySpan') ?? null;
-    }
-  }
-  `;
-  checkTransform(input, expected);
-});
-
-test('@queryAll', () => {
-  const input = `
-  import {LitElement} from 'lit';
-  import {queryAll} from 'lit/decorators.js';
-
-  class MyElement extends LitElement {
-    @queryAll('.myInput')
-    inputs: NodeListOf<HTMLInputElement>;
-  }
-  `;
-
-  const expected = `
-  import {LitElement} from 'lit';
-
-  class MyElement extends LitElement {
-    get inputs() {
-      return this.renderRoot?.querySelectorAll('.myInput') ?? [];
-    }
-  }
-  `;
-  checkTransform(input, expected);
-});
-
-test('@queryAsync', () => {
-  const input = `
-  import {LitElement} from 'lit';
-  import {queryAsync} from 'lit/decorators.js';
-
-  class MyElement extends LitElement {
-    @queryAsync('#myButton')
-    button: Promise<HTMLElement>;
-  }
-  `;
-
-  const expected = `
-  import {LitElement} from 'lit';
-
-  class MyElement extends LitElement {
-    async get button() {
-      await this.updateComplete;
-      return this.renderRoot?.querySelector('#myButton');
-    }
-  }
-  `;
-  checkTransform(input, expected);
-});
-
-test('@queryAssignedNodes (default slot)', () => {
-  const input = `
-  import {LitElement} from 'lit';
-  import {queryAssignedNodes} from 'lit/decorators.js';
-
-  class MyElement extends LitElement {
-    @queryAssignedNodes()
-    listItems: NodeListOf<HTMLElement>;
-  }
-  `;
-
-  const expected = `
-  import {LitElement} from 'lit';
-
-  class MyElement extends LitElement {
-    get listItems() {
-      return this.renderRoot
-        ?.querySelector('slot:not([name])')
-        ?.assignedNodes() ?? [];
-    }
-  }
-  `;
-  checkTransform(input, expected);
-});
-
-test('@queryAssignedNodes (with slot name)', () => {
-  const input = `
-  import {LitElement} from 'lit';
-  import {queryAssignedNodes} from 'lit/decorators.js';
-
-  class MyElement extends LitElement {
-    @queryAssignedNodes('list')
-    listItems: NodeListOf<HTMLElement>;
-  }
-  `;
-
-  const expected = `
-  import {LitElement} from 'lit';
-
-  class MyElement extends LitElement {
-    get listItems() {
-      return this.renderRoot
-        ?.querySelector('slot[name=list]')
-        ?.assignedNodes() ?? [];
-    }
-  }
-  `;
-  checkTransform(input, expected);
-});
-
-test('@queryAssignedNodes (with flatten)', () => {
-  const input = `
-  import {LitElement} from 'lit';
-  import {queryAssignedNodes} from 'lit/decorators.js';
-
-  class MyElement extends LitElement {
-    @queryAssignedNodes('list', true)
-    listItems: NodeListOf<HTMLElement>;
-  }
-  `;
-
-  const expected = `
-  import {LitElement} from 'lit';
-
-  class MyElement extends LitElement {
-    get listItems() {
-      return this.renderRoot
-        ?.querySelector('slot[name=list]')
-        ?.assignedNodes({flatten: true}) ?? [];
-    }
-  }
-  `;
-  checkTransform(input, expected);
-});
-
-test('@queryAssignedNodes (with selector)', () => {
-  const input = `
-  import {LitElement} from 'lit';
-  import {queryAssignedNodes} from 'lit/decorators.js';
-
-  class MyElement extends LitElement {
-    @queryAssignedNodes('list', false, '.item')
-    listItems: NodeListOf<HTMLElement>;
-  }
-  `;
-
-  const expected = `
-  import {LitElement} from 'lit';
-
-  class MyElement extends LitElement {
-    get listItems() {
-      return this.renderRoot
-        ?.querySelector('slot[name=list]')
-        ?.assignedNodes()
-        ?.filter((node) =>
-          node.nodeType === Node.ELEMENT_NODE &&
-            node.matches('.item')
-        ) ?? [];
-    }
-  }
-  `;
-  checkTransform(input, expected);
-});
-
-test('private @eventOptions', () => {
-  const input = `
-  import {eventOptions} from 'lit/decorators.js';
-  import {LitElement, html} from 'lit';
-
-  class MyElement extends LitElement {
-    @eventOptions({capture: true, once: false, passive: true})
-    private _onClick(event) {
-      console.log('click', event.target);
-    }
-
-    render() {
-      return html\`
-        <button @click=\${this._onClick}></button>
-      \`;
-    }
-  }
-  `;
-
-  const expected = `
-  import {LitElement, html} from 'lit';
-
-  class MyElement extends LitElement {
-    _onClick(event) {
-      console.log('click', event.target);
-    }
-
-    render() {
-      return html\`
-        <button @click=\${{
-          handleEvent: (e) => this._onClick(e),
-          capture: true,
-          once: false,
-          passive: true
-        }}></button>
-      \`;
-    }
-  }
-  `;
-  checkTransform(input, expected);
-});
-
-test('private @eventOptions with reversed import order', () => {
-  // Regression test for a bug where import order mattered.
-  const input = `
-  import {LitElement, html} from 'lit';
-  import {eventOptions} from 'lit/decorators.js';
-
-  class MyElement extends LitElement {
-    @eventOptions({capture: true, once: false, passive: true})
-    private _onClick(event) {
-      console.log('click', event.target);
-    }
-
-    render() {
-      return html\`
-        <button @click=\${this._onClick}></button>
-      \`;
-    }
-  }
-  `;
-
-  const expected = `
-  import {LitElement, html} from 'lit';
-
-  class MyElement extends LitElement {
-    _onClick(event) {
-      console.log('click', event.target);
-    }
-
-    render() {
-      return html\`
-        <button @click=\${{
-          handleEvent: (e) => this._onClick(e),
-          capture: true,
-          once: false,
-          passive: true
-        }}></button>
-      \`;
-    }
-  }
-  `;
-  checkTransform(input, expected);
-});
-
-test('private @eventOptions but not an event binding', () => {
-  const input = `
-  import {LitElement, html, svg} from 'lit';
-  import {eventOptions} from 'lit/decorators.js';
-
-  class MyElement extends LitElement {
-    @eventOptions({capture: true, once: false, passive: true})
-    private _onClick(event) {
-      console.log('click', event.target);
-    }
-
-    a() {
-      return this._onClick;
-    }
-    b() {
-      return html\`<p click=\${this._onClick}</p>\`;
-    }
-    c() {
-      return svg\`<p @click=\${this._onClick}</p>\`;
-    }
-  }
-  `;
-
-  const expected = `
-  import {LitElement, html, svg} from 'lit';
-
-  class MyElement extends LitElement {
-    _onClick(event) {
-      console.log('click', event.target);
-    }
-
-    a() {
-      return this._onClick;
-    }
-    b() {
-      return html\`<p click=\${this._onClick}</p>\`;
-    }
-    c() {
-      return svg\`<p @click=\${this._onClick}</p>\`;
-    }
-  }
-  `;
-  checkTransform(input, expected);
-});
-
-test('private @eventOptions but different html tag', () => {
-  const input = `
-  import {LitElement} from 'lit';
-  import {eventOptions} from 'lit/decorators.js';
-  import {html} from './not-lit.js';
-
-  class MyElement extends LitElement {
-    @eventOptions({capture: true, once: false, passive: true})
-    private _onClick(event) {
-      console.log('click', event.target);
-    }
-
-    render() {
-      return html\`<p @click=\${this._onClick}</p>\`;
-    }
-  }
-  `;
-
-  const expected = `
-  import {LitElement} from 'lit';
-  import {html} from './not-lit.js';
-
-  class MyElement extends LitElement {
-    _onClick(event) {
-      console.log('click', event.target);
-    }
-
-    render() {
-      return html\`<p @click=\${this._onClick}</p>\`;
-    }
-  }
-  `;
-  checkTransform(input, expected);
-});
-
-test('public @eventOptions', () => {
-  const input = `
-  import {LitElement, html} from 'lit';
-  import {eventOptions} from 'lit/decorators.js';
-
-  class MyElement extends LitElement {
-    @eventOptions({capture: true, once: false, passive: true})
-    _onClick(event) {
-      console.log('click', event.target);
-    }
-
-    render() {
-      return html\`
-        <button @click=\${this._onClick}></button>
-      \`;
-    }
-  }
-  `;
-
-  const expected = `
-  import {LitElement, html} from 'lit';
-
-  class MyElement extends LitElement {
-    _onClick(event) {
-      console.log('click', event.target);
-    }
-
-    render() {
-      return html\`
-        <button @click=\${this._onClick}></button>
-      \`;
-    }
-  }
-  Object.assign(MyElement.prototype._onClick, {
-    capture: true,
-    once: false,
-    passive: true
-  });
-  `;
-  checkTransform(input, expected);
-});
-
-for (const specifier of [
-  'lit/decorators.js',
-  'lit/decorators/custom-element.js',
-  '@lit/reactive-element/decorators.js',
-  '@lit/reactive-element/decorators/custom-element.js',
-  'lit-element',
-  'lit-element/index.js',
-  'lit-element/decorators.js',
-]) {
-  test(`various valid import specifiers [${specifier}]`, () => {
+const tests = (test: uvu.Test<uvu.Context>, options: ts.CompilerOptions) => {
+  test('@customElement', () => {
     const input = `
     import {LitElement} from 'lit';
-    import {customElement} from '${specifier}';
+    import {customElement} from 'lit/decorators.js';
 
     @customElement('my-element')
     class MyElement extends LitElement {
@@ -707,173 +91,873 @@ for (const specifier of [
     }
     customElements.define('my-element', MyElement);
     `;
-    checkTransform(input, expected);
+    checkTransform(input, expected, options);
   });
-}
 
-for (const specifier of [
-  'lit/decorators',
-  'lit/decorators/custom-element',
-  '@lit/reactive-element/decorators',
-  '@lit/reactive-element/decorators/custom-element',
-  'lit-element/index',
-  'lit-element/decorators',
-]) {
-  test(`various invalid import specifiers [${specifier}]`, () => {
+  test('@property (no existing constructor)', () => {
     const input = `
     import {LitElement} from 'lit';
-    import {customElement} from '${specifier}';
+    import {property} from 'lit/decorators.js';
+
+    class MyElement extends LitElement {
+      @property()
+      reactiveInitializedStr = "foo";
+
+      nonReactiveInitialized = 123;
+
+      @property({type: Object})
+      reactiveUninitializedObj;
+
+      @property({type: Number, attribute: false})
+      reactiveInitializedNum = 42;
+
+      nonReactiveUninitialized: string;
+
+      @property({type: Boolean, reflect: true})
+      reactiveInitializedBool = false;
+    }
+  `;
+
+    let expected;
+    if (options.useDefineForClassFields) {
+      expected = `
+      import {LitElement} from 'lit';
+
+      class MyElement extends LitElement {
+        static get properties() {
+          return {
+            reactiveInitializedStr: {},
+            reactiveUninitializedObj: {type: Object},
+            reactiveInitializedNum: {type: Number, attribute: false},
+            reactiveInitializedBool: {type: Boolean, reflect: true},
+          };
+        }
+
+        constructor() {
+          super(...arguments);
+          this.reactiveInitializedStr = "foo";
+          this.reactiveInitializedNum = 42;
+          this.reactiveInitializedBool = false;
+        }
+
+        nonReactiveInitialized = 123;
+
+        nonReactiveUninitialized;
+      }
+      `;
+    } else {
+      expected = `
+      import {LitElement} from 'lit';
+
+      class MyElement extends LitElement {
+        static get properties() {
+          return {
+            reactiveInitializedStr: {},
+            reactiveUninitializedObj: {type: Object},
+            reactiveInitializedNum: {type: Number, attribute: false},
+            reactiveInitializedBool: {type: Boolean, reflect: true},
+          };
+        }
+
+        constructor() {
+          super(...arguments);
+          this.nonReactiveInitialized = 123;
+          this.reactiveInitializedStr = "foo";
+          this.reactiveInitializedNum = 42;
+          this.reactiveInitializedBool = false;
+        }
+      }
+      `;
+    }
+    checkTransform(input, expected, options);
+  });
+
+  test('@property (existing constructor)', () => {
+    const input = `
+    import {LitElement} from 'lit';
+    import {property} from 'lit/decorators.js';
+
+    class MyElement extends LitElement {
+      @property()
+      reactiveInitializedStr = "foo";
+
+      nonReactiveInitialized = 123;
+
+      @property({type: Object})
+      reactiveUninitializedObj;
+
+      @property({type: Number, attribute: false})
+      reactiveInitializedNum = 42;
+
+      nonReactiveUninitialized: string;
+
+      @property({type: Boolean, reflect: true})
+      reactiveInitializedBool = false;
+
+      constructor() {
+        super();
+      }
+    }
+    `;
+
+    let expected;
+    if (options.useDefineForClassFields) {
+      expected = `
+      import {LitElement} from 'lit';
+
+      class MyElement extends LitElement {
+        static get properties() {
+          return {
+            reactiveInitializedStr: {},
+            reactiveUninitializedObj: {type: Object},
+            reactiveInitializedNum: {type: Number, attribute: false},
+            reactiveInitializedBool: {type: Boolean, reflect: true},
+          };
+        }
+
+        nonReactiveInitialized = 123;
+
+        nonReactiveUninitialized;
+
+        constructor() {
+          super();
+          this.reactiveInitializedStr = "foo";
+          this.reactiveInitializedNum = 42;
+          this.reactiveInitializedBool = false;
+        }
+      }
+      `;
+    } else {
+      expected = `
+      import {LitElement} from 'lit';
+
+      class MyElement extends LitElement {
+        static get properties() {
+          return {
+            reactiveInitializedStr: {},
+            reactiveUninitializedObj: {type: Object},
+            reactiveInitializedNum: {type: Number, attribute: false},
+            reactiveInitializedBool: {type: Boolean, reflect: true},
+          };
+        }
+
+        constructor() {
+          super();
+          this.nonReactiveInitialized = 123;
+          this.reactiveInitializedStr = "foo";
+          this.reactiveInitializedNum = 42;
+          this.reactiveInitializedBool = false;
+        }
+      }
+      `;
+    }
+    checkTransform(input, expected, options);
+  });
+
+  test('@property (merge with existing static properties)', () => {
+    const input = `
+    import {LitElement} from 'lit';
+    import {property} from 'lit/decorators.js';
+
+    class MyElement extends LitElement {
+      static get properties() {
+        return {
+          str: {},
+        };
+      }
+
+      @property({type: Number})
+      num = 42;
+
+      constructor() {
+        super();
+      }
+    }
+    `;
+
+    const expected = `
+    import {LitElement} from 'lit';
+
+    class MyElement extends LitElement {
+      static get properties() {
+        return {
+          str: {},
+          num: {type: Number},
+        };
+      }
+
+      constructor() {
+        super();
+        this.num = 42;
+      }
+    }
+    `;
+    checkTransform(input, expected, options);
+  });
+
+  test('@state', () => {
+    const input = `
+    import {LitElement} from 'lit';
+    import {state} from 'lit/decorators.js';
+
+    class MyElement extends LitElement {
+      @state()
+      num = 42;
+
+      @state({hasChanged: () => false})
+      num2 = 24;
+    }
+    `;
+
+    const expected = `
+    import {LitElement} from 'lit';
+
+    class MyElement extends LitElement {
+      static get properties() {
+        return {
+          num: {state: true},
+          num2: {hasChanged: () => false, state: true},
+        };
+      }
+
+      constructor() {
+        super(...arguments);
+        this.num = 42;
+        this.num2 = 24;
+      }
+    }
+    `;
+    checkTransform(input, expected, options);
+  });
+
+  test('@query (non-caching)', () => {
+    const input = `
+    import {LitElement} from 'lit';
+    import {query} from 'lit/decorators.js';
+
+    class MyElement extends LitElement {
+      @query('#myDiv')
+      div?: HTMLDivElement;
+    }
+    `;
+
+    const expected = `
+    import {LitElement} from 'lit';
+
+    class MyElement extends LitElement {
+      get div() {
+        return this.renderRoot?.querySelector('#myDiv') ?? null;
+      }
+    }
+    `;
+    checkTransform(input, expected, options);
+  });
+
+  test('@query (caching)', () => {
+    const input = `
+    import {LitElement} from 'lit';
+    import {query} from 'lit/decorators.js';
+
+    class MyElement extends LitElement {
+      @query('#mySpan', true)
+      span?: HTMLSpanElement;
+    }
+    `;
+
+    const expected = `
+    import {LitElement} from 'lit';
+
+    class MyElement extends LitElement {
+      get span() {
+        return this.__span ??= this.renderRoot?.querySelector('#mySpan') ?? null;
+      }
+    }
+    `;
+    checkTransform(input, expected, options);
+  });
+
+  test('@queryAll', () => {
+    const input = `
+    import {LitElement} from 'lit';
+    import {queryAll} from 'lit/decorators.js';
+
+    class MyElement extends LitElement {
+      @queryAll('.myInput')
+      inputs: NodeListOf<HTMLInputElement>;
+    }
+    `;
+
+    const expected = `
+    import {LitElement} from 'lit';
+
+    class MyElement extends LitElement {
+      get inputs() {
+        return this.renderRoot?.querySelectorAll('.myInput') ?? [];
+      }
+    }
+    `;
+    checkTransform(input, expected, options);
+  });
+
+  test('@queryAsync', () => {
+    const input = `
+    import {LitElement} from 'lit';
+    import {queryAsync} from 'lit/decorators.js';
+
+    class MyElement extends LitElement {
+      @queryAsync('#myButton')
+      button: Promise<HTMLElement>;
+    }
+    `;
+
+    const expected = `
+    import {LitElement} from 'lit';
+
+    class MyElement extends LitElement {
+      async get button() {
+        await this.updateComplete;
+        return this.renderRoot?.querySelector('#myButton');
+      }
+    }
+    `;
+    checkTransform(input, expected, options);
+  });
+
+  test('@queryAssignedNodes (default slot)', () => {
+    const input = `
+    import {LitElement} from 'lit';
+    import {queryAssignedNodes} from 'lit/decorators.js';
+
+    class MyElement extends LitElement {
+      @queryAssignedNodes()
+      listItems: NodeListOf<HTMLElement>;
+    }
+    `;
+
+    const expected = `
+    import {LitElement} from 'lit';
+
+    class MyElement extends LitElement {
+      get listItems() {
+        return this.renderRoot
+          ?.querySelector('slot:not([name])')
+          ?.assignedNodes() ?? [];
+      }
+    }
+    `;
+    checkTransform(input, expected, options);
+  });
+
+  test('@queryAssignedNodes (with slot name)', () => {
+    const input = `
+    import {LitElement} from 'lit';
+    import {queryAssignedNodes} from 'lit/decorators.js';
+
+    class MyElement extends LitElement {
+      @queryAssignedNodes('list')
+      listItems: NodeListOf<HTMLElement>;
+    }
+    `;
+
+    const expected = `
+    import {LitElement} from 'lit';
+
+    class MyElement extends LitElement {
+      get listItems() {
+        return this.renderRoot
+          ?.querySelector('slot[name=list]')
+          ?.assignedNodes() ?? [];
+      }
+    }
+    `;
+    checkTransform(input, expected, options);
+  });
+
+  test('@queryAssignedNodes (with flatten)', () => {
+    const input = `
+    import {LitElement} from 'lit';
+    import {queryAssignedNodes} from 'lit/decorators.js';
+
+    class MyElement extends LitElement {
+      @queryAssignedNodes('list', true)
+      listItems: NodeListOf<HTMLElement>;
+    }
+    `;
+
+    const expected = `
+    import {LitElement} from 'lit';
+
+    class MyElement extends LitElement {
+      get listItems() {
+        return this.renderRoot
+          ?.querySelector('slot[name=list]')
+          ?.assignedNodes({flatten: true}) ?? [];
+      }
+    }
+    `;
+    checkTransform(input, expected, options);
+  });
+
+  test('@queryAssignedNodes (with selector)', () => {
+    const input = `
+    import {LitElement} from 'lit';
+    import {queryAssignedNodes} from 'lit/decorators.js';
+
+    class MyElement extends LitElement {
+      @queryAssignedNodes('list', false, '.item')
+      listItems: NodeListOf<HTMLElement>;
+    }
+    `;
+
+    const expected = `
+    import {LitElement} from 'lit';
+
+    class MyElement extends LitElement {
+      get listItems() {
+        return this.renderRoot
+          ?.querySelector('slot[name=list]')
+          ?.assignedNodes()
+          ?.filter((node) =>
+            node.nodeType === Node.ELEMENT_NODE &&
+              node.matches('.item')
+          ) ?? [];
+      }
+    }
+    `;
+    checkTransform(input, expected, options);
+  });
+
+  test('private @eventOptions', () => {
+    const input = `
+    import {eventOptions} from 'lit/decorators.js';
+    import {LitElement, html} from 'lit';
+
+    class MyElement extends LitElement {
+      @eventOptions({capture: true, once: false, passive: true})
+      private _onClick(event) {
+        console.log('click', event.target);
+      }
+
+      render() {
+        return html\`
+          <button @click=\${this._onClick}></button>
+        \`;
+      }
+    }
+    `;
+
+    const expected = `
+    import {LitElement, html} from 'lit';
+
+    class MyElement extends LitElement {
+      _onClick(event) {
+        console.log('click', event.target);
+      }
+
+      render() {
+        return html\`
+          <button @click=\${{
+            handleEvent: (e) => this._onClick(e),
+            capture: true,
+            once: false,
+            passive: true
+          }}></button>
+        \`;
+      }
+    }
+    `;
+    checkTransform(input, expected, options);
+  });
+
+  test('private @eventOptions with reversed import order', () => {
+    // Regression test for a bug where import order mattered.
+    const input = `
+    import {LitElement, html} from 'lit';
+    import {eventOptions} from 'lit/decorators.js';
+
+    class MyElement extends LitElement {
+      @eventOptions({capture: true, once: false, passive: true})
+      private _onClick(event) {
+        console.log('click', event.target);
+      }
+
+      render() {
+        return html\`
+          <button @click=\${this._onClick}></button>
+        \`;
+      }
+    }
+    `;
+
+    const expected = `
+    import {LitElement, html} from 'lit';
+
+    class MyElement extends LitElement {
+      _onClick(event) {
+        console.log('click', event.target);
+      }
+
+      render() {
+        return html\`
+          <button @click=\${{
+            handleEvent: (e) => this._onClick(e),
+            capture: true,
+            once: false,
+            passive: true
+          }}></button>
+        \`;
+      }
+    }
+    `;
+    checkTransform(input, expected, options);
+  });
+
+  test('private @eventOptions but not an event binding', () => {
+    const input = `
+    import {LitElement, html, svg} from 'lit';
+    import {eventOptions} from 'lit/decorators.js';
+
+    class MyElement extends LitElement {
+      @eventOptions({capture: true, once: false, passive: true})
+      private _onClick(event) {
+        console.log('click', event.target);
+      }
+
+      a() {
+        return this._onClick;
+      }
+      b() {
+        return html\`<p click=\${this._onClick}</p>\`;
+      }
+      c() {
+        return svg\`<p @click=\${this._onClick}</p>\`;
+      }
+    }
+    `;
+
+    const expected = `
+    import {LitElement, html, svg} from 'lit';
+
+    class MyElement extends LitElement {
+      _onClick(event) {
+        console.log('click', event.target);
+      }
+
+      a() {
+        return this._onClick;
+      }
+      b() {
+        return html\`<p click=\${this._onClick}</p>\`;
+      }
+      c() {
+        return svg\`<p @click=\${this._onClick}</p>\`;
+      }
+    }
+    `;
+    checkTransform(input, expected, options);
+  });
+
+  test('private @eventOptions but different html tag', () => {
+    const input = `
+    import {LitElement} from 'lit';
+    import {eventOptions} from 'lit/decorators.js';
+    import {html} from './not-lit.js';
+
+    class MyElement extends LitElement {
+      @eventOptions({capture: true, once: false, passive: true})
+      private _onClick(event) {
+        console.log('click', event.target);
+      }
+
+      render() {
+        return html\`<p @click=\${this._onClick}</p>\`;
+      }
+    }
+    `;
+
+    const expected = `
+    import {LitElement} from 'lit';
+    import {html} from './not-lit.js';
+
+    class MyElement extends LitElement {
+      _onClick(event) {
+        console.log('click', event.target);
+      }
+
+      render() {
+        return html\`<p @click=\${this._onClick}</p>\`;
+      }
+    }
+    `;
+    checkTransform(input, expected, options);
+  });
+
+  test('public @eventOptions', () => {
+    const input = `
+    import {LitElement, html} from 'lit';
+    import {eventOptions} from 'lit/decorators.js';
+
+    class MyElement extends LitElement {
+      @eventOptions({capture: true, once: false, passive: true})
+      _onClick(event) {
+        console.log('click', event.target);
+      }
+
+      render() {
+        return html\`
+          <button @click=\${this._onClick}></button>
+        \`;
+      }
+    }
+    `;
+
+    const expected = `
+    import {LitElement, html} from 'lit';
+
+    class MyElement extends LitElement {
+      _onClick(event) {
+        console.log('click', event.target);
+      }
+
+      render() {
+        return html\`
+          <button @click=\${this._onClick}></button>
+        \`;
+      }
+    }
+    Object.assign(MyElement.prototype._onClick, {
+      capture: true,
+      once: false,
+      passive: true
+    });
+    `;
+    checkTransform(input, expected, options);
+  });
+
+  for (const specifier of [
+    'lit/decorators.js',
+    'lit/decorators/custom-element.js',
+    '@lit/reactive-element/decorators.js',
+    '@lit/reactive-element/decorators/custom-element.js',
+    'lit-element',
+    'lit-element/index.js',
+    'lit-element/decorators.js',
+  ]) {
+    test(`various valid import specifiers [${specifier}]`, () => {
+      const input = `
+      import {LitElement} from 'lit';
+      import {customElement} from '${specifier}';
+
+      @customElement('my-element')
+      class MyElement extends LitElement {
+      }
+      `;
+
+      const expected = `
+      import {LitElement} from 'lit';
+
+      class MyElement extends LitElement {
+      }
+      customElements.define('my-element', MyElement);
+      `;
+      checkTransform(input, expected, options);
+    });
+  }
+
+  for (const specifier of [
+    'lit/decorators',
+    'lit/decorators/custom-element',
+    '@lit/reactive-element/decorators',
+    '@lit/reactive-element/decorators/custom-element',
+    'lit-element/index',
+    'lit-element/decorators',
+  ]) {
+    test(`various invalid import specifiers [${specifier}]`, () => {
+      const input = `
+      import {LitElement} from 'lit';
+      import {customElement} from '${specifier}';
+
+      @customElement('my-element')
+      class MyElement extends LitElement {
+      }
+      `;
+      assert.throws(
+        () => checkTransform(input, '', options),
+        `Invalid Lit import style. Did you mean '${specifier}.js'?`
+      );
+    });
+  }
+
+  test('only remove imports that will be transformed', () => {
+    const input = `
+    import {LitElement, customElement} from 'lit-element';
 
     @customElement('my-element')
     class MyElement extends LitElement {
     }
     `;
-    assert.throws(
-      () => checkTransform(input, ''),
-      `Invalid Lit import style. Did you mean '${specifier}.js'?`
-    );
+
+    const expected = `
+    import {LitElement} from 'lit-element';
+
+    class MyElement extends LitElement {
+    }
+    customElements.define('my-element', MyElement);
+    `;
+    checkTransform(input, expected, options);
   });
-}
 
-test('only remove imports that will be transformed', () => {
-  const input = `
-  import {LitElement, customElement} from 'lit-element';
+  test("don't remove existing no-binding import", () => {
+    const input = `
+    import {LitElement, customElement} from 'lit-element';
+    import './my-custom-element.js';
 
-  @customElement('my-element')
-  class MyElement extends LitElement {
-  }
-  `;
+    @customElement('my-element')
+    class MyElement extends LitElement {
+    }
+    `;
 
-  const expected = `
-  import {LitElement} from 'lit-element';
+    const expected = `
+    import {LitElement} from 'lit-element';
+    import './my-custom-element.js';
 
-  class MyElement extends LitElement {
-  }
-  customElements.define('my-element', MyElement);
-  `;
-  checkTransform(input, expected);
-});
+    class MyElement extends LitElement {
+    }
+    customElements.define('my-element', MyElement);
+    `;
+    checkTransform(input, expected, options);
+  });
 
-test("don't remove existing no-binding import", () => {
-  const input = `
-  import {LitElement, customElement} from 'lit-element';
-  import './my-custom-element.js';
+  test('ignore non-lit class decorator', () => {
+    const input = `
+    import {LitElement} from 'lit';
+    import {customElement} from './not-lit.js';
 
-  @customElement('my-element')
-  class MyElement extends LitElement {
-  }
-  `;
+    @customElement('my-element')
+    class MyElement extends LitElement {
+    }
+    `;
 
-  const expected = `
-  import {LitElement} from 'lit-element';
-  import './my-custom-element.js';
+    const expected = `
+    import {__decorate} from 'tslib';
+    import {LitElement} from 'lit';
+    import {customElement} from './not-lit.js';
 
-  class MyElement extends LitElement {
-  }
-  customElements.define('my-element', MyElement);
-  `;
-  checkTransform(input, expected);
-});
+    let MyElement = class MyElement extends LitElement {};
 
-test('ignore non-lit class decorator', () => {
-  const input = `
-  import {LitElement} from 'lit';
-  import {customElement} from './not-lit.js';
+    MyElement = __decorate([customElement("my-element")], MyElement);
+    `;
+    checkTransform(input, expected, options);
+  });
 
-  @customElement('my-element')
-  class MyElement extends LitElement {
-  }
-  `;
+  test('ignore non-lit method decorator', () => {
+    const input = `
+    import {LitElement} from 'lit';
+    import {property} from './not-lit.js';
 
-  const expected = `
-  import {__decorate} from 'tslib';
-  import {LitElement} from 'lit';
-  import {customElement} from './not-lit.js';
+    class MyElement extends LitElement {
+      @property()
+      foo;
+    }
+    `;
 
-  let MyElement = class MyElement extends LitElement {};
+    let expected;
+    if (options.useDefineForClassFields) {
+      expected = `
+      import {__decorate} from 'tslib';
+      import {LitElement} from 'lit';
+      import {property} from './not-lit.js';
 
-  MyElement = __decorate([customElement("my-element")], MyElement);
-  `;
-  checkTransform(input, expected);
-});
-
-test('ignore non-lit method decorator', () => {
-  const input = `
-  import {LitElement} from 'lit';
-  import {property} from './not-lit.js';
-
-  class MyElement extends LitElement {
-    @property()
-    foo;
-  }
-  `;
-
-  const expected = `
-  import {__decorate} from 'tslib';
-  import {LitElement} from 'lit';
-  import {property} from './not-lit.js';
-
-  class MyElement extends LitElement {
-    foo;
-  };
-  __decorate([property()], MyElement.prototype, "foo", void 0);
-  `;
-  checkTransform(input, expected);
-});
-
-test('aliased class decorator import', () => {
-  const input = `
-  import {LitElement} from 'lit';
-  import {customElement as cabbage} from 'lit/decorators.js';
-
-  @cabbage('my-element')
-  class MyElement extends LitElement {
-  }
-  `;
-
-  const expected = `
-  import {LitElement} from 'lit';
-
-  class MyElement extends LitElement {
-  }
-  customElements.define('my-element', MyElement);
-  `;
-  checkTransform(input, expected);
-});
-
-test('aliased property decorator import', () => {
-  const input = `
-  import {LitElement} from 'lit';
-  import {property as potato} from 'lit/decorators.js';
-
-  class MyElement extends LitElement {
-    @potato()
-    str = "foo";
-
-    @potato({type: Number, attribute: false})
-    num = 42;
-  }
-  `;
-
-  const expected = `
-  import {LitElement} from 'lit';
-
-  class MyElement extends LitElement {
-    static get properties() {
-      return {
-        str: {},
-        num: {type: Number, attribute: false},
+      class MyElement extends LitElement {
+        foo;
       };
-    }
+      __decorate([property()], MyElement.prototype, "foo", void 0);
+      `;
+    } else {
+      expected = `
+      import {__decorate} from 'tslib';
+      import {LitElement} from 'lit';
+      import {property} from './not-lit.js';
 
-    constructor() {
-      super(...arguments);
-      this.str = "foo";
-      this.num = 42;
+      class MyElement extends LitElement {
+      };
+      __decorate([property()], MyElement.prototype, "foo", void 0);
+      `;
     }
-  }
-  `;
-  checkTransform(input, expected);
-});
+    checkTransform(input, expected, options);
+  });
 
-test.run();
+  test('aliased class decorator import', () => {
+    const input = `
+    import {LitElement} from 'lit';
+    import {customElement as cabbage} from 'lit/decorators.js';
+
+    @cabbage('my-element')
+    class MyElement extends LitElement {
+    }
+    `;
+
+    const expected = `
+    import {LitElement} from 'lit';
+
+    class MyElement extends LitElement {
+    }
+    customElements.define('my-element', MyElement);
+    `;
+    checkTransform(input, expected, options);
+  });
+
+  test('aliased property decorator import', () => {
+    const input = `
+    import {LitElement} from 'lit';
+    import {property as potato} from 'lit/decorators.js';
+
+    class MyElement extends LitElement {
+      @potato()
+      str = "foo";
+
+      @potato({type: Number, attribute: false})
+      num = 42;
+    }
+    `;
+
+    const expected = `
+    import {LitElement} from 'lit';
+
+    class MyElement extends LitElement {
+      static get properties() {
+        return {
+          str: {},
+          num: {type: Number, attribute: false},
+        };
+      }
+
+      constructor() {
+        super(...arguments);
+        this.str = "foo";
+        this.num = 42;
+      }
+    }
+    `;
+    checkTransform(input, expected, options);
+  });
+
+  test.run();
+};
+
+const baseOptions = () => {
+  const options = ts.getDefaultCompilerOptions();
+  options.target = ts.ScriptTarget.ESNext;
+  options.module = ts.ModuleKind.ESNext;
+  options.moduleResolution = ts.ModuleResolutionKind.NodeJs;
+  options.importHelpers = true;
+  return options;
+};
+
+const standardOptions = baseOptions();
+standardOptions.useDefineForClassFields = true;
+tests(suite('standard class field emit'), standardOptions);
+
+const legacyOptions = baseOptions();
+legacyOptions.useDefineForClassFields = false;
+tests(suite('legacy class field emit'), legacyOptions);

--- a/packages/ts-transformers/src/tests/idiomatic-test.ts
+++ b/packages/ts-transformers/src/tests/idiomatic-test.ts
@@ -95,17 +95,28 @@ test('@customElement', () => {
   checkTransform(input, expected);
 });
 
-test('@property', () => {
+test('@property (no existing constructor)', () => {
   const input = `
   import {LitElement} from 'lit';
   import {property} from 'lit/decorators.js';
 
   class MyElement extends LitElement {
     @property()
-    str = "foo";
+    reactiveInitializedStr = "foo";
+
+    nonReactiveInitialized = 123;
+
+    @property({type: Object})
+    reactiveUninitializedObj;
 
     @property({type: Number, attribute: false})
-    num = 42;
+    reactiveInitializedNum = 42;
+
+    nonReactiveUninitialized: string;
+
+    @property({type: Boolean, reflect: true})
+    reactiveInitializedBool = false;
+
   }
   `;
 
@@ -115,15 +126,78 @@ test('@property', () => {
   class MyElement extends LitElement {
     static get properties() {
       return {
-        str: {},
-        num: {type: Number, attribute: false},
+        reactiveInitializedStr: {},
+        reactiveUninitializedObj: {type: Object},
+        reactiveInitializedNum: {type: Number, attribute: false},
+        reactiveInitializedBool: {type: Boolean, reflect: true},
       };
     }
 
     constructor() {
       super(...arguments);
-      this.str = "foo";
-      this.num = 42;
+      this.reactiveInitializedStr = "foo";
+      this.reactiveInitializedNum = 42;
+      this.reactiveInitializedBool = false;
+    }
+
+    nonReactiveInitialized = 123;
+
+    nonReactiveUninitialized;
+  }
+  `;
+  checkTransform(input, expected);
+});
+
+test('@property (existing constructor)', () => {
+  const input = `
+  import {LitElement} from 'lit';
+  import {property} from 'lit/decorators.js';
+
+  class MyElement extends LitElement {
+    @property()
+    reactiveInitializedStr = "foo";
+
+    nonReactiveInitialized = 123;
+
+    @property({type: Object})
+    reactiveUninitializedObj;
+
+    @property({type: Number, attribute: false})
+    reactiveInitializedNum = 42;
+
+    nonReactiveUninitialized: string;
+
+    @property({type: Boolean, reflect: true})
+    reactiveInitializedBool = false;
+
+    constructor() {
+      super();
+    }
+  }
+  `;
+
+  const expected = `
+  import {LitElement} from 'lit';
+
+  class MyElement extends LitElement {
+    static get properties() {
+      return {
+        reactiveInitializedStr: {},
+        reactiveUninitializedObj: {type: Object},
+        reactiveInitializedNum: {type: Number, attribute: false},
+        reactiveInitializedBool: {type: Boolean, reflect: true},
+      };
+    }
+
+    nonReactiveInitialized = 123;
+
+    nonReactiveUninitialized;
+
+    constructor() {
+      super();
+      this.reactiveInitializedStr = "foo";
+      this.reactiveInitializedNum = 42;
+      this.reactiveInitializedBool = false;
     }
   }
   `;

--- a/packages/ts-transformers/src/tests/idiomatic-test.ts
+++ b/packages/ts-transformers/src/tests/idiomatic-test.ts
@@ -25,9 +25,6 @@ const cache = new CompilerHostCache();
 function checkTransform(inputTs: string, expectedJs: string) {
   const options = ts.getDefaultCompilerOptions();
   options.target = ts.ScriptTarget.ESNext;
-  // Don't emit standard class fields. They aren't compatible with Lit. Defaults
-  // to true when target = ESNext.
-  options.useDefineForClassFields = false;
   options.module = ts.ModuleKind.ESNext;
   options.moduleResolution = ts.ModuleResolutionKind.NodeJs;
   options.importHelpers = true;
@@ -816,7 +813,9 @@ test('ignore non-lit method decorator', () => {
   import {LitElement} from 'lit';
   import {property} from './not-lit.js';
 
-  class MyElement extends LitElement {};
+  class MyElement extends LitElement {
+    foo;
+  };
   __decorate([property()], MyElement.prototype, "foo", void 0);
   `;
   checkTransform(input, expected);


### PR DESCRIPTION
**Note to reviewer**: I recommend looking at each commit separately, I tried to break it up for readability.

Transforms `@property` decorated class fields into `constructor` assignments, ***even when `useDefineForClassFields` is enabled***.

#### Context

Standard class fields are not compatible with Lit, because they are defined as own-properties on the instance, which shadow the getters/setters defined on the prototype by `ReactiveElement`.

When the TypeScript `useDefineForClassFields` compiler option is `true`, these standard class field semantics are emitted, instead of the legacy behavior where class fields were emitted as `constructor` assignments. Additionally, in TypeScript 4.4, `useDefineForClassFields` became the default when `target: ESNext`.

This PR gets in front of the standard TypeScript class field transformer to make sure that `@property` decorated class fields are always emitted as constructor assignments.

#### Example

Transforms:

```ts
class MyElement extends LitElement {
  @property()
  foo = 123;
}
```

Into:

```ts
class MyElement extends LitElement {
  constructor() {
    super(...arguments);
    this.foo = 123;
  }
}
```