### PR TITLE
fix: make willUpdate lifecycle hook protected

### DIFF
--- a/.changeset/empty-cobras-lick.md
+++ b/.changeset/empty-cobras-lick.md
@@ -1,0 +1,5 @@
+---
+'@lit/reactive-element': patch
+---
+
+Make `willUpdate` lifecycle hook protected

--- a/packages/reactive-element/src/reactive-element.ts
+++ b/packages/reactive-element/src/reactive-element.ts
@@ -1222,7 +1222,7 @@ export abstract class ReactiveElement
   /**
    * @category updates
    */
-  willUpdate(_changedProperties: PropertyValues) {}
+  protected willUpdate(_changedProperties: PropertyValues): void {}
 
   // Note, this is an override point for polyfill-support.
   // @internal


### PR DESCRIPTION
## What I did

Changed `willUpdate()` to be `protected`, same as related hooks: `update()`, `updated()` and `firstUpdated()`.

Fixes #2266 

Main question: should we consider this change safe for a patch release? It might break someone's code 🤔 