### PR TITLE
Remove dynamic naming for `DEV_MODE` polyfill support functions.

### DIFF
--- a/.changeset/spicy-shirts-repair.md
+++ b/.changeset/spicy-shirts-repair.md
@@ -1,0 +1,7 @@
+---
+'lit-element': patch
+'lit-html': patch
+'@lit/reactive-element': patch
+---
+
+Replace dynamic name lookups for polyfill support functions with static names.

--- a/packages/lit-element/src/lit-element.ts
+++ b/packages/lit-element/src/lit-element.ts
@@ -168,9 +168,10 @@ export class LitElement extends ReactiveElement {
 globalThis.litElementHydrateSupport?.({LitElement});
 
 // Apply polyfills if available
-globalThis[`litElementPolyfillSupport${DEV_MODE ? `DevMode` : ``}`]?.({
-  LitElement,
-});
+const polyfillSupport = DEV_MODE
+  ? globalThis.litElementPolyfillSupportDevMode
+  : globalThis.litElementPolyfillSupport;
+polyfillSupport?.({LitElement});
 
 // DEV mode warnings
 if (DEV_MODE) {
@@ -196,7 +197,7 @@ if (DEV_MODE) {
     };
     warnRemovedOrRenamed(this, 'render');
     warnRemovedOrRenamed(this, 'getStyles', true);
-    warnRemovedOrRenamed(this.prototype, 'adoptStyles');
+    warnRemovedOrRenamed(this.prototype as {}, 'adoptStyles');
     return true;
   };
   /* eslint-enable @typescript-eslint/no-explicit-any */

--- a/packages/lit-element/src/lit-element.ts
+++ b/packages/lit-element/src/lit-element.ts
@@ -197,7 +197,7 @@ if (DEV_MODE) {
     };
     warnRemovedOrRenamed(this, 'render');
     warnRemovedOrRenamed(this, 'getStyles', true);
-    warnRemovedOrRenamed(this.prototype as {}, 'adoptStyles');
+    warnRemovedOrRenamed(this.prototype, 'adoptStyles');
     return true;
   };
   /* eslint-enable @typescript-eslint/no-explicit-any */

