### PR TITLE
[react] Add React.HTMLAttributes to component props

### DIFF
--- a/.changeset/hungry-shrimps-listen.md
+++ b/.changeset/hungry-shrimps-listen.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/react': patch
+---
+
+Adds React.HTMLAttributes to component props, which enables the built-in `onXyz` event handler props.

--- a/packages/labs/react/src/create-component.ts
+++ b/packages/labs/react/src/create-component.ts
@@ -178,7 +178,7 @@ export const createComponent = <I extends HTMLElement, E>(
         setProperty(
           this._element,
           prop,
-          this.props[prop as Exclude<keyof ComponentProps, symbol>],
+          this.props[prop as keyof ComponentProps],
           oldProps ? oldProps[prop as keyof ComponentProps] : undefined,
           events
         );

--- a/packages/labs/react/src/create-component.ts
+++ b/packages/labs/react/src/create-component.ts
@@ -126,7 +126,11 @@ export const createComponent = <I extends HTMLElement, E>(
   // TODO: we might need to omit more properties from HTMLElement than just
   // 'children', but 'children' is special to JSX, so we must at least do that.
   type UserProps = React.PropsWithChildren<
-    React.PropsWithRef<Partial<Omit<I, 'children'>> & Events<E>>
+    React.PropsWithRef<
+      Partial<Omit<I, 'children'>> &
+        Events<E> &
+        React.HTMLAttributes<HTMLElement>
+    >
   >;
 
   // Props used by this component wrapper. This is the UserProps and the
@@ -174,7 +178,7 @@ export const createComponent = <I extends HTMLElement, E>(
         setProperty(
           this._element,
           prop,
-          this.props[prop as keyof ComponentProps],
+          this.props[prop as Exclude<keyof ComponentProps, symbol>],
           oldProps ? oldProps[prop as keyof ComponentProps] : undefined,
           events
         );

--- a/packages/labs/react/src/test/create-component_test.tsx
+++ b/packages/labs/react/src/test/create-component_test.tsx
@@ -280,6 +280,17 @@ suite('createComponent', () => {
     assert.equal(fooEvent2, undefined);
   });
 
+  test('can listen to native events', async () => {
+    let clickEvent!: React.MouseEvent;
+    await renderReactComponent({
+      onClick(e: React.MouseEvent) {
+        clickEvent = e;
+      },
+    });
+    el.click();
+    assert.equal(clickEvent?.type, 'click');
+  });
+
   test('can set children', async () => {
     const children = (window.React.createElement(
       'div'


### PR DESCRIPTION
Fixes #2026

The React.HTMLAttributes type contains the built-in properties and event handlers and such, including the `onFoo` synthetic event handlers.