### PR TITLE
Skip Husky in the release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,5 +31,6 @@ jobs:
         with:
           publish: npm run release
         env:
+          HUSKY: 0
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Hopefully this fixes the error in the release workflow.

Husky docs: https://typicode.github.io/husky/#/?id=bypass-hooks