### PR TITLE
[localize] Add <x equiv-text> XLIFF placeholder style and use by default

### DIFF
--- a/.changeset/slimy-brooms-happen.md
+++ b/.changeset/slimy-brooms-happen.md
@@ -1,0 +1,18 @@
+---
+'@lit/localize-tools': minor
+---
+
+**BREAKING** Placeholders containing HTML markup and dynamic expressions are now
+represented in XLIFF as `<x>` tags instead of `<ph>` tags.
+
+To preserve the previous behavior of using `<ph>` tags, update your JSON config
+file and set `interchange.placeholderStyle` to `"ph"`:
+
+```json
+{
+  "interchange": {
+    "format": "xliff",
+    "placeholderStyle": "ph"
+  }
+}
+```

--- a/packages/localize-tools/config.schema.json
+++ b/packages/localize-tools/config.schema.json
@@ -114,6 +114,14 @@
                     ],
                     "type": "string"
                 },
+                "placeholderStyle": {
+                    "description": "How to represent placeholders containing HTML markup and dynamic\nexpressions. Different localization tools and services have varying support\nfor placeholder syntax.\n\nDefaults to \"x\". Options:\n\n- \"x\": Emit placeholders using <x> tags. See\n  http://docs.oasis-open.org/xliff/v1.2/os/xliff-core.html#x\n\n- \"ph\": Emit placeholders using <ph> tags. See\n  http://docs.oasis-open.org/xliff/v1.2/os/xliff-core.html#ph",
+                    "enum": [
+                        "ph",
+                        "x"
+                    ],
+                    "type": "string"
+                },
                 "xliffDir": {
                     "description": "Directory on disk to read/write .xlf XML files. For each target locale,\nthe file path \"<xliffDir>/<locale>.xlf\" will be used.",
                     "type": "string"

--- a/packages/localize-tools/src/modes/runtime.ts
+++ b/packages/localize-tools/src/modes/runtime.ts
@@ -220,9 +220,9 @@ function makeMessageString(
   // many ${} expressions, so the index of the _placeholder_ is not the same as
   // the index of the _expression_:
   //
-  //   <ph>&lt;a href="http://example.com/"></ph>
-  //   <ph>&lt;a href="${/*0*/ url}"></ph>
-  //   <ph>&lt;a href="${/*1*/ url}/${/*2*/ path}"></ph>
+  //   <x equiv-text="&lt;a href='http://example.com/'&gt;"/>
+  //   <x equiv-text="&lt;a href='${/*0*/ url}'&gt;"/>
+  //   <x equiv-text="&lt;a href='${/*1*/ url}/${/*2*/ path}'&gt;"/>
   const placeholderOrder = new Map<string, number>();
 
   const placeholderOrderKey = (

--- a/packages/localize-tools/src/tests/e2e/build-runtime-xliff-ph.test.ts
+++ b/packages/localize-tools/src/tests/e2e/build-runtime-xliff-ph.test.ts
@@ -1,0 +1,12 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {e2eGoldensTest} from './e2e-goldens-test.js';
+
+e2eGoldensTest('build-runtime-xliff-ph', [
+  '--config=lit-localize.json',
+  'build',
+]);

--- a/packages/localize-tools/src/tests/e2e/extract-xliff-fresh-ph.test.ts
+++ b/packages/localize-tools/src/tests/e2e/extract-xliff-fresh-ph.test.ts
@@ -1,0 +1,12 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {e2eGoldensTest} from './e2e-goldens-test.js';
+
+e2eGoldensTest('extract-xliff-fresh-ph', [
+  '--config=lit-localize.json',
+  'extract',
+]);

--- a/packages/localize-tools/src/types/formatters.d.ts
+++ b/packages/localize-tools/src/types/formatters.d.ts
@@ -44,4 +44,19 @@ export interface XliffConfig {
    * the file path "<xliffDir>/<locale>.xlf" will be used.
    */
   xliffDir: string;
+
+  /**
+   * How to represent placeholders containing HTML markup and dynamic
+   * expressions. Different localization tools and services have varying support
+   * for placeholder syntax.
+   *
+   * Defaults to "x". Options:
+   *
+   * - "x": Emit placeholders using <x> tags. See
+   *   http://docs.oasis-open.org/xliff/v1.2/os/xliff-core.html#x
+   *
+   * - "ph": Emit placeholders using <ph> tags. See
+   *   http://docs.oasis-open.org/xliff/v1.2/os/xliff-core.html#ph
+   */
+  placeholderStyle?: 'x' | 'ph';
 }

--- a/packages/localize-tools/testdata/build-runtime-xlb/goldens/tsout/empty.txt
+++ b/packages/localize-tools/testdata/build-runtime-xlb/goldens/tsout/empty.txt
@@ -1,1 +1,0 @@
-git won't track an empty directory

--- a/packages/localize-tools/testdata/build-runtime-xlb/input/tsout/empty.txt
+++ b/packages/localize-tools/testdata/build-runtime-xlb/input/tsout/empty.txt
@@ -1,1 +1,0 @@
-git won't track an empty directory

--- a/packages/localize-tools/testdata/build-runtime-xliff-js/goldens/lit-localize.json
+++ b/packages/localize-tools/testdata/build-runtime-xliff-js/goldens/lit-localize.json
@@ -10,6 +10,7 @@
   },
   "interchange": {
     "format": "xliff",
-    "xliffDir": "xliff/"
+    "xliffDir": "xliff/",
+    "placeholderStyle": "ph"
   }
 }

--- a/packages/localize-tools/testdata/build-runtime-xliff-js/input/lit-localize.json
+++ b/packages/localize-tools/testdata/build-runtime-xliff-js/input/lit-localize.json
@@ -10,6 +10,7 @@
   },
   "interchange": {
     "format": "xliff",
-    "xliffDir": "xliff/"
+    "xliffDir": "xliff/",
+    "placeholderStyle": "ph"
   }
 }

--- a/packages/localize-tools/testdata/build-runtime-xliff-ph/goldens/foo.ts
+++ b/packages/localize-tools/testdata/build-runtime-xliff-ph/goldens/foo.ts
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {html} from 'lit';
+import {msg, str} from '@lit/localize';
+
+const user = 'Friend';
+const url = 'https://www.example.com/';
+
+// Plain string
+msg('Hello World!');
+
+// Plain string with expression
+msg(str`Hello ${user}!`);
+
+// Lit template
+msg(html`Hello <b>World</b>!`);
+
+// Lit template with variable expression (one placeholder)
+msg(html`Hello <b>${user}</b>!`);
+
+// Lit template with variable expression (two placeholders)
+msg(html`Click <a href=${url}>here</a>!`);
+
+// Lit template with string expression
+//
+// TODO(aomarks) The "SALT" text is here because we have a check to make sure
+// that two messages can't have the same ID unless they have identical template
+// contents. After https://github.com/lit/lit/issues/1621 is
+// implemented, add a "meaning" parameter instead.
+msg(html`[SALT] Click <a href="${'https://www.example.com/'}">here</a>!`);
+
+// Lit template with nested msg expression
+msg(html`[SALT] Hello <b>${msg('World')}</b>!`);
+
+// Lit template with comment
+msg(html`Hello <b><!-- comment -->World</b>!`);
+
+// Lit template with expression order inversion
+msg(html`a:${'A'} b:${'B'} c:${'C'}`);
+
+// Custom ID
+msg('Hello World', {id: 'myId'});
+
+// Description
+msg('described 0', {desc: 'Description of 0'});
+
+// This example has 4 <ph> placeholders. The 2nd has two expressions, and the
+// rest have 0 expressions. Ensure that we index these expressions as [0, 1] by
+// counting _expressions_, instead of [2, 2] by counting _placeholders_ See
+// https://github.com/lit/lit/issues/1896).
+const urlBase = 'http://example.com/';
+const urlPath = 'foo';
+msg(html`<b>Hello</b>! Click <a href="${urlBase}/${urlPath}">here</a>!`);
+
+// Escaped markup characters should remain escaped
+msg(html`&lt;Hello<b>&lt;World &amp; Friends&gt;</b>!&gt;`);

--- a/packages/localize-tools/testdata/build-runtime-xliff-ph/goldens/lit-localize.json
+++ b/packages/localize-tools/testdata/build-runtime-xliff-ph/goldens/lit-localize.json
@@ -2,15 +2,20 @@
   "$schema": "../../../config.schema.json",
   "sourceLocale": "en",
   "targetLocales": ["es-419", "zh_CN"],
-  "inputFiles": ["**/*.js"],
+  "tsConfig": "tsconfig.json",
   "output": {
-    "mode": "transform",
-    "outputDir": "locales",
-    "localeCodesModule": "locale-codes.js"
+    "mode": "runtime",
+    "outputDir": "tsout",
+    "localeCodesModule": "locale-codes.ts"
   },
   "interchange": {
     "format": "xliff",
     "xliffDir": "xliff/",
     "placeholderStyle": "ph"
+  },
+  "patches": {
+    "es-419": {
+      "lit": [{"before": "Mundo", "after": "Galaxia"}]
+    }
   }
 }

--- a/packages/localize-tools/testdata/build-runtime-xliff-ph/goldens/locale-codes.ts
+++ b/packages/localize-tools/testdata/build-runtime-xliff-ph/goldens/locale-codes.ts
@@ -1,0 +1,18 @@
+// Do not modify this file by hand!
+// Re-generate this file by running lit-localize.
+
+/**
+ * The locale code that templates in this source code are written in.
+ */
+export const sourceLocale = `en`;
+
+/**
+ * The other locale codes that this application is localized into. Sorted
+ * lexicographically.
+ */
+export const targetLocales = [`es-419`, `zh_CN`] as const;
+
+/**
+ * All valid project locale codes. Sorted lexicographically.
+ */
+export const allLocales = [`en`, `es-419`, `zh_CN`] as const;

