### PR TITLE
Additional documentation for `html` and `nothing`

### DIFF
--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -337,18 +337,21 @@ export const noChange = Symbol.for('lit-noChange');
 /**
  * A sentinel value that signals a ChildPart to fully clear its content.
  *
- * The values `undefined`, `null`, and the empty string `''` all render an empty
- * text node. To render nothing at all, use `nothing` provided by Lit:
- *
  * ```ts
- * import {html, nothing} from 'lit';
- *
  * const button = html`${
  *  user.isAdmin
  *    ? html`<button>DELETE</button>`
  *    : nothing
  * }`;
  * ```
+ *
+ * Prefer using `nothing` over other falsy values as it provides a consistent
+ * behavior between various expression binding contexts.
+ *
+ * In child expressions, `undefined`, `null`, `''`, and `nothing` all behave the
+ * same and render no nodes. In attribute expressions, `nothing` _removes_ the
+ * attribute, while `undefined` and `null` will render an empty string. In
+ * property expressions `nothing` becomes `undefined`.
  */
 export const nothing = Symbol.for('lit-nothing');
 

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -310,6 +310,54 @@ const tag =
 /**
  * Interprets a template literal as an HTML template that can efficiently
  * render to and update a container.
+ *
+ * ```ts
+ * const header = (title: string) => html`<h1>${title}</h1>`;
+ * ```
+ *
+ * The `html` tag takes the literal strings and embedded expression values for
+ * the tagged template literal, and returns a `TemplateResult`. The key features
+ * of template tags that Lit utilizes to make updates fast, is that the object
+ * holding the literal strings of the template is _exactly_ the same for every
+ * call to the tag for a particular template.
+ *
+ * This means that the strings can be used as a key into a cache so that Lit can
+ * do the template preparation just once, the first time it renders a template,
+ * and updates skip that work.
+ *
+ * The first time a particular lit-html template is rendered anywhere in the
+ * application, lit-html does one-time setup work to create the HTML template
+ * behind the scenes. It joins all the literal parts with a special placeholder,
+ * similar to `"{{}}"`, then creates a `<template>` and sets its `innerHTML` to
+ * the result.
+ *
+ * If we start with a template like:
+ *
+ * ```ts
+ * const header = (title) => html`<h1>${title}</h1>`;
+ * ```
+ *
+ * lit-html will generate the following HTML:
+ *
+ * ```html
+ * <h1>{{}}</h1>
+ * ```
+ *
+ * And create a `<template>` from that.
+ *
+ * Then lit-html walks the template's DOM and extracts the placeholders and
+ * records their location. The final template doesn't contain the placeholders:
+ *
+ * ```html
+ * <h1></h1>
+ * ```
+ *
+ * lit-html keeps an auxillary table of expression locations for efficient
+ * updates:
+ *
+ * ```js
+ * [{type: 'node', index: 1}]
+ * ```
  */
 export const html = tag(HTML_RESULT);
 
@@ -327,6 +375,19 @@ export const noChange = Symbol.for('lit-noChange');
 
 /**
  * A sentinel value that signals a ChildPart to fully clear its content.
+ *
+ * The values `undefined`, `null`, and the empty string `''` all render an empty
+ * text node. To render nothing at all, use `nothing` provided by Lit:
+ *
+ * ```ts
+ * import {html, nothing} from 'lit';
+ *
+ * const button = html`${
+ *  user.isAdmin
+ *    ? html`<button>DELETE</button>`
+ *    : nothing
+ * }`;
+ * ```
  */
 export const nothing = Symbol.for('lit-nothing');
 

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -315,49 +315,10 @@ const tag =
  * const header = (title: string) => html`<h1>${title}</h1>`;
  * ```
  *
- * The `html` tag takes the literal strings and embedded expression values for
- * the tagged template literal, and returns a `TemplateResult`. The key features
- * of template tags that Lit utilizes to make updates fast, is that the object
- * holding the literal strings of the template is _exactly_ the same for every
- * call to the tag for a particular template.
- *
- * This means that the strings can be used as a key into a cache so that Lit can
- * do the template preparation just once, the first time it renders a template,
- * and updates skip that work.
- *
- * The first time a particular lit-html template is rendered anywhere in the
- * application, lit-html does one-time setup work to create the HTML template
- * behind the scenes. It joins all the literal parts with a special placeholder,
- * similar to `"{{}}"`, then creates a `<template>` and sets its `innerHTML` to
- * the result.
- *
- * If we start with a template like:
- *
- * ```ts
- * const header = (title) => html`<h1>${title}</h1>`;
- * ```
- *
- * lit-html will generate the following HTML:
- *
- * ```html
- * <h1>{{}}</h1>
- * ```
- *
- * And create a `<template>` from that.
- *
- * Then lit-html walks the template's DOM and extracts the placeholders and
- * records their location. The final template doesn't contain the placeholders:
- *
- * ```html
- * <h1></h1>
- * ```
- *
- * lit-html keeps an auxillary table of expression locations for efficient
- * updates:
- *
- * ```js
- * [{type: 'node', index: 1}]
- * ```
+ * The `html` tag returns a description of the DOM to render as a value. It is
+ * lazy, meaning no work is done until the template is rendered. When rendering,
+ * if a template comes from the same expression as a previously rendered result,
+ * it's efficiently updated instead of replaced.
  */
 export const html = tag(HTML_RESULT);
 


### PR DESCRIPTION
Addresses github issue: https://github.com/lit/lit/issues/1883

### Context

Documenting lit-html's `html` and `nothing`. The API documentation is sparse so I've borrowed heavily from the original [lit-html polymer website](https://lit-html.polymer-project.org/guide/writing-templates).

Let me know if there is too much (especially in the `html` tag case) and if we only want to keep a smaller amount or something different. Intent was to share that there isn't string concatenation going on under the hood.

Identified as currently on lit.dev there is minimal documentation and they are heavily used in Lit: https://lit.dev/docs/api/templates/

### Testing

Tested with mouse over in VsCode.

Thank you!