### PR TITLE
Expand jsdoc documentation for reactive-element and lit-element.

### DIFF
--- a/.changeset/great-walls-clap.md
+++ b/.changeset/great-walls-clap.md
@@ -1,0 +1,6 @@
+---
+'lit-element': patch
+'@lit/reactive-element': patch
+---
+
+Additional documentation on Lit APIs

--- a/packages/lit-element/src/lit-element.ts
+++ b/packages/lit-element/src/lit-element.ts
@@ -142,9 +142,7 @@ export class LitElement extends ReactiveElement {
    * In `connectedCallback()` you should setup tasks that should only occur when
    * the element is connected to the document. The most common of these is
    * adding event listeners to nodes external to the element, like a keydown
-   * event handler added to the window. Typically, anything done in
-   * `connectedCallback()` should be undone when the element is disconnected —
-   * for example, removing event listeners on window to prevent memory leaks.
+   * event handler added to the window.
    *
    * ```ts
    * connectedCallback() {
@@ -152,6 +150,9 @@ export class LitElement extends ReactiveElement {
    *   addEventListener('keydown', this._handleKeydown);
    * }
    * ```
+   *
+   * Typically, anything done in `connectedCallback()` should be undone when the
+   * element is disconnected, in `disconnectedCallback()`.
    *
    * @category lifecycle
    */

--- a/packages/lit-element/src/lit-element.ts
+++ b/packages/lit-element/src/lit-element.ts
@@ -137,6 +137,22 @@ export class LitElement extends ReactiveElement {
   }
 
   /**
+   * Invoked when the component is added to the document's DOM.
+   *
+   * In `connectedCallback()` you should setup tasks that should only occur when
+   * the element is connected to the document. The most common of these is
+   * adding event listeners to nodes external to the element, like a keydown
+   * event handler added to the window. Typically, anything done in
+   * `connectedCallback()` should be undone when the element is disconnected —
+   * for example, removing event listeners on window to prevent memory leaks.
+   *
+   * ```ts
+   * connectedCallback() {
+   *   super.connectedCallback();
+   *   addEventListener('keydown', this._handleKeydown);
+   * }
+   * ```
+   *
    * @category lifecycle
    */
   override connectedCallback() {
@@ -145,6 +161,22 @@ export class LitElement extends ReactiveElement {
   }
 
   /**
+   * Invoked when the component is removed from the document's DOM.
+   *
+   * This callback is the main signal to the element that it may no longer be
+   * used. `disconnectedCallback()` should ensure that nothing is holding a
+   * reference to the element (such as event listeners added to nodes external
+   * to the element), so that it is free to be garbage collected.
+   *
+   * ```ts
+   * disconnectedCallback() {
+   *   super.disconnectedCallback();
+   *   window.removeEventListener('keydown', this._handleKeydown);
+   * }
+   * ```
+   *
+   * An element may be re-connected after being disconnected.
+   *
    * @category lifecycle
    */
   override disconnectedCallback() {

--- a/packages/reactive-element/src/reactive-element.ts
+++ b/packages/reactive-element/src/reactive-element.ts
@@ -759,11 +759,15 @@ export abstract class ReactiveElement
   private __updatePromise!: Promise<boolean>;
 
   /**
+   * Internal flag marking a pending update.
    * @category updates
    */
   isUpdatePending = false;
 
   /**
+   * Is set to `true` after the first update. Required for compatibility with
+   * server-side rendering as the element code cannot assume that `renderRoot`
+   * exists before the element `hasUpdated`.
    * @category updates
    */
   hasUpdated = false;
@@ -817,6 +821,9 @@ export abstract class ReactiveElement
   }
 
   /**
+   * Install a [[`ReactiveController`]] onto the element's reactive update
+   * cycle. LitElement automatically calls into any installed controllers during
+   * its lifecycle callbacks.
    * @category controllers
    */
   addController(controller: ReactiveController) {
@@ -831,6 +838,7 @@ export abstract class ReactiveElement
   }
 
   /**
+   * Remove a [[`ReactiveController`]] from the element.
    * @category controllers
    */
   removeController(controller: ReactiveController) {

--- a/packages/reactive-element/src/reactive-element.ts
+++ b/packages/reactive-element/src/reactive-element.ts
@@ -821,8 +821,8 @@ export abstract class ReactiveElement
   }
 
   /**
-   * Install a `ReactiveController` onto the element's reactive update cycle.
-   * LitElement automatically calls into any installed controllers during its
+   * Registers a `ReactiveController` to participate in the element's reactive update cycle.
+   * The element automatically calls into any registered controllers during its
    * lifecycle callbacks.
    * @category controllers
    */
@@ -838,7 +838,7 @@ export abstract class ReactiveElement
   }
 
   /**
-   * Remove a `ReactiveController` from the element.
+   * Removes a `ReactiveController` from the element.
    * @category controllers
    */
   removeController(controller: ReactiveController) {

--- a/packages/reactive-element/src/reactive-element.ts
+++ b/packages/reactive-element/src/reactive-element.ts
@@ -759,15 +759,15 @@ export abstract class ReactiveElement
   private __updatePromise!: Promise<boolean>;
 
   /**
-   * Internal flag marking a pending update.
+   * True if there is a pending update as a result of calling `requestUpdate()`.
+   * Should only be read.
    * @category updates
    */
   isUpdatePending = false;
 
   /**
-   * Is set to `true` after the first update. Required for compatibility with
-   * server-side rendering as the element code cannot assume that `renderRoot`
-   * exists before the element `hasUpdated`.
+   * Is set to `true` after the first update. The element code cannot assume
+   * that `renderRoot` exists before the element `hasUpdated`.
    * @category updates
    */
   hasUpdated = false;
@@ -821,9 +821,12 @@ export abstract class ReactiveElement
   }
 
   /**
-   * Registers a `ReactiveController` to participate in the element's reactive update cycle.
-   * The element automatically calls into any registered controllers during its
-   * lifecycle callbacks.
+   * Registers a `ReactiveController` to participate in the element's reactive
+   * update cycle. The element automatically calls into any registered
+   * controllers during its lifecycle callbacks.
+   *
+   * If the element is connected when `addController()` is called, the
+   * controller's `hostConnected()` callback will be immediately called.
    * @category controllers
    */
   addController(controller: ReactiveController) {

--- a/packages/reactive-element/src/reactive-element.ts
+++ b/packages/reactive-element/src/reactive-element.ts
@@ -821,9 +821,9 @@ export abstract class ReactiveElement
   }
 
   /**
-   * Install a [[`ReactiveController`]] onto the element's reactive update
-   * cycle. LitElement automatically calls into any installed controllers during
-   * its lifecycle callbacks.
+   * Install a `ReactiveController` onto the element's reactive update cycle.
+   * LitElement automatically calls into any installed controllers during its
+   * lifecycle callbacks.
    * @category controllers
    */
   addController(controller: ReactiveController) {
@@ -838,7 +838,7 @@ export abstract class ReactiveElement
   }
 
   /**
-   * Remove a [[`ReactiveController`]] from the element.
+   * Remove a `ReactiveController` from the element.
    * @category controllers
    */
   removeController(controller: ReactiveController) {


### PR DESCRIPTION
### Context

Add some documentation for some public undocumented methods in lit-element and reactive-element. Addresses github issue: https://github.com/lit/lit/issues/1883

### How

Used lit.dev documentation to guide the jsdocs, and addressed some class members that had no documentation on the lit.dev/docs/api pages.

Added some documentation for previously undocumented:
 - `LitElement.connectedCallback()`
 - `LitElement.disconnectedCallback()`
 - `ReactiveElement.hasUpdated`
 - `ReactiveElement.addController`
 - `ReactiveElement.removeController`

### Testing

Tested with mouse over in VsCode.

Thank you!