### PR TITLE
[@lit-labs/react] Fix displayName

### DIFF
--- a/packages/labs/react/src/create-component.ts
+++ b/packages/labs/react/src/create-component.ts
@@ -169,6 +169,8 @@ export const createComponent = <I extends HTMLElement, E>(
     private _userRef?: React.Ref<unknown>;
     private _ref?: React.RefCallback<I>;
 
+    static displayName = elementClass.name;
+
     private _updateElement(oldProps?: ComponentProps) {
       if (this._element === null) {
         return;
@@ -249,11 +251,17 @@ export const createComponent = <I extends HTMLElement, E>(
     }
   }
 
-  return React.forwardRef((props?: UserProps, ref?: React.Ref<unknown>) =>
-    createElement(
-      ReactComponent,
-      {...props, __forwardedRef: ref} as ComponentProps,
-      props?.children
-    )
+  const ForwardedComponent = React.forwardRef(
+    (props?: UserProps, ref?: React.Ref<unknown>) =>
+      createElement(
+        ReactComponent,
+        {...props, __forwardedRef: ref} as ComponentProps,
+        props?.children
+      )
   );
+
+  // To ease debugging in the React Developer Tools
+  ForwardedComponent.displayName = ReactComponent.displayName;
+
+  return ForwardedComponent;
 };

--- a/packages/labs/react/src/test/create-component_test.tsx
+++ b/packages/labs/react/src/test/create-component_test.tsx
@@ -83,10 +83,7 @@ suite('createComponent', () => {
   const renderReactComponent = async (
     props?: ReactModule.ComponentProps<typeof BasicElementComponent>
   ) => {
-    window.ReactDOM.render(
-      <BasicElementComponent {...props}/>,
-      container
-    );
+    window.ReactDOM.render(<BasicElementComponent {...props} />, container);
     el = container.querySelector(elementName)! as BasicElement;
     await el.updateComplete;
   };
@@ -100,6 +97,10 @@ suite('createComponent', () => {
     el = container.querySelector(elementName)! as BasicElement;
     await el.updateComplete;
     assert.equal(el.textContent, 'Hello World');
+  });
+
+  test('has valid displayName', () => {
+    assert.equal(BasicElementComponent.displayName, 'BasicElement');
   });
 
   test('wrapper renders custom element that updates', async () => {
@@ -292,12 +293,12 @@ suite('createComponent', () => {
   });
 
   test('can set children', async () => {
-    const children = (window.React.createElement(
+    const children = window.React.createElement(
       'div'
       // Note, constructing children like this is rare and the React type expects
       // this to be an HTMLCollection even though that's not the output of
       // `createElement`.
-    ) as unknown) as HTMLCollection;
+    ) as unknown as HTMLCollection;
     await renderReactComponent({children});
     assert.equal(el.childNodes.length, 1);
     assert.equal(el.firstElementChild!.localName, 'div');


### PR DESCRIPTION
Fixes #2154

It also makes Lit React components work properly with [react-element-to-jsx-string](https://www.npmjs.com/package/react-element-to-jsx-string).