### PR TITLE
Add script to update global version variables

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,6 +29,7 @@ jobs:
         id: changesets
         uses: changesets/action@master
         with:
+          version: npm run version
           publish: npm run release
         env:
           HUSKY: 0

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test": "lerna run test --ignore lit --ignore lit-html --ignore lit-element --ignore @lit/reactive-element --ignore @lit-labs/motion --concurrency 1 --stream",
     "prepare": "husky install",
     "changeset": "changeset",
-    "version": "npm run changeset version",
+    "version": "npm run changeset version && npm run update-version-vars",
+    "update-version-vars": "node scripts/update-version-variables.js",
     "release": "npm run build && npm run changeset publish"
   },
   "devDependencies": {

--- a/packages/lit-element/src/lit-element.ts
+++ b/packages/lit-element/src/lit-element.ts
@@ -269,7 +269,6 @@ export const _$LE = {
 
 // IMPORTANT: do not change the property name or the assignment expression.
 // This line will be used in regexes to search for LitElement usage.
-// TODO(justinfagnani): inject version number at build time
 (globalThis.litElementVersions ??= []).push('3.0.0');
 if (DEV_MODE && globalThis.litElementVersions.length > 1) {
   issueWarning!(

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -1772,7 +1772,6 @@ polyfillSupport?.(Template, ChildPart);
 
 // IMPORTANT: do not change the property name or the assignment expression.
 // This line will be used in regexes to search for lit-html usage.
-// TODO(justinfagnani): inject version number at build time
 (globalThis.litHtmlVersions ??= []).push('2.0.0');
 if (DEV_MODE && globalThis.litHtmlVersions.length > 1) {
   issueWarning!(

--- a/packages/reactive-element/src/reactive-element.ts
+++ b/packages/reactive-element/src/reactive-element.ts
@@ -1381,7 +1381,6 @@ if (DEV_MODE) {
 
 // IMPORTANT: do not change the property name or the assignment expression.
 // This line will be used in regexes to search for ReactiveElement usage.
-// TODO(justinfagnani): inject version number at build time
 (globalThis.reactiveElementVersions ??= []).push('1.0.0');
 if (DEV_MODE && globalThis.reactiveElementVersions.length > 1) {
   issueWarning!(

--- a/scripts/update-version-variables.js
+++ b/scripts/update-version-variables.js
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright 2017 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import * as fs from 'fs/promises';
+import * as path from 'path';
+
+/**
+ * Updates a global version variable.
+ */
+const updateVersionVariable = async (packageDir, sourcePath, variableName) => {
+  // Read new version from package.json
+  const packagePath = path.resolve('./packages', packageDir, 'package.json');
+  const packageSource = await fs.readFile(packagePath, 'utf-8');
+  const packageData = JSON.parse(packageSource);
+  const {version} = packageData;
+
+  // Read source file
+  const filePath = path.resolve('./packages', packageDir, 'src', sourcePath);
+  console.log(`updating version for ${filePath} to ${version}`);
+  const fileSource = await fs.readFile(filePath, 'utf-8');
+
+  // Replace version number
+  const versionVarRegex = new RegExp(
+    `\\(globalThis\\.${variableName} \\?\\?= \\[\\]\\)\\.push\\('\\d+\\.\\d+\\.\\d+'\\)`
+  );
+  let replaced = false;
+  const newSource = fileSource.replace(versionVarRegex, () => {
+    replaced = true;
+    return `(globalThis.${variableName} ??= []).push('${version}')`;
+  });
+  if (!replaced) {
+    throw new Error(`Version variable not found: ${filePath} ${variableName}`);
+  }
+
+  // Write file
+  await fs.writeFile(filePath, newSource);
+};
+
+await Promise.all([
+  updateVersionVariable('lit-html', 'lit-html.ts', 'litHtmlVersions'),
+  updateVersionVariable('lit-element', 'lit-element.ts', 'litElementVersions'),
+  updateVersionVariable(
+    'reactive-element',
+    'reactive-element.ts',
+    'reactiveElementVersions'
+  ),
+]);

--- a/scripts/update-version-variables.js
+++ b/scripts/update-version-variables.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2017 Google LLC
+ * Copyright 2021 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
  */
 


### PR DESCRIPTION
Part of #2178

This script runs after `changeset version` and copies the new versions into the source files that have these global version variables.