### PR TITLE
[lit-html] Add test for sync AsyncDirective.setValue() call

### DIFF
--- a/.changeset/twelve-squids-appear.md
+++ b/.changeset/twelve-squids-appear.md
@@ -1,0 +1,5 @@
+---
+'lit-html': patch
+---
+
+Add test for AsyncDirectives that synchronously call this.setValue()

--- a/packages/lit-html/src/test/lit-html_test.ts
+++ b/packages/lit-html/src/test/lit-html_test.ts
@@ -2197,8 +2197,10 @@ suite('lit-html', () => {
 
     test('async directive can call setValue synchronously', () => {
       assertRender(
-        html`<div foo=${syncAsyncDirective('test')}></div>`,
-        '<div foo="test"></div>'
+        html`<div foo=${syncAsyncDirective('test')}>${syncAsyncDirective(
+          'test'
+        )}</div>`,
+        '<div foo="test">test</div>'
       );
     });
 

--- a/packages/lit-html/src/test/lit-html_test.ts
+++ b/packages/lit-html/src/test/lit-html_test.ts
@@ -2176,6 +2176,7 @@ suite('lit-html', () => {
     }
     const aDirective = directive(ADirective);
     let aDirectiveInst: ADirective;
+
     const bDirective = directive(
       class extends Directive {
         count = 0;
@@ -2184,6 +2185,22 @@ suite('lit-html', () => {
         }
       }
     );
+
+    const syncAsyncDirective = directive(
+      class extends AsyncDirective {
+        render(x: string) {
+          this.setValue(x);
+          return noChange;
+        }
+      }
+    );
+
+    test('async directive can call setValue synchronously', () => {
+      assertRender(
+        html`<div foo=${syncAsyncDirective('test')}></div>`,
+        '<div foo="test"></div>'
+      );
+    });
 
     test('async directives in ChildPart', async () => {
       const template = (promise: Promise<unknown>) =>


### PR DESCRIPTION
Fixes #1541 

This is just some assurance that `setValue()` works synchronously as well, since we don't want to add code to prevent it .