### PR TITLE
fix: docs for queryAssignedNodes decorator

### DIFF
--- a/packages/reactive-element/src/decorators/query-assigned-nodes.ts
+++ b/packages/reactive-element/src/decorators/query-assigned-nodes.ts
@@ -17,9 +17,11 @@ import {decorateProperty} from './base.js';
 /**
  * A property decorator that converts a class property into a getter that
  * returns the `assignedNodes` of the given named `slot`. Note, the type of
- * this property should be annotated as `NodeListOf<HTMLElement>`.
+ * this property should be annotated as `Node[]` if a _falsy_ _slotName_
+ * is passed or as `HTMLElement[]` if the _slotName_ is not _falsy_.
  *
- * @param slotName A string name of the slot.
+ * @param slotName A string name of the slot or a _falsy_ value to query the
+ *     _default slot_.
  * @param flatten A boolean which when true flattens the assigned nodes,
  *     meaning any assigned nodes that are slot elements are replaced with their
  *     assigned nodes.


### PR DESCRIPTION
This fixes #2171 the documentation about the type, that should be annotated:
* [assignedNodes()](https://developer.mozilla.org/en-US/docs/Web/API/HTMLSlotElement/assignedNodes#return_value) always returns a `Node[]` for a _named slot_ it is safe to assume it will return `HTMLElement[]`.

It is furthermore documented, that passing a _falsy_ value will get you the _default slot_

_falsy_ values are crazy in JS; because of the non-explicit ternary crazy type coercion of JS is used, i.e. `@queryAssignedNodes(null)` will get you the `Nodes[]` for the default slot (and so does `''`, `undefined`). Let's hope, somebody is not too picky about it. :)