--- a/packages/localize-tools/testdata/build-runtime-xliff-ph/goldens/tsconfig.json
+++ b/packages/localize-tools/testdata/build-runtime-xliff-ph/goldens/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "preserveConstEnums": true,
+    "forceConsistentCasingInFileNames": true,
+    "rootDir": "./"
+  },
+  "include": ["**/*.ts"]
+}

--- a/packages/localize-tools/testdata/build-runtime-xliff-ph/goldens/tsout/empty.txt
+++ b/packages/localize-tools/testdata/build-runtime-xliff-ph/goldens/tsout/empty.txt
@@ -1,1 +1,0 @@
-git won't track an empty directory

--- a/packages/localize-tools/testdata/build-runtime-xliff-ph/goldens/tsout/empty.txt
+++ b/packages/localize-tools/testdata/build-runtime-xliff-ph/goldens/tsout/empty.txt
@@ -1,0 +1,1 @@
+git won't track an empty directory

--- a/packages/localize-tools/testdata/build-runtime-xliff-ph/goldens/tsout/es-419.ts
+++ b/packages/localize-tools/testdata/build-runtime-xliff-ph/goldens/tsout/es-419.ts
@@ -1,0 +1,25 @@
+// Do not modify this file by hand!
+// Re-generate this file by running lit-localize
+
+import {html} from 'lit';
+import {str} from '@lit/localize';
+
+/* eslint-disable no-irregular-whitespace */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export const templates = {
+  h02c268d9b1fcb031: html`&lt;Hola<b>&lt;Mundo &amp; Amigos&gt;</b>!&gt;`,
+  h349c3c4777670217: html`[SALT] Hola <b>${0}</b>!`,
+  h3c44aff2d5f5ef6b: html`Hola <b>Mundo</b>!`,
+  h82ccc38d4d46eaa9: html`Hola <b>${0}</b>!`,
+  h8d70dfec810d1eae: html`<b>Hola</b>! Clic <a href="${0}/${1}">aquí</a>!`,
+  h99e74f744fda7e25: html`Clic <a href="${0}">aquí</a>!`,
+  hbe936ff3da20ffdf: html`Hola <b><!-- comment -->Mundo</b>!`,
+  hc1c6bfa4414cb3e3: html`[SALT] Clic <a href="${0}">aquí</a>!`,
+  hf979404a36e879cb: html`c:${2} a:${0} b:${1}`,
+  myId: `Hola Mundo`,
+  s00ad08ebae1e0f74: str`Hola ${0}!`,
+  s03c68d79ad36e8d4: `described 0`,
+  s0f19e6c4e521dd53: `Mundo`,
+  s8c0ec8d1fb9e6e32: `Hola Mundo!`,
+};

--- a/packages/localize-tools/testdata/build-runtime-xliff-ph/goldens/tsout/zh_CN.ts
+++ b/packages/localize-tools/testdata/build-runtime-xliff-ph/goldens/tsout/zh_CN.ts
@@ -1,0 +1,25 @@
+// Do not modify this file by hand!
+// Re-generate this file by running lit-localize
+
+import {html} from 'lit';
+import {str} from '@lit/localize';
+
+/* eslint-disable no-irregular-whitespace */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export const templates = {
+  h3c44aff2d5f5ef6b: html`你好 <b>世界</b>!`,
+  s8c0ec8d1fb9e6e32: `你好，世界!`,
+  s00ad08ebae1e0f74: str`Hello ${0}!`,
+  h82ccc38d4d46eaa9: html`Hello <b>${0}</b>!`,
+  h99e74f744fda7e25: html`Click <a href="${0}">here</a>!`,
+  hc1c6bfa4414cb3e3: html`[SALT] Click <a href="${0}">here</a>!`,
+  h349c3c4777670217: html`[SALT] Hello <b>${0}</b>!`,
+  s0f19e6c4e521dd53: `World`,
+  hbe936ff3da20ffdf: html`Hello <b><!-- comment -->World</b>!`,
+  hf979404a36e879cb: html`a:${0} b:${1} c:${2}`,
+  myId: `Hello World`,
+  s03c68d79ad36e8d4: `described 0`,
+  h8d70dfec810d1eae: html`<b>Hello</b>! Click <a href="${0}/${1}">here</a>!`,
+  h02c268d9b1fcb031: html`&lt;Hello<b>&lt;World &amp; Friends&gt;</b>!&gt;`,
+};

--- a/packages/localize-tools/testdata/build-runtime-xliff-ph/goldens/xliff/es-419.xlf
+++ b/packages/localize-tools/testdata/build-runtime-xliff-ph/goldens/xliff/es-419.xlf
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<file target-language="es-419" source-language="en" original="lit-localize-inputs" datatype="plaintext">
+<body>
+<trans-unit id="s8c0ec8d1fb9e6e32">
+  <source>Hello World!</source>
+  <target>Hola Mundo!</target>
+</trans-unit>
+<trans-unit id="s00ad08ebae1e0f74">
+  <source>Hello <ph id="0">${user}</ph>!</source>
+  <target>Hola <ph id="0">${user}</ph>!</target>
+</trans-unit>
+<trans-unit id="h3c44aff2d5f5ef6b">
+  <source>Hello <ph id="0">&lt;b></ph>World<ph id="1">&lt;/b></ph>!</source>
+  <target>Hola <ph id="0">&lt;b></ph>Mundo<ph id="1">&lt;/b></ph>!</target>
+</trans-unit>
+<trans-unit id="h82ccc38d4d46eaa9">
+  <source>Hello <ph id="0">&lt;b>${user}&lt;/b></ph>!</source>
+  <target>Hola <ph id="0">&lt;b>${user}&lt;/b></ph>!</target>
+</trans-unit>
+<trans-unit id="h99e74f744fda7e25">
+  <source>Click <ph id="0">&lt;a href="${url}"></ph>here<ph id="1">&lt;/a></ph>!</source>
+  <target>Clic <ph id="0">&lt;a href="${url}"></ph>aquí<ph id="1">&lt;/a></ph>!</target>
+</trans-unit>
+<trans-unit id="hc1c6bfa4414cb3e3">
+  <source>[SALT] Click <ph id="0">&lt;a href="${'https://www.example.com/'}"></ph>here<ph id="1">&lt;/a></ph>!</source>
+  <target>[SALT] Clic <ph id="0">&lt;a href="${'https://www.example.com/'}"></ph>aquí<ph id="1">&lt;/a></ph>!</target>
+</trans-unit>
+<trans-unit id="h349c3c4777670217">
+  <source>[SALT] Hello <ph id="0">&lt;b>${msg('World')}&lt;/b></ph>!</source>
+  <target>[SALT] Hola <ph id="0">&lt;b>${msg('World')}&lt;/b></ph>!</target>
+</trans-unit>
+<trans-unit id="s0f19e6c4e521dd53">
+  <source>World</source>
+  <target>Mundo</target>
+</trans-unit>
+<trans-unit id="hbe936ff3da20ffdf">
+  <source>Hello <ph id="0">&lt;b>&lt;!-- comment --></ph>World<ph id="1">&lt;/b></ph>!</source>
+  <target>Hola <ph id="0">&lt;b>&lt;!-- comment --></ph>Mundo<ph id="1">&lt;/b></ph>!</target>
+</trans-unit>
+<trans-unit id="hf979404a36e879cb">
+  <source>a:<ph id="0">${'A'}</ph> b:<ph id="1">${'B'}</ph> c:<ph id="2">${'C'}</ph></source>
+  <target>c:<ph id="2">${'C'}</ph> a:<ph id="0">${'A'}</ph> b:<ph id="1">${'B'}</ph></target>
+</trans-unit>
+<trans-unit id="myId">
+  <source>Hello World</source>
+  <target>Hola Mundo</target>
+</trans-unit>
+<trans-unit id="h8d70dfec810d1eae">
+  <source><ph id="0">&lt;b></ph>Hello<ph id="1">&lt;/b></ph>! Click <ph id="2">&lt;a href="${urlBase}/${urlPath}"></ph>here<ph id="3">&lt;/a></ph>!</source>
+  <target><ph id="0">&lt;b></ph>Hola<ph id="1">&lt;/b></ph>! Clic <ph id="2">&lt;a href="${urlBase}/${urlPath}"></ph>aquí<ph id="3">&lt;/a></ph>!</target>
+</trans-unit>
+<trans-unit id="s03c68d79ad36e8d4">
+  <note>Description of 0</note>
+  <source>described 0</source>
+  <target>described 0</target>
+</trans-unit>
+<trans-unit id="h02c268d9b1fcb031">
+  <source>&lt;Hello<ph id="0">&lt;b></ph>&lt;World &amp; Friends><ph id="1">&lt;/b></ph>!></source>
+  <target>&lt;Hola<ph id="0">&lt;b></ph>&lt;Mundo &amp; Amigos><ph id="1">&lt;/b></ph>!></target>
+</trans-unit>
+</body>
+</file>
+</xliff>

