### PR TITLE
[labs/motion] Add meaningful error when not used on LitElement

### DIFF
--- a/packages/labs/motion/src/animate.ts
+++ b/packages/labs/motion/src/animate.ts
@@ -192,6 +192,9 @@ export class Animate extends AsyncDirective {
     const firstUpdate = this._host === undefined;
     if (firstUpdate) {
       this._host = part.options?.host as LitElement;
+      if (this._host == null) {
+        throw new Error("animate directive must be used in a LitElement");
+      }
       this._host.addController(this);
       this.element = part.element;
       nodeToAnimateMap.set(this.element, this);


### PR DESCRIPTION
Because directives can be used with standalone templates, users can get confused when `animate` is not working (I had to debug the code to find the problem). Not sure if this the best way to do the check but it'd be nice to offer a more meaningful error when the host `LitElement` cannot be found. It'd be also desirable to put in the README, I can see a PR to include a mention if that's OK.