--- a/packages/lit-element/src/polyfill-support.ts
+++ b/packages/lit-element/src/polyfill-support.ts
@@ -47,11 +47,7 @@ interface PatchableLitElement extends HTMLElement {
 // eslint-disable-next-line no-var
 var DEV_MODE = true;
 
-globalThis[`litElementPolyfillSupport${DEV_MODE ? `DevMode` : ``}`] ??= ({
-  LitElement,
-}: {
-  LitElement: PatchableLitElement;
-}) => {
+const polyfillSupport = ({LitElement}: {LitElement: PatchableLitElement}) => {
   // polyfill-support is only needed if ShadyCSS or the ApplyShim is in use
   // We test at the point of patching, which makes it safe to load
   // webcomponentsjs and polyfill-support in either order
@@ -84,3 +80,9 @@ globalThis[`litElementPolyfillSupport${DEV_MODE ? `DevMode` : ``}`] ??= ({
     return createRenderRoot.call(this);
   };
 };
+
+if (DEV_MODE) {
+  globalThis.litElementPolyfillSupportDevMode ??= polyfillSupport;
+} else {
+  globalThis.litElementPolyfillSupport ??= polyfillSupport;
+}

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -1740,10 +1740,10 @@ export const _$LH = {
 };
 
 // Apply polyfills if available
-globalThis[`litHtmlPolyfillSupport${DEV_MODE ? `DevMode` : ``}`]?.(
-  Template,
-  ChildPart
-);
+const polyfillSupport = DEV_MODE
+  ? window.litHtmlPolyfillSupportDevMode
+  : window.litHtmlPolyfillSupport;
+polyfillSupport?.(Template, ChildPart);
 
 // IMPORTANT: do not change the property name or the assignment expression.
 // This line will be used in regexes to search for lit-html usage.

--- a/packages/lit-html/src/polyfill-support.ts
+++ b/packages/lit-html/src/polyfill-support.ts
@@ -25,6 +25,8 @@
  * @packageDocumentation
  */
 
+export {};
+
 interface RenderOptions {
   readonly renderBefore?: ChildNode | null;
   scope?: string;
@@ -95,7 +97,7 @@ var DEV_MODE = true;
  * * ChildPart.prototype._$getTemplate
  * * ChildPart.prototype._$setValue
  */
-globalThis[`litHtmlPolyfillSupport${DEV_MODE ? `DevMode` : ``}`] ??= (
+const polyfillSupport = (
   Template: PatchableTemplateConstructor,
   ChildPart: PatchableChildPartConstructor
 ) => {
@@ -289,7 +291,11 @@ globalThis[`litHtmlPolyfillSupport${DEV_MODE ? `DevMode` : ``}`] ??= (
 };
 
 if (ENABLE_SHADYDOM_NOPATCH) {
-  globalThis[
-    `litHtmlPolyfillSupport${DEV_MODE ? `DevMode` : ``}`
-  ]!.noPatchSupported = ENABLE_SHADYDOM_NOPATCH;
+  polyfillSupport.noPatchSupported = ENABLE_SHADYDOM_NOPATCH;
+}
+
+if (DEV_MODE) {
+  globalThis.litHtmlPolyfillSupportDevMode ??= polyfillSupport;
+} else {
+  globalThis.litHtmlPolyfillSupport ??= polyfillSupport;
 }

--- a/packages/reactive-element/src/polyfill-support.ts
+++ b/packages/reactive-element/src/polyfill-support.ts
@@ -16,6 +16,8 @@
  * @packageDocumentation
  */
 
+export {};
+
 interface RenderOptions {
   readonly renderBefore?: ChildNode | null;
   scope?: string;
@@ -48,7 +50,7 @@ interface PatchableReactiveElement extends HTMLElement {
 // eslint-disable-next-line no-var
 var DEV_MODE = true;
 
-globalThis[`reactiveElementPolyfillSupport${DEV_MODE ? `DevMode` : ``}`] ??= ({
+const polyfillSupport = ({
   ReactiveElement,
 }: {
   ReactiveElement: PatchableReactiveElement;
@@ -155,3 +157,9 @@ globalThis[`reactiveElementPolyfillSupport${DEV_MODE ? `DevMode` : ``}`] ??= ({
     didUpdate.call(this, changedProperties);
   };
 };
+
+if (DEV_MODE) {
+  globalThis.reactiveElementPolyfillSupportDevMode ??= polyfillSupport;
+} else {
+  globalThis.reactiveElementPolyfillSupport ??= polyfillSupport;
+}

--- a/packages/reactive-element/src/reactive-element.ts
+++ b/packages/reactive-element/src/reactive-element.ts
@@ -38,6 +38,10 @@ let requestUpdateThenable: (name: string) => {
 
 let issueWarning: (code: string, warning: string) => void;
 
+const polyfillSupport = DEV_MODE
+  ? window.reactiveElementPolyfillSupportDevMode
+  : window.reactiveElementPolyfillSupport;
+
 if (DEV_MODE) {
   // Ensure warnings are issued only 1x, even if multiple versions of Lit
   // are loaded.
@@ -59,11 +63,7 @@ if (DEV_MODE) {
   );
 
   // Issue polyfill support warning.
-  if (
-    window.ShadyDOM?.inUse &&
-    globalThis[`reactiveElementPolyfillSupport${DEV_MODE ? `DevMode` : ``}`] ===
-      undefined
-  ) {
+  if (window.ShadyDOM?.inUse && polyfillSupport === undefined) {
     issueWarning(
       'polyfill-support-missing',
       `Shadow DOM is being polyfilled via \`ShadyDOM\` but ` +
@@ -1334,9 +1334,7 @@ export abstract class ReactiveElement
 }
 
 // Apply polyfills if available
-globalThis[`reactiveElementPolyfillSupport${DEV_MODE ? `DevMode` : ``}`]?.({
-  ReactiveElement,
-});
+polyfillSupport?.({ReactiveElement});
 
 // Dev mode warnings...
 if (DEV_MODE) {


### PR DESCRIPTION
These dynamic lookups cause their expression to have an implicit `any` type, which is disallowed internally.