--- a/packages/localize-tools/testdata/build-runtime-xliff-ph/goldens/xliff/zh_CN.xlf
+++ b/packages/localize-tools/testdata/build-runtime-xliff-ph/goldens/xliff/zh_CN.xlf
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-strict.xsd">
+<file target-language="zh_CN" source-language="en" original="lit-localize-inputs" datatype="plaintext">
+<body>
+<trans-unit id="s8c0ec8d1fb9e6e32">
+  <source>Hello World!</source>
+  <target>你好，世界!</target>
+</trans-unit>
+<trans-unit id="h3c44aff2d5f5ef6b">
+  <source>Hello <ph id="0">&lt;b></ph>World<ph id="1">&lt;/b></ph>!</source>
+  <target>你好 <ph id="0">&lt;b></ph>世界<ph id="1">&lt;/b></ph>!</target>
+</trans-unit>
+</body>
+</file>
+</xliff>

--- a/packages/localize-tools/testdata/build-runtime-xliff-ph/input/foo.ts
+++ b/packages/localize-tools/testdata/build-runtime-xliff-ph/input/foo.ts
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {html} from 'lit';
+import {msg, str} from '@lit/localize';
+
+const user = 'Friend';
+const url = 'https://www.example.com/';
+
+// Plain string
+msg('Hello World!');
+
+// Plain string with expression
+msg(str`Hello ${user}!`);
+
+// Lit template
+msg(html`Hello <b>World</b>!`);
+
+// Lit template with variable expression (one placeholder)
+msg(html`Hello <b>${user}</b>!`);
+
+// Lit template with variable expression (two placeholders)
+msg(html`Click <a href=${url}>here</a>!`);
+
+// Lit template with string expression
+//
+// TODO(aomarks) The "SALT" text is here because we have a check to make sure
+// that two messages can't have the same ID unless they have identical template
+// contents. After https://github.com/lit/lit/issues/1621 is
+// implemented, add a "meaning" parameter instead.
+msg(html`[SALT] Click <a href="${'https://www.example.com/'}">here</a>!`);
+
+// Lit template with nested msg expression
+msg(html`[SALT] Hello <b>${msg('World')}</b>!`);
+
+// Lit template with comment
+msg(html`Hello <b><!-- comment -->World</b>!`);
+
+// Lit template with expression order inversion
+msg(html`a:${'A'} b:${'B'} c:${'C'}`);
+
+// Custom ID
+msg('Hello World', {id: 'myId'});
+
+// Description
+msg('described 0', {desc: 'Description of 0'});
+
+// This example has 4 <ph> placeholders. The 2nd has two expressions, and the
+// rest have 0 expressions. Ensure that we index these expressions as [0, 1] by
+// counting _expressions_, instead of [2, 2] by counting _placeholders_ See
+// https://github.com/lit/lit/issues/1896).
+const urlBase = 'http://example.com/';
+const urlPath= 'foo';
+msg(html`<b>Hello</b>! Click <a href="${urlBase}/${urlPath}">here</a>!`);
+
+// Escaped markup characters should remain escaped
+msg(html`&lt;Hello<b>&lt;World &amp; Friends&gt;</b>!&gt;`);

--- a/packages/localize-tools/testdata/build-runtime-xliff-ph/input/lit-localize.json
+++ b/packages/localize-tools/testdata/build-runtime-xliff-ph/input/lit-localize.json
@@ -2,15 +2,20 @@
   "$schema": "../../../config.schema.json",
   "sourceLocale": "en",
   "targetLocales": ["es-419", "zh_CN"],
-  "inputFiles": ["**/*.js"],
+  "tsConfig": "tsconfig.json",
   "output": {
-    "mode": "transform",
-    "outputDir": "locales",
-    "localeCodesModule": "locale-codes.js"
+    "mode": "runtime",
+    "outputDir": "tsout",
+    "localeCodesModule": "locale-codes.ts"
   },
   "interchange": {
     "format": "xliff",
     "xliffDir": "xliff/",
     "placeholderStyle": "ph"
+  },
+  "patches": {
+    "es-419": {
+      "lit": [{"before": "Mundo", "after": "Galaxia"}]
+    }
   }
 }

--- a/packages/localize-tools/testdata/build-runtime-xliff-ph/input/tsconfig.json
+++ b/packages/localize-tools/testdata/build-runtime-xliff-ph/input/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "preserveConstEnums": true,
+    "forceConsistentCasingInFileNames": true,
+    "rootDir": "./"
+  },
+  "include": ["**/*.ts"]
+}

--- a/packages/localize-tools/testdata/build-runtime-xliff-ph/input/tsout/empty.txt
+++ b/packages/localize-tools/testdata/build-runtime-xliff-ph/input/tsout/empty.txt
@@ -1,1 +1,0 @@
-git won't track an empty directory

--- a/packages/localize-tools/testdata/build-runtime-xliff-ph/input/tsout/empty.txt
+++ b/packages/localize-tools/testdata/build-runtime-xliff-ph/input/tsout/empty.txt
@@ -1,0 +1,1 @@
+git won't track an empty directory

--- a/packages/localize-tools/testdata/build-runtime-xliff-ph/input/xliff/es-419.xlf
+++ b/packages/localize-tools/testdata/build-runtime-xliff-ph/input/xliff/es-419.xlf
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<file target-language="es-419" source-language="en" original="lit-localize-inputs" datatype="plaintext">
+<body>
+<trans-unit id="s8c0ec8d1fb9e6e32">
+  <source>Hello World!</source>
+  <target>Hola Mundo!</target>
+</trans-unit>
+<trans-unit id="s00ad08ebae1e0f74">
+  <source>Hello <ph id="0">${user}</ph>!</source>
+  <target>Hola <ph id="0">${user}</ph>!</target>
+</trans-unit>
+<trans-unit id="h3c44aff2d5f5ef6b">
+  <source>Hello <ph id="0">&lt;b></ph>World<ph id="1">&lt;/b></ph>!</source>
+  <target>Hola <ph id="0">&lt;b></ph>Mundo<ph id="1">&lt;/b></ph>!</target>
+</trans-unit>
+<trans-unit id="h82ccc38d4d46eaa9">
+  <source>Hello <ph id="0">&lt;b>${user}&lt;/b></ph>!</source>
+  <target>Hola <ph id="0">&lt;b>${user}&lt;/b></ph>!</target>
+</trans-unit>
+<trans-unit id="h99e74f744fda7e25">
+  <source>Click <ph id="0">&lt;a href="${url}"></ph>here<ph id="1">&lt;/a></ph>!</source>
+  <target>Clic <ph id="0">&lt;a href="${url}"></ph>aquí<ph id="1">&lt;/a></ph>!</target>
+</trans-unit>
+<trans-unit id="hc1c6bfa4414cb3e3">
+  <source>[SALT] Click <ph id="0">&lt;a href="${'https://www.example.com/'}"></ph>here<ph id="1">&lt;/a></ph>!</source>
+  <target>[SALT] Clic <ph id="0">&lt;a href="${'https://www.example.com/'}"></ph>aquí<ph id="1">&lt;/a></ph>!</target>
+</trans-unit>
+<trans-unit id="h349c3c4777670217">
+  <source>[SALT] Hello <ph id="0">&lt;b>${msg('World')}&lt;/b></ph>!</source>
+  <target>[SALT] Hola <ph id="0">&lt;b>${msg('World')}&lt;/b></ph>!</target>
+</trans-unit>
+<trans-unit id="s0f19e6c4e521dd53">
+  <source>World</source>
+  <target>Mundo</target>
+</trans-unit>
+<trans-unit id="hbe936ff3da20ffdf">
+  <source>Hello <ph id="0">&lt;b>&lt;!-- comment --></ph>World<ph id="1">&lt;/b></ph>!</source>
+  <target>Hola <ph id="0">&lt;b>&lt;!-- comment --></ph>Mundo<ph id="1">&lt;/b></ph>!</target>
+</trans-unit>
+<trans-unit id="hf979404a36e879cb">
+  <source>a:<ph id="0">${'A'}</ph> b:<ph id="1">${'B'}</ph> c:<ph id="2">${'C'}</ph></source>
+  <target>c:<ph id="2">${'C'}</ph> a:<ph id="0">${'A'}</ph> b:<ph id="1">${'B'}</ph></target>
+</trans-unit>
+<trans-unit id="myId">
+  <source>Hello World</source>
+  <target>Hola Mundo</target>
+</trans-unit>
+<trans-unit id="h8d70dfec810d1eae">
+  <source><ph id="0">&lt;b></ph>Hello<ph id="1">&lt;/b></ph>! Click <ph id="2">&lt;a href="${urlBase}/${urlPath}"></ph>here<ph id="3">&lt;/a></ph>!</source>
+  <target><ph id="0">&lt;b></ph>Hola<ph id="1">&lt;/b></ph>! Clic <ph id="2">&lt;a href="${urlBase}/${urlPath}"></ph>aquí<ph id="3">&lt;/a></ph>!</target>
+</trans-unit>
+<trans-unit id="s03c68d79ad36e8d4">
+  <note>Description of 0</note>
+  <source>described 0</source>
+  <target>described 0</target>
+</trans-unit>
+<trans-unit id="h02c268d9b1fcb031">
+  <source>&lt;Hello<ph id="0">&lt;b></ph>&lt;World &amp; Friends><ph id="1">&lt;/b></ph>!></source>
+  <target>&lt;Hola<ph id="0">&lt;b></ph>&lt;Mundo &amp; Amigos><ph id="1">&lt;/b></ph>!></target>
+</trans-unit>
+</body>
+</file>
+</xliff>

