### PR TITLE
Add basic event support

### DIFF
--- a/packages/labs/ssr/src/lib/dom-shim.ts
+++ b/packages/labs/ssr/src/lib/dom-shim.ts
@@ -37,7 +37,42 @@ export const getWindow = ({
     return attrs;
   };
 
-  class Element {}
+  /**
+   * Extends EventTarget to have a parent reference and adds event propagation.
+   */
+  class EventTargetWithParent extends EventTarget {
+    __eventTargetParent: EventTarget | undefined;
+
+    override dispatchEvent(event: Event): boolean {
+      // TODO (justinfagnani): This doesn't implement capture at all.
+      // To implement capture we'd need to patch addEventListener to track the
+      // capturing listeners separately, then call into a capture method here
+      // which would supercall before processing any capturing listeners.
+
+      // First dispatch the event on this instance
+      let canceled = super.dispatchEvent(event);
+
+      // Then conditionally bubble up. cancelBubble is true if a handler
+      // on this instance called event.stopPropagation()
+      if (!event.cancelBubble && this.__eventTargetParent !== undefined) {
+        canceled &&= this.__eventTargetParent.dispatchEvent(event);
+      }
+      return canceled;
+    }
+  }
+
+  class CustomEvent<T = any> extends Event {
+    detail: T;
+
+    constructor(type: string, init?: CustomEventInit<T>) {
+      super(type, init);
+      this.detail = init?.detail as T;
+    }
+  }
+
+  class Element extends EventTargetWithParent {
+    readonly parentNode: Element | null = null;
+  }
 
   abstract class HTMLElement extends Element {
     get attributes() {
@@ -118,6 +153,9 @@ export const getWindow = ({
   }
 
   const window = {
+    EventTarget: EventTargetWithParent,
+    Event,
+    CustomEvent,
     Element,
     HTMLElement,
     Document,

--- a/packages/labs/ssr/src/test/lib/render-lit_test.ts
+++ b/packages/labs/ssr/src/test/lib/render-lit_test.ts
@@ -309,4 +309,11 @@ test.skip('class-map directive with other bindings', async () => {
 
 test('calls customElementRendered', () => {});
 
+test('dispatchEvent', async () => {
+  const {render, eventDispatch} = await setup();
+  const result = await render(eventDispatch);
+
+  assert.match(result, '<p><!--lit-part-->set<!--/lit-part--></p>');
+});
+
 test.run();

--- a/packages/labs/ssr/src/test/test-files/render-test-module.ts
+++ b/packages/labs/ssr/src/test/test-files/render-test-module.ts
@@ -212,3 +212,40 @@ export const nestedTemplateResult = html`<div></div>`;
 export const trickyNestedDynamicChildren = html`<test-simple-slot
   >${html`${nestedTemplateResult}${nestedTemplateResult}`}</test-simple-slot
 >`;
+
+/* Events */
+
+@customElement('test-event-dispatch')
+export class TestEventDispatch extends LitElement {
+  @property() testProperty!: string;
+
+  override connectedCallback() {
+    super.connectedCallback();
+    const event = new CustomEvent('test-event', {
+      bubbles: true,
+      detail: {testProperty: 'initial'},
+    });
+    this.dispatchEvent(event);
+    this.testProperty = event.detail.testProperty;
+  }
+
+  override render() {
+    return html`<p>${this.testProperty}</p>`;
+  }
+}
+
+@customElement('test-event-listen')
+export class TestEventListen extends LitElement {
+  override connectedCallback() {
+    super.connectedCallback();
+    this.addEventListener('test-event', (e: Event) => {
+      (e as CustomEvent<{testProperty: string}>).detail.testProperty = 'set';
+    });
+  }
+
+  override render() {
+    return html`<test-event-dispatch></test-event-dispatch>`;
+  }
+}
+
+export const eventDispatch = html`<test-event-listen></test-event-listen>`;


### PR DESCRIPTION
This is a start of what it would look like to add event support to SSR. It uses Node's `Event` and `EventTarget` classes and extends `EventTarget` to have a parent that it can dispatch to to implement bubbling. `stopPropagation()`, etc., should work, but aren't tested yet.

The big open questions are:
* Can we have an event path of just the custom elements without materializing the built-ins that would be on the path with a full DOM structure? This seems ok if the only event patterns we support are for cross-custom-element communication, ie context.
* Where do elements install event listeners? I added a call to `connectedCallback()` in here, but that only doesn't throw because none of the test elements do anything with the DOM in `connectedCallback()`. That wouldn't be viable in general.
* Do we need to implement the capture phase?
* How could we implement the proper composed path? We would need some concept of slotted elements being in the custom element instance stack.