### PR TITLE
[@lit-labs/motion] Ensure `*.d.ts` files are included with production output

### DIFF
--- a/.changeset/strange-experts-do.md
+++ b/.changeset/strange-experts-do.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/motion': patch
+---
+
+Ensures `*.d.ts` files are included in production output.

--- a/.eslintignore
+++ b/.eslintignore
@@ -129,6 +129,7 @@ packages/ts-transformers/*.d.ts
 packages/ts-transformers/internal/
 packages/ts-transformers/tests/
 packages/labs/motion/development/
+packages/labs/motion/test/
 packages/labs/motion/node_modules/
 packages/labs/motion/index.*
 packages/labs/motion/animate.*

--- a/.prettierignore
+++ b/.prettierignore
@@ -115,6 +115,7 @@ packages/ts-transformers/*.d.ts
 packages/ts-transformers/internal/
 packages/ts-transformers/tests/
 packages/labs/motion/development/
+packages/labs/motion/test/
 packages/labs/motion/node_modules/
 packages/labs/motion/index.*
 packages/labs/motion/animate.*

--- a/packages/labs/motion/.gitignore
+++ b/packages/labs/motion/.gitignore
@@ -1,4 +1,5 @@
 /development/
+/test/
 /node_modules/
 /index.*
 /animate.*

--- a/packages/labs/motion/package.json
+++ b/packages/labs/motion/package.json
@@ -32,10 +32,11 @@
   ],
   "scripts": {
     "start": "web-dev-server -- --node-resolve --watch --preserve-sym-links --open demo/index.html",
-    "build": "npm run clean && tsc --build && rollup -c",
+    "build": "npm run clean && npm run build:ts --build && rollup -c",
+    "build:watch": "rollup -c --watch",
     "build:ts": "tsc --build && treemirror development . '**/*.d.ts{,.map}'",
     "build:ts:watch": "tsc  --build --watch",
-    "clean": "rm -rf {index,animate,position}.{js,js.map,d.ts} development/ test/ *.tsbuildinfo",
+    "clean": "rm -rf {index,animate,position,animate-controller}.{js,js.map,d.ts} development/ test/ *.tsbuildinfo",
     "dev": "scripts/dev.sh",
     "test": "npm run test:dev && npm run test:prod",
     "test:dev": "cd ../../tests && npx wtr '../labs/motion/development/**/*_test.js'",
@@ -54,6 +55,7 @@
     "@web/dev-server": "^0.1.22",
     "chokidar-cli": "^3.0.0",
     "concurrently": "^6.2.1",
+    "internal-scripts": "^1.0.0",
     "mocha": "^9.1.1",
     "rollup": "^2.28.2",
     "typescript": "^4.3.5"


### PR DESCRIPTION
* Fixes #2184 by ensuring `*.d.ts` files are included in the production output.
* Makes `package.json` similar to other `@lit-labs` packages.