### PR TITLE
Don't throw the shadowed properties dev-mode error when a property is intentionally not reactive.

### DIFF
--- a/.changeset/unlucky-carrots-tickle.md
+++ b/.changeset/unlucky-carrots-tickle.md
@@ -1,0 +1,6 @@
+---
+'@lit/reactive-element': patch
+---
+
+Prevents the dev-mode error about shadowed properties from being thrown in
+certain cases where the property intentionally has no generated descriptor.

--- a/packages/reactive-element/src/reactive-element.ts
+++ b/packages/reactive-element/src/reactive-element.ts
@@ -601,7 +601,7 @@ export abstract class ReactiveElement
     name: PropertyKey,
     key: string | symbol,
     options: PropertyDeclaration
-  ) {
+  ): PropertyDescriptor | undefined {
     return {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       get(): any {

--- a/packages/reactive-element/src/test/decorators/property_test.ts
+++ b/packages/reactive-element/src/test/decorators/property_test.ts
@@ -340,7 +340,7 @@ suite('@property', () => {
           name,
           key,
           options
-        );
+        )!;
         return {
           get: defaultDescriptor.get,
           set(this: E, value: unknown) {

--- a/packages/reactive-element/src/test/reactive-element_test.ts
+++ b/packages/reactive-element/src/test/reactive-element_test.ts
@@ -1831,7 +1831,7 @@ suite('ReactiveElement', () => {
           name,
           key,
           options
-        );
+        )!;
         return {
           get: defaultDescriptor.get,
           set(this: E, value: unknown) {
@@ -1938,8 +1938,8 @@ suite('ReactiveElement', () => {
           name,
           key,
           options
-        );
-        const setter = defaultDescriptor.set;
+        )!;
+        const setter = defaultDescriptor.set!;
         return Object.assign(defaultDescriptor, {
           set(this: E, value: unknown) {
             setter.call(this, value);


### PR DESCRIPTION
This PR prevents the dev-mode error about shadowed properties from being thrown if the property is configured not to have a generated descriptor. This includes setting `noAccessor` in the properties block / `@property` decorator and returning undefined from `getPropertyDescriptor`.

This PR also adds `undefined` as a possible return type for `getPropertyDescriptor`, which is documented as if it should be able to do this, but currently isn't allowed due to the inferred return type. This change required adding a few `!` assertions in some existing tests.