--- a/packages/localize-tools/testdata/build-runtime-xliff-ph/input/xliff/zh_CN.xlf
+++ b/packages/localize-tools/testdata/build-runtime-xliff-ph/input/xliff/zh_CN.xlf
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-strict.xsd">
+<file target-language="zh_CN" source-language="en" original="lit-localize-inputs" datatype="plaintext">
+<body>
+<trans-unit id="s8c0ec8d1fb9e6e32">
+  <source>Hello World!</source>
+  <target>你好，世界!</target>
+</trans-unit>
+<trans-unit id="h3c44aff2d5f5ef6b">
+  <source>Hello <ph id="0">&lt;b></ph>World<ph id="1">&lt;/b></ph>!</source>
+  <target>你好 <ph id="0">&lt;b></ph>世界<ph id="1">&lt;/b></ph>!</target>
+</trans-unit>
+</body>
+</file>
+</xliff>

--- a/packages/localize-tools/testdata/build-runtime-xliff/goldens/tsout/empty.txt
+++ b/packages/localize-tools/testdata/build-runtime-xliff/goldens/tsout/empty.txt
@@ -1,1 +1,0 @@
-git won't track an empty directory

--- a/packages/localize-tools/testdata/build-runtime-xliff/goldens/xliff/es-419.xlf
+++ b/packages/localize-tools/testdata/build-runtime-xliff/goldens/xliff/es-419.xlf
@@ -7,57 +7,57 @@
   <target>Hola Mundo!</target>
 </trans-unit>
 <trans-unit id="s00ad08ebae1e0f74">
-  <source>Hello <ph id="0">${user}</ph>!</source>
-  <target>Hola <ph id="0">${user}</ph>!</target>
+  <source>Hello <x id="0" equiv-text="${user}"/>!</source>
+  <target>Hola <x id="0" equiv-text="${user}"/>!</target>
 </trans-unit>
 <trans-unit id="h3c44aff2d5f5ef6b">
-  <source>Hello <ph id="0">&lt;b></ph>World<ph id="1">&lt;/b></ph>!</source>
-  <target>Hola <ph id="0">&lt;b></ph>Mundo<ph id="1">&lt;/b></ph>!</target>
+  <source>Hello <x id="0" equiv-text="&lt;b>"/>World<x id="1" equiv-text="&lt;/b>"/>!</source>
+  <target>Hola <x id="0" equiv-text="&lt;b>"/>Mundo<x id="1" equiv-text="&lt;/b>"/>!</target>
 </trans-unit>
 <trans-unit id="h82ccc38d4d46eaa9">
-  <source>Hello <ph id="0">&lt;b>${user}&lt;/b></ph>!</source>
-  <target>Hola <ph id="0">&lt;b>${user}&lt;/b></ph>!</target>
+  <source>Hello <x id="0" equiv-text="&lt;b>${user}&lt;/b>"/>!</source>
+  <target>Hola <x id="0" equiv-text="&lt;b>${user}&lt;/b>"/>!</target>
 </trans-unit>
 <trans-unit id="h99e74f744fda7e25">
-  <source>Click <ph id="0">&lt;a href="${url}"></ph>here<ph id="1">&lt;/a></ph>!</source>
-  <target>Clic <ph id="0">&lt;a href="${url}"></ph>aquí<ph id="1">&lt;/a></ph>!</target>
+  <source>Click <x id="0" equiv-text="&lt;a href=&quot;${url}&quot;>"/>here<x id="1" equiv-text="&lt;/a>"/>!</source>
+  <target>Clic <x id="0" equiv-text="&lt;a href=&quot;${url}&quot;>"/>aquí<x id="1" equiv-text="&lt;/a>"/>!</target>
 </trans-unit>
 <trans-unit id="hc1c6bfa4414cb3e3">
-  <source>[SALT] Click <ph id="0">&lt;a href="${'https://www.example.com/'}"></ph>here<ph id="1">&lt;/a></ph>!</source>
-  <target>[SALT] Clic <ph id="0">&lt;a href="${'https://www.example.com/'}"></ph>aquí<ph id="1">&lt;/a></ph>!</target>
+  <source>[SALT] Click <x id="0" equiv-text="&lt;a href=&quot;${'https://www.example.com/'}&quot;>"/>here<x id="1" equiv-text="&lt;/a>"/>!</source>
+  <target>[SALT] Clic <x id="0" equiv-text="&lt;a href=&quot;${'https://www.example.com/'}&quot;>"/>aquí<x id="1" equiv-text="&lt;/a>"/>!</target>
 </trans-unit>
 <trans-unit id="h349c3c4777670217">
-  <source>[SALT] Hello <ph id="0">&lt;b>${msg('World')}&lt;/b></ph>!</source>
-  <target>[SALT] Hola <ph id="0">&lt;b>${msg('World')}&lt;/b></ph>!</target>
+  <source>[SALT] Hello <x id="0" equiv-text="&lt;b>${msg('World')}&lt;/b>"/>!</source>
+  <target>[SALT] Hola <x id="0" equiv-text="&lt;b>${msg('World')}&lt;/b>"/>!</target>
 </trans-unit>
 <trans-unit id="s0f19e6c4e521dd53">
   <source>World</source>
   <target>Mundo</target>
 </trans-unit>
 <trans-unit id="hbe936ff3da20ffdf">
-  <source>Hello <ph id="0">&lt;b>&lt;!-- comment --></ph>World<ph id="1">&lt;/b></ph>!</source>
-  <target>Hola <ph id="0">&lt;b>&lt;!-- comment --></ph>Mundo<ph id="1">&lt;/b></ph>!</target>
+  <source>Hello <x id="0" equiv-text="&lt;b>&lt;!-- comment -->"/>World<x id="1" equiv-text="&lt;/b>"/>!</source>
+  <target>Hola <x id="0" equiv-text="&lt;b>&lt;!-- comment -->"/>Mundo<x id="1" equiv-text="&lt;/b>"/>!</target>
 </trans-unit>
 <trans-unit id="hf979404a36e879cb">
-  <source>a:<ph id="0">${'A'}</ph> b:<ph id="1">${'B'}</ph> c:<ph id="2">${'C'}</ph></source>
-  <target>c:<ph id="2">${'C'}</ph> a:<ph id="0">${'A'}</ph> b:<ph id="1">${'B'}</ph></target>
+  <source>a:<x id="0" equiv-text="${'A'}"/> b:<x id="1" equiv-text="${'B'}"/> c:<x id="2" equiv-text="${'C'}"/></source>
+  <target>c:<x id="0" equiv-text="${'C'}"/> a:<x id="1" equiv-text="${'A'}"/> b:<x id="2" equiv-text="${'B'}"/></target>
 </trans-unit>
 <trans-unit id="myId">
   <source>Hello World</source>
   <target>Hola Mundo</target>
 </trans-unit>
 <trans-unit id="h8d70dfec810d1eae">
-  <source><ph id="0">&lt;b></ph>Hello<ph id="1">&lt;/b></ph>! Click <ph id="2">&lt;a href="${urlBase}/${urlPath}"></ph>here<ph id="3">&lt;/a></ph>!</source>
-  <target><ph id="0">&lt;b></ph>Hola<ph id="1">&lt;/b></ph>! Clic <ph id="2">&lt;a href="${urlBase}/${urlPath}"></ph>aquí<ph id="3">&lt;/a></ph>!</target>
+  <source><x id="0" equiv-text="&lt;b>"/>Hello<x id="1" equiv-text="&lt;/b>"/>! Click <x id="2" equiv-text="&lt;a href=&quot;${urlBase}/${urlPath}&quot;>"/>here<x id="3" equiv-text="&lt;/a>"/>!</source>
+  <target><x id="0" equiv-text="&lt;b>"/>Hola<x id="1" equiv-text="&lt;/b>"/>! Clic <x id="2" equiv-text="&lt;a href=&quot;${urlBase}/${urlPath}&quot;>"/>aquí<x id="3" equiv-text="&lt;/a>"/>!</target>
+</trans-unit>
+<trans-unit id="h02c268d9b1fcb031">
+  <source>&lt;Hello<x id="0" equiv-text="&lt;b>"/>&lt;World &amp; Friends><x id="1" equiv-text="&lt;/b>"/>!></source>
+  <target>&lt;Hola<x id="0" equiv-text="&lt;b>"/>&lt;Mundo &amp; Amigos><x id="1" equiv-text="&lt;/b>"/>!></target>
 </trans-unit>
 <trans-unit id="s03c68d79ad36e8d4">
   <note>Description of 0</note>
   <source>described 0</source>
   <target>described 0</target>
-</trans-unit>
-<trans-unit id="h02c268d9b1fcb031">
-  <source>&lt;Hello<ph id="0">&lt;b></ph>&lt;World &amp; Friends><ph id="1">&lt;/b></ph>!></source>
-  <target>&lt;Hola<ph id="0">&lt;b></ph>&lt;Mundo &amp; Amigos><ph id="1">&lt;/b></ph>!></target>
 </trans-unit>
 </body>
 </file>

--- a/packages/localize-tools/testdata/build-runtime-xliff/goldens/xliff/zh_CN.xlf
+++ b/packages/localize-tools/testdata/build-runtime-xliff/goldens/xliff/zh_CN.xlf
@@ -1,14 +1,51 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-strict.xsd">
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
 <file target-language="zh_CN" source-language="en" original="lit-localize-inputs" datatype="plaintext">
 <body>
 <trans-unit id="s8c0ec8d1fb9e6e32">
   <source>Hello World!</source>
   <target>你好，世界!</target>
 </trans-unit>
