### PR TITLE
[starter-kits] Fix starter kits so `npm run serve` isn't `npm run docs:serve`

### DIFF
--- a/.changeset/metal-news-sin.md
+++ b/.changeset/metal-news-sin.md
@@ -1,0 +1,6 @@
+---
+'@lit/lit-starter-js': patch
+'@lit/lit-starter-ts': patch
+---
+
+Fix starter kits so `npm run serve` serves the root directory, and add a link to the `/dev/index.html` component example from `/`.

--- a/packages/lit-starter-js/index.html
+++ b/packages/lit-starter-js/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Lit Starter Kit</title>
+  </head>
+  <body>
+    <a href="/dev/index.html">Component Demo</a>
+  </body>
+</html>

--- a/packages/lit-starter-js/web-dev-server.config.js
+++ b/packages/lit-starter-js/web-dev-server.config.js
@@ -14,7 +14,6 @@ if (!['dev', 'prod'].includes(mode)) {
 export default {
   nodeResolve: {exportConditions: mode === 'dev' ? ['development'] : []},
   preserveSymlinks: true,
-  rootDir: 'docs',
   plugins: [
     legacyPlugin({
       polyfills: {

--- a/packages/lit-starter-ts/index.html
+++ b/packages/lit-starter-ts/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Lit Starter Kit</title>
+  </head>
+  <body>
+    <a href="/dev/index.html">Component Demo</a>
+  </body>
+</html>

--- a/packages/lit-starter-ts/web-dev-server.config.js
+++ b/packages/lit-starter-ts/web-dev-server.config.js
@@ -14,7 +14,6 @@ if (!['dev', 'prod'].includes(mode)) {
 export default {
   nodeResolve: {exportConditions: mode === 'dev' ? ['development'] : []},
   preserveSymlinks: true,
-  rootDir: 'docs',
   plugins: [
     legacyPlugin({
       polyfills: {


### PR DESCRIPTION
### Context

Currently you cannot serve your component from the starter kit. You always get the generated docs.

This change makes it so when you run `npm run serve`, you get your component. Docs are still available via the `nom run docs:serve` command.

Currently: `npm run serve` and `npm run docs:serve` give you the same output.

### Why

Because it's confusing and has resulted in the following efforts to fix:
 - https://github.com/lit/lit-element-starter-ts/issues/58
   - In the linked video: https://www.youtube.com/watch?v=86tet76u0uk&ab_channel=MiklosNemeth , they are unable to figure out how to serve their component. This is fixed by this change.
- This PR on the original repo: https://github.com/lit/lit-element-starter-ts/pull/57 fixes the serve command explicitly.

### Repro bug

1. Make a new template based on the starter kit.
1. `npm i`
1. `npm run build`
1. `npm run serve` -> get docs page.
1. Follow instructions in readme and navigate to `/dev/index.html` and get a 404.

### Impact

Fixes serve command so it matches what expectation is set in the readme. Following links in readme, i.e. `/dev/index.html` return your component instead of 200.

