### PR TITLE
[ssr] Add customElementRendered callback

### DIFF
--- a/.changeset/tasty-zebras-double.md
+++ b/.changeset/tasty-zebras-double.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/ssr': minor
+---
+
+Add customElementRendered callback to RenderInfo so that callers can konw what elements were rendered.

--- a/.changeset/tasty-zebras-double.md
+++ b/.changeset/tasty-zebras-double.md
@@ -2,4 +2,4 @@
 '@lit-labs/ssr': minor
 ---
 
-Add customElementRendered callback to RenderInfo so that callers can konw what elements were rendered.
+Add customElementRendered callback to RenderInfo so that callers can know what elements were rendered.

--- a/packages/labs/ssr/src/test/test-files/render-test-module.ts
+++ b/packages/labs/ssr/src/test/test-files/render-test-module.ts
@@ -19,7 +19,7 @@ export const simpleTemplateResult = html`<div></div>`;
 
 /* Text Expressions */
 // prettier-ignore
-export const templateWithTextExpression = (x: string) => html`<div>${x}</div>`;
+export const templateWithTextExpression = (x: string|null|undefined) => html`<div>${x}</div>`;
 
 /* Attribute Expressions */
 // prettier-ignore


### PR DESCRIPTION
This allows callers to see what tags are rendered as they are streamed. An important use case is to enable on-demand bundling of just the modules required to hydrate the page or a subset of the page.