+<trans-unit id="s00ad08ebae1e0f74">
+  <source>Hello <x id="0" equiv-text="${user}"/>!</source>
+</trans-unit>
 <trans-unit id="h3c44aff2d5f5ef6b">
-  <source>Hello <ph id="0">&lt;b></ph>World<ph id="1">&lt;/b></ph>!</source>
-  <target>你好 <ph id="0">&lt;b></ph>世界<ph id="1">&lt;/b></ph>!</target>
+  <source>Hello <x id="0" equiv-text="&lt;b>"/>World<x id="1" equiv-text="&lt;/b>"/>!</source>
+  <target>你好 <x id="0" equiv-text="&lt;b>"/>世界<x id="1" equiv-text="&lt;/b>"/>!</target>
+</trans-unit>
+<trans-unit id="h82ccc38d4d46eaa9">
+  <source>Hello <x id="0" equiv-text="&lt;b>${user}&lt;/b>"/>!</source>
+</trans-unit>
+<trans-unit id="h99e74f744fda7e25">
+  <source>Click <x id="0" equiv-text="&lt;a href=&quot;${url}&quot;>"/>here<x id="1" equiv-text="&lt;/a>"/>!</source>
+</trans-unit>
+<trans-unit id="hc1c6bfa4414cb3e3">
+  <source>[SALT] Click <x id="0" equiv-text="&lt;a href=&quot;${'https://www.example.com/'}&quot;>"/>here<x id="1" equiv-text="&lt;/a>"/>!</source>
+</trans-unit>
+<trans-unit id="h349c3c4777670217">
+  <source>[SALT] Hello <x id="0" equiv-text="&lt;b>${msg('World')}&lt;/b>"/>!</source>
+</trans-unit>
+<trans-unit id="s0f19e6c4e521dd53">
+  <source>World</source>
+</trans-unit>
+<trans-unit id="hbe936ff3da20ffdf">
+  <source>Hello <x id="0" equiv-text="&lt;b>&lt;!-- comment -->"/>World<x id="1" equiv-text="&lt;/b>"/>!</source>
+</trans-unit>
+<trans-unit id="hf979404a36e879cb">
+  <source>a:<x id="0" equiv-text="${'A'}"/> b:<x id="1" equiv-text="${'B'}"/> c:<x id="2" equiv-text="${'C'}"/></source>
+</trans-unit>
+<trans-unit id="myId">
+  <source>Hello World</source>
+</trans-unit>
+<trans-unit id="h8d70dfec810d1eae">
+  <source><x id="0" equiv-text="&lt;b>"/>Hello<x id="1" equiv-text="&lt;/b>"/>! Click <x id="2" equiv-text="&lt;a href=&quot;${urlBase}/${urlPath}&quot;>"/>here<x id="3" equiv-text="&lt;/a>"/>!</source>
+</trans-unit>
+<trans-unit id="h02c268d9b1fcb031">
+  <source>&lt;Hello<x id="0" equiv-text="&lt;b>"/>&lt;World &amp; Friends><x id="1" equiv-text="&lt;/b>"/>!></source>
+</trans-unit>
+<trans-unit id="s03c68d79ad36e8d4">
+  <note>Description of 0</note>
+  <source>described 0</source>
 </trans-unit>
 </body>
 </file>

--- a/packages/localize-tools/testdata/build-runtime-xliff/input/tsout/empty.txt
+++ b/packages/localize-tools/testdata/build-runtime-xliff/input/tsout/empty.txt
@@ -1,1 +1,0 @@
-git won't track an empty directory

--- a/packages/localize-tools/testdata/build-runtime-xliff/input/xliff/es-419.xlf
+++ b/packages/localize-tools/testdata/build-runtime-xliff/input/xliff/es-419.xlf
@@ -7,57 +7,57 @@
   <target>Hola Mundo!</target>
 </trans-unit>
 <trans-unit id="s00ad08ebae1e0f74">
-  <source>Hello <ph id="0">${user}</ph>!</source>
-  <target>Hola <ph id="0">${user}</ph>!</target>
+  <source>Hello <x id="0" equiv-text="${user}"/>!</source>
+  <target>Hola <x id="0" equiv-text="${user}"/>!</target>
 </trans-unit>
 <trans-unit id="h3c44aff2d5f5ef6b">
-  <source>Hello <ph id="0">&lt;b></ph>World<ph id="1">&lt;/b></ph>!</source>
-  <target>Hola <ph id="0">&lt;b></ph>Mundo<ph id="1">&lt;/b></ph>!</target>
+  <source>Hello <x id="0" equiv-text="&lt;b>"/>World<x id="1" equiv-text="&lt;/b>"/>!</source>
+  <target>Hola <x id="0" equiv-text="&lt;b>"/>Mundo<x id="1" equiv-text="&lt;/b>"/>!</target>
 </trans-unit>
 <trans-unit id="h82ccc38d4d46eaa9">
-  <source>Hello <ph id="0">&lt;b>${user}&lt;/b></ph>!</source>
-  <target>Hola <ph id="0">&lt;b>${user}&lt;/b></ph>!</target>
+  <source>Hello <x id="0" equiv-text="&lt;b>${user}&lt;/b>"/>!</source>
+  <target>Hola <x id="0" equiv-text="&lt;b>${user}&lt;/b>"/>!</target>
 </trans-unit>
 <trans-unit id="h99e74f744fda7e25">
-  <source>Click <ph id="0">&lt;a href="${url}"></ph>here<ph id="1">&lt;/a></ph>!</source>
-  <target>Clic <ph id="0">&lt;a href="${url}"></ph>aquí<ph id="1">&lt;/a></ph>!</target>
+  <source>Click <x id="0" equiv-text="&lt;a href=&quot;${url}&quot;>"/>here<x id="1" equiv-text="&lt;/a>"/>!</source>
+  <target>Clic <x id="0" equiv-text="&lt;a href=&quot;${url}&quot;>"/>aquí<x id="1" equiv-text="&lt;/a>"/>!</target>
 </trans-unit>
 <trans-unit id="hc1c6bfa4414cb3e3">
-  <source>[SALT] Click <ph id="0">&lt;a href="${'https://www.example.com/'}"></ph>here<ph id="1">&lt;/a></ph>!</source>
-  <target>[SALT] Clic <ph id="0">&lt;a href="${'https://www.example.com/'}"></ph>aquí<ph id="1">&lt;/a></ph>!</target>
+  <source>[SALT] Click <x id="0" equiv-text="&lt;a href=&quot;${'https://www.example.com/'}&quot;>"/>here<x id="1" equiv-text="&lt;/a>"/>!</source>
+  <target>[SALT] Clic <x id="0" equiv-text="&lt;a href=&quot;${'https://www.example.com/'}&quot;>"/>aquí<x id="1" equiv-text="&lt;/a>"/>!</target>
 </trans-unit>
 <trans-unit id="h349c3c4777670217">
-  <source>[SALT] Hello <ph id="0">&lt;b>${msg('World')}&lt;/b></ph>!</source>
-  <target>[SALT] Hola <ph id="0">&lt;b>${msg('World')}&lt;/b></ph>!</target>
+  <source>[SALT] Hello <x id="0" equiv-text="&lt;b>${msg('World')}&lt;/b>"/>!</source>
+  <target>[SALT] Hola <x id="0" equiv-text="&lt;b>${msg('World')}&lt;/b>"/>!</target>
 </trans-unit>
 <trans-unit id="s0f19e6c4e521dd53">
   <source>World</source>
   <target>Mundo</target>
 </trans-unit>
 <trans-unit id="hbe936ff3da20ffdf">
-  <source>Hello <ph id="0">&lt;b>&lt;!-- comment --></ph>World<ph id="1">&lt;/b></ph>!</source>
-  <target>Hola <ph id="0">&lt;b>&lt;!-- comment --></ph>Mundo<ph id="1">&lt;/b></ph>!</target>
+  <source>Hello <x id="0" equiv-text="&lt;b>&lt;!-- comment -->"/>World<x id="1" equiv-text="&lt;/b>"/>!</source>
+  <target>Hola <x id="0" equiv-text="&lt;b>&lt;!-- comment -->"/>Mundo<x id="1" equiv-text="&lt;/b>"/>!</target>
 </trans-unit>
 <trans-unit id="hf979404a36e879cb">
-  <source>a:<ph id="0">${'A'}</ph> b:<ph id="1">${'B'}</ph> c:<ph id="2">${'C'}</ph></source>
-  <target>c:<ph id="2">${'C'}</ph> a:<ph id="0">${'A'}</ph> b:<ph id="1">${'B'}</ph></target>
+  <source>a:<x id="0" equiv-text="${'A'}"/> b:<x id="1" equiv-text="${'B'}"/> c:<x id="2" equiv-text="${'C'}"/></source>
+  <target>c:<x id="0" equiv-text="${'C'}"/> a:<x id="1" equiv-text="${'A'}"/> b:<x id="2" equiv-text="${'B'}"/></target>
 </trans-unit>
 <trans-unit id="myId">
   <source>Hello World</source>
   <target>Hola Mundo</target>
 </trans-unit>
 <trans-unit id="h8d70dfec810d1eae">
