### PR TITLE
[ts-transformers] Emit static properties as class fields

### DIFF
--- a/packages/ts-transformers/src/constructor-cleanup.ts
+++ b/packages/ts-transformers/src/constructor-cleanup.ts
@@ -6,7 +6,7 @@
 
 import * as ts from 'typescript';
 import {BLANK_LINE_PLACEHOLDER_COMMENT} from './preserve-blank-lines.js';
-import {getHeritage} from './util.js';
+import {getHeritage, isStatic} from './util.js';
 
 /**
  * TypeScript transformer which improves the readability of the default
@@ -98,11 +98,7 @@ const cleanupClassConstructor = (
     // common style.
     newCtorIdx = 0;
     for (let i = class_.members.length - 1; i >= 0; i--) {
-      const isStatic =
-        class_.members[i].modifiers?.find(
-          (modifier) => modifier.kind === ts.SyntaxKind.StaticKeyword
-        ) !== undefined;
-      if (isStatic) {
+      if (isStatic(class_.members[i])) {
         newCtorIdx = ctorIdx > i ? i + 1 : i;
         break;
       }

--- a/packages/ts-transformers/src/lit-transformer.ts
+++ b/packages/ts-transformers/src/lit-transformer.ts
@@ -367,11 +367,9 @@ export class LitTransformer {
   ) {
     const f = this._context.factory;
     const properties = [
-      ...(existingProperties?.properties
-        ? existingProperties.properties.map((prop) =>
-            cloneNode(prop, {factory: this._context.factory})
-          )
-        : []),
+      ...(existingProperties?.properties.map((prop) =>
+        cloneNode(prop, {factory: this._context.factory})
+      ) ?? []),
       ...newProperties.map(({name, options}) =>
         f.createPropertyAssignment(
           f.createIdentifier(name),

--- a/packages/ts-transformers/src/lit-transformer.ts
+++ b/packages/ts-transformers/src/lit-transformer.ts
@@ -15,6 +15,7 @@ import type {
   MemberDecoratorVisitor,
   GenericVisitor,
 } from './visitor.js';
+import {isStatic} from './util.js';
 
 /**
  * A transformer for Lit code.
@@ -291,16 +292,26 @@ export class LitTransformer {
     }
 
     if (litClassContext.reactiveProperties.length > 0) {
-      const existing = this._findExistingStaticProperties(class_);
-      if (existing !== undefined) {
-        this._litFileContext.nodeReplacements.set(existing.getter, undefined);
-      }
-      litClassContext.classMembers.unshift(
-        this._createStaticProperties(
-          existing?.properties,
-          litClassContext.reactiveProperties
-        )
+      const oldProperties =
+        this._findExistingStaticPropertiesExpression(class_);
+      const newProperties = this._createStaticPropertiesExpression(
+        oldProperties,
+        litClassContext.reactiveProperties
       );
+      if (oldProperties !== undefined) {
+        this._litFileContext.nodeReplacements.set(oldProperties, newProperties);
+      } else {
+        const f = this._context.factory;
+        const staticPropertiesField = f.createPropertyDeclaration(
+          undefined,
+          [f.createModifier(ts.SyntaxKind.StaticKeyword)],
+          f.createIdentifier('properties'),
+          undefined,
+          undefined,
+          newProperties
+        );
+        litClassContext.classMembers.unshift(staticPropertiesField);
+      }
     }
 
     this._addExtraConstructorStatements(litClassContext);
@@ -345,14 +356,17 @@ export class LitTransformer {
    *     }
    *   }
    */
