### PR TITLE
[ssr] Don't assign DOM shim window.global to window

### DIFF
--- a/.changeset/khaki-grapes-shave.md
+++ b/.changeset/khaki-grapes-shave.md
@@ -1,0 +1,10 @@
+---
+'@lit-labs/ssr': patch
+---
+
+Don't assign DOM shim window.global (and hence globalThis.global) to window
+
+This means that globalThis.global will retain its Node built-ins, whereas
+before it would lose anything we didn't explicitly set on window.
+
+Fixes https://github.com/lit/lit/issues/2118

--- a/packages/labs/ssr/src/lib/dom-shim.ts
+++ b/packages/labs/ssr/src/lib/dom-shim.ts
@@ -141,14 +141,12 @@ export const getWindow = ({
 
     // Set below
     window: undefined as unknown,
-    global: undefined as unknown,
 
     // User-provided globals, like `require`
     ...props,
   };
 
   window.window = window;
-  window.global = window; // Required for node-fetch
 
   if (includeJSBuiltIns) {
     Object.assign(window, {


### PR DESCRIPTION
This means that `globalThis.global` will retain its Node built-ins, and `globalThis.global === globalThis` will hold, whereas before it would lose anything we didn't explicitly set on `window`, so something like `global.Promise` would be `undefined`.

This `window.global` assignment seems to have been done for compatibility with `node-fetch`, but I tried a `fetch` from the `demo/global/module.js` module, and the fetch seemed to work fine. Not sure if there is another invocation path I missed, but it seems ok?

Fixes https://github.com/lit/lit/issues/2118

cc @fetherston 