-  <source><ph id="0">&lt;b></ph>Hello<ph id="1">&lt;/b></ph>! Click <ph id="2">&lt;a href="${urlBase}/${urlPath}"></ph>here<ph id="3">&lt;/a></ph>!</source>
-  <target><ph id="0">&lt;b></ph>Hola<ph id="1">&lt;/b></ph>! Clic <ph id="2">&lt;a href="${urlBase}/${urlPath}"></ph>aquí<ph id="3">&lt;/a></ph>!</target>
+  <source><x id="0" equiv-text="&lt;b>"/>Hello<x id="1" equiv-text="&lt;/b>"/>! Click <x id="2" equiv-text="&lt;a href=&quot;${urlBase}/${urlPath}&quot;>"/>here<x id="3" equiv-text="&lt;/a>"/>!</source>
+  <target><x id="0" equiv-text="&lt;b>"/>Hola<x id="1" equiv-text="&lt;/b>"/>! Clic <x id="2" equiv-text="&lt;a href=&quot;${urlBase}/${urlPath}&quot;>"/>aquí<x id="3" equiv-text="&lt;/a>"/>!</target>
+</trans-unit>
+<trans-unit id="h02c268d9b1fcb031">
+  <source>&lt;Hello<x id="0" equiv-text="&lt;b>"/>&lt;World &amp; Friends><x id="1" equiv-text="&lt;/b>"/>!></source>
+  <target>&lt;Hola<x id="0" equiv-text="&lt;b>"/>&lt;Mundo &amp; Amigos><x id="1" equiv-text="&lt;/b>"/>!></target>
 </trans-unit>
 <trans-unit id="s03c68d79ad36e8d4">
   <note>Description of 0</note>
   <source>described 0</source>
   <target>described 0</target>
-</trans-unit>
-<trans-unit id="h02c268d9b1fcb031">
-  <source>&lt;Hello<ph id="0">&lt;b></ph>&lt;World &amp; Friends><ph id="1">&lt;/b></ph>!></source>
-  <target>&lt;Hola<ph id="0">&lt;b></ph>&lt;Mundo &amp; Amigos><ph id="1">&lt;/b></ph>!></target>
 </trans-unit>
 </body>
 </file>

--- a/packages/localize-tools/testdata/build-runtime-xliff/input/xliff/zh_CN.xlf
+++ b/packages/localize-tools/testdata/build-runtime-xliff/input/xliff/zh_CN.xlf
@@ -1,14 +1,51 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-strict.xsd">
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
 <file target-language="zh_CN" source-language="en" original="lit-localize-inputs" datatype="plaintext">
 <body>
 <trans-unit id="s8c0ec8d1fb9e6e32">
   <source>Hello World!</source>
   <target>你好，世界!</target>
 </trans-unit>
+<trans-unit id="s00ad08ebae1e0f74">
+  <source>Hello <x id="0" equiv-text="${user}"/>!</source>
+</trans-unit>
 <trans-unit id="h3c44aff2d5f5ef6b">
-  <source>Hello <ph id="0">&lt;b></ph>World<ph id="1">&lt;/b></ph>!</source>
-  <target>你好 <ph id="0">&lt;b></ph>世界<ph id="1">&lt;/b></ph>!</target>
+  <source>Hello <x id="0" equiv-text="&lt;b>"/>World<x id="1" equiv-text="&lt;/b>"/>!</source>
+  <target>你好 <x id="0" equiv-text="&lt;b>"/>世界<x id="1" equiv-text="&lt;/b>"/>!</target>
+</trans-unit>
+<trans-unit id="h82ccc38d4d46eaa9">
+  <source>Hello <x id="0" equiv-text="&lt;b>${user}&lt;/b>"/>!</source>
+</trans-unit>
+<trans-unit id="h99e74f744fda7e25">
+  <source>Click <x id="0" equiv-text="&lt;a href=&quot;${url}&quot;>"/>here<x id="1" equiv-text="&lt;/a>"/>!</source>
+</trans-unit>
+<trans-unit id="hc1c6bfa4414cb3e3">
+  <source>[SALT] Click <x id="0" equiv-text="&lt;a href=&quot;${'https://www.example.com/'}&quot;>"/>here<x id="1" equiv-text="&lt;/a>"/>!</source>
+</trans-unit>
+<trans-unit id="h349c3c4777670217">
+  <source>[SALT] Hello <x id="0" equiv-text="&lt;b>${msg('World')}&lt;/b>"/>!</source>
+</trans-unit>
+<trans-unit id="s0f19e6c4e521dd53">
+  <source>World</source>
+</trans-unit>
+<trans-unit id="hbe936ff3da20ffdf">
+  <source>Hello <x id="0" equiv-text="&lt;b>&lt;!-- comment -->"/>World<x id="1" equiv-text="&lt;/b>"/>!</source>
+</trans-unit>
+<trans-unit id="hf979404a36e879cb">
+  <source>a:<x id="0" equiv-text="${'A'}"/> b:<x id="1" equiv-text="${'B'}"/> c:<x id="2" equiv-text="${'C'}"/></source>
+</trans-unit>
+<trans-unit id="myId">
+  <source>Hello World</source>
+</trans-unit>
+<trans-unit id="h8d70dfec810d1eae">
+  <source><x id="0" equiv-text="&lt;b>"/>Hello<x id="1" equiv-text="&lt;/b>"/>! Click <x id="2" equiv-text="&lt;a href=&quot;${urlBase}/${urlPath}&quot;>"/>here<x id="3" equiv-text="&lt;/a>"/>!</source>
+</trans-unit>
+<trans-unit id="h02c268d9b1fcb031">
+  <source>&lt;Hello<x id="0" equiv-text="&lt;b>"/>&lt;World &amp; Friends><x id="1" equiv-text="&lt;/b>"/>!></source>
+</trans-unit>
+<trans-unit id="s03c68d79ad36e8d4">
+  <note>Description of 0</note>
+  <source>described 0</source>
 </trans-unit>
 </body>
 </file>

--- a/packages/localize-tools/testdata/build-transform-xliff-js/input/lit-localize.json
+++ b/packages/localize-tools/testdata/build-transform-xliff-js/input/lit-localize.json
@@ -10,6 +10,7 @@
   },
   "interchange": {
     "format": "xliff",
-    "xliffDir": "xliff/"
+    "xliffDir": "xliff/",
+    "placeholderStyle": "ph"
   }
 }

--- a/packages/localize-tools/testdata/build-transform-xliff/goldens/lit-localize.json
+++ b/packages/localize-tools/testdata/build-transform-xliff/goldens/lit-localize.json
@@ -9,6 +9,7 @@
   },
   "interchange": {
     "format": "xliff",
-    "xliffDir": "xliff/"
+    "xliffDir": "xliff/",
+    "placeholderStyle": "ph"
   }
 }

--- a/packages/localize-tools/testdata/build-transform-xliff/input/lit-localize.json
+++ b/packages/localize-tools/testdata/build-transform-xliff/input/lit-localize.json
@@ -9,6 +9,7 @@
   },
   "interchange": {
     "format": "xliff",
-    "xliffDir": "xliff/"
+    "xliffDir": "xliff/",
+    "placeholderStyle": "ph"
   }
 }

--- a/packages/localize-tools/testdata/extract-xlb-fresh/goldens/tsout/empty.txt
+++ b/packages/localize-tools/testdata/extract-xlb-fresh/goldens/tsout/empty.txt
@@ -1,1 +1,0 @@
-git won't track an empty directory

--- a/packages/localize-tools/testdata/extract-xlb-fresh/goldens/xlb/empty.txt
+++ b/packages/localize-tools/testdata/extract-xlb-fresh/goldens/xlb/empty.txt
@@ -1,1 +1,0 @@
-git won't track an empty directory

--- a/packages/localize-tools/testdata/extract-xlb-fresh/input/tsout/empty.txt
+++ b/packages/localize-tools/testdata/extract-xlb-fresh/input/tsout/empty.txt
@@ -1,1 +1,0 @@
-git won't track an empty directory

--- a/packages/localize-tools/testdata/extract-xlb-fresh/input/xlb/empty.txt
+++ b/packages/localize-tools/testdata/extract-xlb-fresh/input/xlb/empty.txt
@@ -1,1 +1,0 @@
-git won't track an empty directory

--- a/packages/localize-tools/testdata/extract-xliff-fresh-js/goldens/lit-localize.json
+++ b/packages/localize-tools/testdata/extract-xliff-fresh-js/goldens/lit-localize.json
@@ -9,6 +9,7 @@
   },
   "interchange": {
     "format": "xliff",
-    "xliffDir": "data/xliff/"
+    "xliffDir": "data/xliff/",
+    "placeholderStyle": "ph"
   }
 }

--- a/packages/localize-tools/testdata/extract-xliff-fresh-js/input/lit-localize.json
+++ b/packages/localize-tools/testdata/extract-xliff-fresh-js/input/lit-localize.json
@@ -9,6 +9,7 @@
   },
   "interchange": {
     "format": "xliff",
-    "xliffDir": "data/xliff/"
+    "xliffDir": "data/xliff/",
+    "placeholderStyle": "ph"
   }
 }

--- a/packages/localize-tools/testdata/extract-xliff-fresh-ph/goldens/data/xliff/es-419.xlf
+++ b/packages/localize-tools/testdata/extract-xliff-fresh-ph/goldens/data/xliff/es-419.xlf
@@ -3,11 +3,11 @@
 <file target-language="es-419" source-language="en" original="lit-localize-inputs" datatype="plaintext">
 <body>
 <trans-unit id="h02c268d9b1fcb031">
-  <source>&lt;Hello<x id="0" equiv-text="&lt;b>"/>&lt;World &amp; Friends><x id="1" equiv-text="&lt;/b>"/>!></source>
+  <source>&lt;Hello<ph id="0">&lt;b></ph>&lt;World &amp; Friends><ph id="1">&lt;/b></ph>!></source>
 </trans-unit>
 <trans-unit id="he7b474847636149b">
   <note>Description of Hello $(name)</note>
