### PR TITLE
Remove reference to LitElement in lit-labs/motion

### DIFF
--- a/.changeset/cold-windows-pretend.md
+++ b/.changeset/cold-windows-pretend.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/motion': patch
+---
+
+Make `animate` directive compatible with any element implementing `ReactiveControllerHost` instead of just `LitElement`.


### PR DESCRIPTION
The animate controller should be compatible with any component implementing `ReactiveControllerHost` not only LitElement, see #2197