-  private _createStaticProperties(
-    existingProperties: ts.NodeArray<ts.ObjectLiteralElementLike> | undefined,
-    newProperties: Array<{name: string; options?: ts.ObjectLiteralExpression}>
+  private _createStaticPropertiesExpression(
+    existingProperties: ts.ObjectLiteralExpression | undefined,
+    newProperties: Array<{
+      name: string;
+      options?: ts.ObjectLiteralExpression;
+    }>
   ) {
     const f = this._context.factory;
     const properties = [
-      ...(existingProperties
-        ? existingProperties.map((prop) =>
+      ...(existingProperties?.properties
+        ? existingProperties.properties.map((prop) =>
             cloneNode(prop, {factory: this._context.factory})
           )
         : []),
@@ -363,57 +377,60 @@ export class LitTransformer {
         )
       ),
     ];
-    return f.createGetAccessorDeclaration(
-      undefined,
-      [f.createModifier(ts.SyntaxKind.StaticKeyword)],
-      f.createIdentifier('properties'),
-      [],
-      undefined,
-      f.createBlock(
-        [
-          f.createReturnStatement(
-            f.createObjectLiteralExpression(properties, true)
-          ),
-        ],
-        true
-      )
-    );
+    return f.createObjectLiteralExpression(properties, true);
   }
 
-  private _findExistingStaticProperties(class_: ts.ClassDeclaration):
-    | {
-        getter: ts.ClassElement;
-        properties: ts.NodeArray<ts.ObjectLiteralElementLike>;
-      }
-    | undefined {
-    const getter = class_.members.find(
+  private _findExistingStaticPropertiesExpression(
+    class_: ts.ClassDeclaration
+  ): ts.ObjectLiteralExpression | undefined {
+    const staticProperties = class_.members.find(
       (member) =>
-        ts.isGetAccessor(member) &&
+        isStatic(member) &&
+        member.name !== undefined &&
         ts.isIdentifier(member.name) &&
         member.name.text === 'properties'
     );
-    if (
-      getter === undefined ||
-      !ts.isGetAccessorDeclaration(getter) ||
-      getter.body === undefined
-    ) {
+    if (staticProperties === undefined) {
       return undefined;
     }
-    const returnStatement = getter.body.statements[0];
-    if (
-      returnStatement === undefined ||
-      !ts.isReturnStatement(returnStatement)
-    ) {
-      return undefined;
+    // Static class field.
+    if (ts.isPropertyDeclaration(staticProperties)) {
+      if (
+        staticProperties.initializer !== undefined &&
+        ts.isObjectLiteralExpression(staticProperties.initializer)
+      ) {
+        return staticProperties.initializer;
+      } else {
+        throw new Error(
+          'Static properties class field initializer must be an object expression.'
+        );
+      }
     }
-    const objectLiteral = returnStatement.expression;
-    if (
-      objectLiteral === undefined ||
-      !ts.isObjectLiteralExpression(objectLiteral)
-    ) {
-      return undefined;
+    // Static getter.
+    if (ts.isGetAccessorDeclaration(staticProperties)) {
+      const returnStatement = staticProperties.body?.statements[0];
+      if (
+        returnStatement === undefined ||
+        !ts.isReturnStatement(returnStatement)
+      ) {
+        throw new Error(
+          'Static properties getter must contain purely a return statement.'
+        );
+      }
+      const returnExpression = returnStatement.expression;
+      if (
+        returnExpression === undefined ||
+        !ts.isObjectLiteralExpression(returnExpression)
+      ) {
+        throw new Error(
+          'Static properties getter must return an object expression.'
+        );
+      }
+      return returnExpression;
     }
-    return {getter, properties: objectLiteral.properties};
+    throw new Error(
+      'Static properties class member must be a class field or getter.'
+    );
   }
 
   /**

--- a/packages/ts-transformers/src/util.ts
+++ b/packages/ts-transformers/src/util.ts
@@ -7,6 +7,14 @@
 import * as ts from 'typescript';
 
 /**
+ * Return whether the given node has the static keyword modifier.
+ */
+export const isStatic = (node: ts.Node) =>
+  node.modifiers?.find(
+    (modifier) => modifier.kind === ts.SyntaxKind.StaticKeyword
+  ) !== undefined;
+
+/**
  * Return each class declaration in the given nodes lineage, including the given
  * node. Use the given type checker for resolving parent class names.
  */


### PR DESCRIPTION
1. Updates the transformers so that we emit `static properties = { ... }` instead of `static get properties() { return { ... }; }`.

2. If there is an existing `static properties` field *or* getter, then we will augment whatever is already there with new properties, without changing the syntax.

3. Found and fixed a new weird bug that only cropped up after this change for some reason, relating to the difference between `class.decorators = []` and `class.decorators = undefined`. When `decorators` is an empty array, there is sometimes some no-op decorator transform cruft left around by the transform, like this:
   ```ts
   MyElement = __decorate([], MyElement)
   ```
   I believe this is due to some conditionals in the built-in transform like `if (class.decorators)` as opposed to `if (class.decorators && class.decorators.length > 0)`.