-  <source>Hello <x id="0" equiv-text="&lt;b>${name}"/>!<x id="1" equiv-text="&lt;/b>"/></source>
+  <source>Hello <ph id="0">&lt;b>${name}</ph>!<ph id="1">&lt;/b></ph></source>
 </trans-unit>
 <trans-unit id="s8c0ec8d1fb9e6e32">
   <note>Description of Hello World</note>

--- a/packages/localize-tools/testdata/extract-xliff-fresh-ph/goldens/data/xliff/zh_CN.xlf
+++ b/packages/localize-tools/testdata/extract-xliff-fresh-ph/goldens/data/xliff/zh_CN.xlf
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-<file target-language="es-419" source-language="en" original="lit-localize-inputs" datatype="plaintext">
+<file target-language="zh_CN" source-language="en" original="lit-localize-inputs" datatype="plaintext">
 <body>
 <trans-unit id="h02c268d9b1fcb031">
-  <source>&lt;Hello<x id="0" equiv-text="&lt;b>"/>&lt;World &amp; Friends><x id="1" equiv-text="&lt;/b>"/>!></source>
+  <source>&lt;Hello<ph id="0">&lt;b></ph>&lt;World &amp; Friends><ph id="1">&lt;/b></ph>!></source>
 </trans-unit>
 <trans-unit id="he7b474847636149b">
   <note>Description of Hello $(name)</note>
-  <source>Hello <x id="0" equiv-text="&lt;b>${name}"/>!<x id="1" equiv-text="&lt;/b>"/></source>
+  <source>Hello <ph id="0">&lt;b>${name}</ph>!<ph id="1">&lt;/b></ph></source>
 </trans-unit>
 <trans-unit id="s8c0ec8d1fb9e6e32">
   <note>Description of Hello World</note>

--- a/packages/localize-tools/testdata/extract-xliff-fresh-ph/goldens/foo.ts
+++ b/packages/localize-tools/testdata/extract-xliff-fresh-ph/goldens/foo.ts
@@ -1,0 +1,16 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {html} from 'lit';
+import {msg} from '@lit/localize';
+
+msg('Hello World!', {desc: 'Description of Hello World'});
+
+const name = 'friend';
+msg(html`Hello <b>${name}!</b>`, {desc: 'Description of Hello $(name)'});
+
+// Escaped markup characters should remain escaped
+msg(html`&lt;Hello<b>&lt;World &amp; Friends&gt;</b>!&gt;`);

--- a/packages/localize-tools/testdata/extract-xliff-fresh-ph/goldens/lit-localize.json
+++ b/packages/localize-tools/testdata/extract-xliff-fresh-ph/goldens/lit-localize.json
@@ -2,15 +2,14 @@
   "$schema": "../../../config.schema.json",
   "sourceLocale": "en",
   "targetLocales": ["es-419", "zh_CN"],
-  "inputFiles": ["**/*.js"],
+  "tsConfig": "tsconfig.json",
   "output": {
-    "mode": "transform",
-    "outputDir": "locales",
-    "localeCodesModule": "locale-codes.js"
+    "mode": "runtime",
+    "outputDir": "tsout/locales"
   },
   "interchange": {
     "format": "xliff",
-    "xliffDir": "xliff/",
+    "xliffDir": "data/xliff/",
     "placeholderStyle": "ph"
   }
 }

--- a/packages/localize-tools/testdata/extract-xliff-fresh-ph/goldens/tsconfig.json
+++ b/packages/localize-tools/testdata/extract-xliff-fresh-ph/goldens/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "preserveConstEnums": true,
+    "forceConsistentCasingInFileNames": true,
+    "rootDir": "./"
+  },
+  "include": ["**/*.ts"]
+}

--- a/packages/localize-tools/testdata/extract-xliff-fresh-ph/input/foo.ts
+++ b/packages/localize-tools/testdata/extract-xliff-fresh-ph/input/foo.ts
@@ -1,0 +1,16 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {html} from 'lit';
+import {msg} from '@lit/localize';
+
+msg('Hello World!', {desc: 'Description of Hello World'});
+
+const name = 'friend';
+msg(html`Hello <b>${name}!</b>`, {desc: 'Description of Hello $(name)'});
+
+// Escaped markup characters should remain escaped
+msg(html`&lt;Hello<b>&lt;World &amp; Friends&gt;</b>!&gt;`);

--- a/packages/localize-tools/testdata/extract-xliff-fresh-ph/input/lit-localize.json
+++ b/packages/localize-tools/testdata/extract-xliff-fresh-ph/input/lit-localize.json
@@ -2,15 +2,14 @@
   "$schema": "../../../config.schema.json",
   "sourceLocale": "en",
   "targetLocales": ["es-419", "zh_CN"],
-  "inputFiles": ["**/*.js"],
+  "tsConfig": "tsconfig.json",
   "output": {
-    "mode": "transform",
-    "outputDir": "locales",
-    "localeCodesModule": "locale-codes.js"
+    "mode": "runtime",
+    "outputDir": "tsout/locales"
   },
   "interchange": {
     "format": "xliff",
-    "xliffDir": "xliff/",
+    "xliffDir": "data/xliff/",
     "placeholderStyle": "ph"
   }
 }

--- a/packages/localize-tools/testdata/extract-xliff-fresh-ph/input/tsconfig.json
+++ b/packages/localize-tools/testdata/extract-xliff-fresh-ph/input/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "preserveConstEnums": true,
+    "forceConsistentCasingInFileNames": true,
+    "rootDir": "./"
+  },
+  "include": ["**/*.ts"]
+}

--- a/packages/localize-tools/testdata/extract-xliff-fresh/goldens/data/xliff/zh_CN.xlf
+++ b/packages/localize-tools/testdata/extract-xliff-fresh/goldens/data/xliff/zh_CN.xlf
@@ -3,11 +3,11 @@
 <file target-language="zh_CN" source-language="en" original="lit-localize-inputs" datatype="plaintext">
 <body>
 <trans-unit id="h02c268d9b1fcb031">
-  <source>&lt;Hello<ph id="0">&lt;b></ph>&lt;World &amp; Friends><ph id="1">&lt;/b></ph>!></source>
+  <source>&lt;Hello<x id="0" equiv-text="&lt;b>"/>&lt;World &amp; Friends><x id="1" equiv-text="&lt;/b>"/>!></source>
 </trans-unit>
 <trans-unit id="he7b474847636149b">
   <note>Description of Hello $(name)</note>
-  <source>Hello <ph id="0">&lt;b>${name}</ph>!<ph id="1">&lt;/b></ph></source>
+  <source>Hello <x id="0" equiv-text="&lt;b>${name}"/>!<x id="1" equiv-text="&lt;/b>"/></source>
 </trans-unit>
 <trans-unit id="s8c0ec8d1fb9e6e32">
   <note>Description of Hello World</note>

--- a/packages/localize-tools/testdata/extract-xliff-merge/goldens/lit-localize.json
+++ b/packages/localize-tools/testdata/extract-xliff-merge/goldens/lit-localize.json
@@ -9,6 +9,7 @@
   },
   "interchange": {
     "format": "xliff",
-    "xliffDir": "xliff/"
+    "xliffDir": "xliff/",
+    "placeholderStyle": "ph"
   }
 }

--- a/packages/localize-tools/testdata/extract-xliff-merge/input/lit-localize.json
+++ b/packages/localize-tools/testdata/extract-xliff-merge/input/lit-localize.json
@@ -9,6 +9,7 @@
   },
   "interchange": {
     "format": "xliff",
-    "xliffDir": "xliff/"
+    "xliffDir": "xliff/",
+    "placeholderStyle": "ph"
   }
 }

--- a/packages/localize-tools/testdata/placeholder-errors/goldens/lit-localize.json
+++ b/packages/localize-tools/testdata/placeholder-errors/goldens/lit-localize.json
@@ -8,6 +8,7 @@
   },
   "interchange": {
     "format": "xliff",
-    "xliffDir": "xliff/"
+    "xliffDir": "xliff/",
+    "placeholderStyle": "ph"
   }
 }

--- a/packages/localize-tools/testdata/placeholder-errors/input/lit-localize.json
+++ b/packages/localize-tools/testdata/placeholder-errors/input/lit-localize.json
@@ -8,6 +8,7 @@
   },
   "interchange": {
     "format": "xliff",
-    "xliffDir": "xliff/"
+    "xliffDir": "xliff/",
+    "placeholderStyle": "ph"
   }
 }

--- a/packages/localize/README.md
+++ b/packages/localize/README.md
@@ -72,9 +72,9 @@ file, a format which is supported by many localization tools and services:
 
 ```xml
 <trans-unit id="h3c44aff2d5f5ef6b">
-  <source>Hello <ph id="0">&lt;b></ph>World<ph id="1">&lt;/b></ph>!</source>
+  <source>Hello <x id="0" equiv-text="&lt;b&gt;">World<x id="1" equiv-text="&lt;/b&gt;">!</source>
   <!-- target tag added by your localization process -->
-  <target>Hola <ph id="0">&lt;b></ph>Mundo<ph id="1">&lt;/b></ph>!</target>
+  <target>Hola <x id="0" equiv-text="&lt;b&gt;">Mundo<x id="1" equiv-text="&lt;/b&gt;">!</target>
 </trans-unit>
 ```
 
@@ -197,11 +197,11 @@ lit-localize supports two output modes: _transform_ and _runtime_.
 5. Take a look at the generated XLIFF file `xliff/es-419.xlf`. Note that we have
    a `<source>` template extracted from your source code, but we don't have a
    localized version yet. Also note that embedded HTML markup has been encoded
-   into `<ph>` tags.
+   into `<x>` tags.
 
    ```xml
    <trans-unit id="h3c44aff2d5f5ef6b">
-     <source>Hello <ph id="0">&lt;b></ph>World<ph id="1">&lt;/b></ph>!</source>
+     <source>Hello <x id="0" equiv-text="&lt;b&gt;">World<x id="1" equiv-text="&lt;/b&gt;">!</source>
    </trans-unit>
    ```
 
@@ -211,8 +211,8 @@ lit-localize supports two output modes: _transform_ and _runtime_.
 
    ```xml
    <trans-unit id="h3c44aff2d5f5ef6b">
-     <source>Hello <ph id="0">&lt;b></ph>World<ph id="1">&lt;/b></ph>!</source>
-     <target>Hola <ph id="0">&lt;b></ph>Mundo<ph id="1">&lt;/b></ph>!</target>
+    <source>Hello <x id="0" equiv-text="&lt;b&gt;">World<x id="1" equiv-text="&lt;/b&gt;">!</source>
+    <target>Hola <x id="0" equiv-text="&lt;b&gt;">Mundo<x id="1" equiv-text="&lt;/b&gt;">!</target>
    </trans-unit>
    ```
 
@@ -416,7 +416,7 @@ Descriptions are represented in XLIFF using `<note>` elements.
 ```xml
 <trans-unit id="h3c44aff2d5f5ef6b">
   <note>Greeting to everybody on homepage</note>
-  <source>Hello <ph id="0">&lt;b></ph>World<ph id="1">&lt;/b></ph>!</source>
+  <source>Hello <x id="0" equiv-text="&lt;b&gt;">World<x id="1" equiv-text="&lt;/b&gt;">!</source>
 </trans-unit>
 ```
 
@@ -557,22 +557,23 @@ lit-localize command [--flags]
 
 ## Config file
 
-| Property                                 | Type                       | Description                                                                                                                                                                                                                                                                               |
-| ---------------------------------------- | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `sourceLocale`                           | `string`                   | Required locale code that templates in the source code are written in.                                                                                                                                                                                                                    |
-| `targetLocales`                          | `string[]`                 | Required locale codes that templates will be localized to.                                                                                                                                                                                                                                |
-| `inputFiles`                             | `string[]`                 | Array of filenames or [glob](https://github.com/mrmlnc/fast-glob#pattern-syntax) patterns to extract messages from. Required unless `tsConfig` is specified. If `tsConfig` is also specified, then this field takes precedence.                                                           |
-| `tsConfig`                               | `string`                   | Path to a `tsconfig.json` file that determines the source files from which messages will be extracted, and also the compiler options that will be used when building for transform mode. Required unless `inputFiles` is specified. If both are specified, `inputFiles` takes precedence. |
-| `output.mode`                            | `"transform"`, `"runtime"` | What kind of output should be produced. See [modes](#modes).                                                                                                                                                                                                                              |
-| `output.localeCodesModule`               | `string`                   | Optional filepath for a generated module that exports `sourceLocale`, `targetLocales`, and `allLocales` using the locale codes from your config file. Use to keep your config file and client config in sync.                                                                             |
-| `interchange.format`                     | `"xliff"`, `"xlb"`         | Data format to be consumed by your localization process. Options:<br><br>- `"xliff"`: [XLIFF 1.2](http://docs.oasis-open.org/xliff/v1.2/os/xliff-core.html) XML format<br>- `"xlb"`: Google-internal XML format                                                                           |
+| Property                                 | Type                       | Description                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| ---------------------------------------- | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `sourceLocale`                           | `string`                   | Required locale code that templates in the source code are written in.                                                                                                                                                                                                                                                                                                                                                              |
+| `targetLocales`                          | `string[]`                 | Required locale codes that templates will be localized to.                                                                                                                                                                                                                                                                                                                                                                          |
+| `inputFiles`                             | `string[]`                 | Array of filenames or [glob](https://github.com/mrmlnc/fast-glob#pattern-syntax) patterns to extract messages from. Required unless `tsConfig` is specified. If `tsConfig` is also specified, then this field takes precedence.                                                                                                                                                                                                     |
+| `tsConfig`                               | `string`                   | Path to a `tsconfig.json` file that determines the source files from which messages will be extracted, and also the compiler options that will be used when building for transform mode. Required unless `inputFiles` is specified. If both are specified, `inputFiles` takes precedence.                                                                                                                                           |
+| `output.mode`                            | `"transform"`, `"runtime"` | What kind of output should be produced. See [modes](#modes).                                                                                                                                                                                                                                                                                                                                                                        |
+| `output.localeCodesModule`               | `string`                   | Optional filepath for a generated module that exports `sourceLocale`, `targetLocales`, and `allLocales` using the locale codes from your config file. Use to keep your config file and client config in sync.                                                                                                                                                                                                                       |
+| `interchange.format`                     | `"xliff"`, `"xlb"`         | Data format to be consumed by your localization process. Options:<br><br>- `"xliff"`: [XLIFF 1.2](http://docs.oasis-open.org/xliff/v1.2/os/xliff-core.html) XML format<br>- `"xlb"`: Google-internal XML format                                                                                                                                                                                                                     |
 | <h4 colspan="3">Runtime mode only</h4>   |
-| `output.language`                        | `"js"`, `"ts"`             | Language for emitting generated modules. Defaults to `"js"` unless a `tsConfig` was specified, in which case it defaults to `"ts"`.                                                                                                                                                       |
-| `output.outputDir`                       | `string`                   | Output directory for generated modules. Into this directory will be generated a `<locale>.js` or `<locale>.ts` file for each `targetLocale`, each a module that exports the translations in that locale keyed by message ID.                                                              |
+| `output.language`                        | `"js"`, `"ts"`             | Language for emitting generated modules. Defaults to `"js"` unless a `tsConfig` was specified, in which case it defaults to `"ts"`.                                                                                                                                                                                                                                                                                                 |
+| `output.outputDir`                       | `string`                   | Output directory for generated modules. Into this directory will be generated a `<locale>.js` or `<locale>.ts` file for each `targetLocale`, each a module that exports the translations in that locale keyed by message ID.                                                                                                                                                                                                        |
 | <h4 colspan="3">Transform mode only</h4> |
-| `output.outputDir`                       | `string`                   | Output directory for transformed projects. A subdirectory will be created for each locale within this directory, each containing a full build of the project for that locale. Required unless `tsConfig` is specified, in which case it defaults to that config's `outDir`.               |
+| `output.outputDir`                       | `string`                   | Output directory for transformed projects. A subdirectory will be created for each locale within this directory, each containing a full build of the project for that locale. Required unless `tsConfig` is specified, in which case it defaults to that config's `outDir`.                                                                                                                                                         |
 | <h4 colspan="3">XLIFF only</h4>          |                            |
-| `interchange.xliffDir`                   | `string`                   | Directory on disk to read/write `.xlf` XML files. For each target locale, the file path `"<xliffDir>/<locale>.xlf"` will be used.                                                                                                                                                         |
+| `interchange.xliffDir`                   | `string`                   | Directory on disk to read/write `.xlf` XML files. For each target locale, the file path `"<xliffDir>/<locale>.xlf"` will be used.                                                                                                                                                                                                                                                                                                   |
+| `interchange.placeholderStyle`           | `"x"`, `"ph"`              | How to represent placeholders containing HTML markup and dynamic expressions. Different localization tools and services have varying support for placeholder syntax. Defaults to `"x"`. Options:<br><br>- `"x"`: Emit placeholders using [`<x>`](http://docs.oasis-open.org/xliff/v1.2/os/xliff-core.html#x) tags.<br>- `"ph"`: Emit placeholders using [`<ph>`](http://docs.oasis-open.org/xliff/v1.2/os/xliff-core.html#ph) tags. |
 
 ## Rollup
 


### PR DESCRIPTION
See https://github.com/lit/lit/issues/2271 for more context.

XLIFF is the XML format we use to represent extracted templates/strings that need translation. XLIFF specifies multiple ways of encoding placeholders (for representing HTML markup and dynamic expressions). The differences according to the spec are a bit confusing:

- [`<ph>`](http://docs.oasis-open.org/xliff/v1.2/os/xliff-core.html#ph): "Placeholder - The <ph> element is used to delimit a sequence of native stand-alone codes in the translation unit."
- [`<x>`](http://docs.oasis-open.org/xliff/v1.2/os/xliff-core.html#x): "Generic placeholder - The <x/> element is used to replace any code of the original document."

Previously we were using `<ph>`, because the spec seemed to match what we need, and I was primed by XLB (Google's very similar format) which also uses `<ph>` tags for this purpose. However, I found that in practice translation tools seem to have much better support for the XLIFF `<x>` tag (I have tested crowdin, phrase, and lokalise). Additionally, `<x>` is the approach used by Angular (see https://angular.io/guide/i18n-example), so it is likely that translation tools/services have been already tested with Angular style message extraction.

This is possibly breaking because it changes the default from `<ph>` to `<x>`, but upgrading both source and translated messages to `<x>` will happen automatically when the user next runs `lit-localize extract`. We retain the ability to use `<ph>` tags by setting a new config file setting.

Fixes https://github.com/lit/lit/issues/2271

cc @fetherston fyi