### PR TITLE
[lit-html-1.x] Type fixes for TypeScript 4.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "lit-html",
       "version": "1.4.1",
       "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/web-ie11": "^0.0.0"
+      },
       "devDependencies": {
         "@types/chai": "^4.1.0",
         "@types/mocha": "^7.0.1",
@@ -1283,6 +1286,11 @@
         "@types/node": "*",
         "@types/vinyl": "*"
       }
+    },
+    "node_modules/@types/web-ie11": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/@types/web-ie11/-/web-ie11-0.0.0.tgz",
+      "integrity": "sha512-44abV3xJfnkWkv0nqdJ7hCa36/rOMpuabXAyYadqpNllqLPnd+JbiRAnJV12sMdO2cNSesaUbMK3+7O9QD00bw=="
     },
     "node_modules/@types/whatwg-url": {
       "version": "6.4.0",
@@ -16926,6 +16934,11 @@
         "@types/node": "*",
         "@types/vinyl": "*"
       }
+    },
+    "@types/web-ie11": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/@types/web-ie11/-/web-ie11-0.0.0.tgz",
+      "integrity": "sha512-44abV3xJfnkWkv0nqdJ7hCa36/rOMpuabXAyYadqpNllqLPnd+JbiRAnJV12sMdO2cNSesaUbMK3+7O9QD00bw=="
     },
     "@types/whatwg-url": {
       "version": "6.4.0",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@types/chai": "^4.1.0",
     "@types/mocha": "^7.0.1",
     "@types/trusted-types": "^1.0.1",
+    "@types/web-ie11": "^0.0.0",
     "@typescript-eslint/eslint-plugin": "^2.26.0",
     "@typescript-eslint/parser": "^2.26.0",
     "@webcomponents/shadycss": "^1.8.0",

--- a/src/test/lib/shady-render_test.ts
+++ b/src/test/lib/shady-render_test.ts
@@ -347,32 +347,32 @@ suite('shady-render', () => {
         const container = document.createElement('some-element');
         document.body.appendChild(container);
         const shadowRoot = container.attachShadow({mode: 'open'});
-        let error1 = undefined;
+        let error1: Error|undefined = undefined;
         try {
           (shadyRender as any)(
               html`some content`, shadowRoot /*, not provided */);
         } catch (e) {
-          error1 = e;
+          error1 = e as Error;
         }
         assert.notEqual(error1, undefined);
-        assert.equal(error1.message, 'The `scopeName` option is required.');
-        let error2 = undefined;
+        assert.equal(error1?.message, 'The `scopeName` option is required.');
+        let error2: Error|undefined = undefined;
         try {
           (shadyRender as any)(html`some content`, shadowRoot, 'not an object');
         } catch (e) {
-          error2 = e;
+          error2 = e as Error;
         }
         assert.notEqual(error2, undefined);
-        assert.equal(error2.message, 'The `scopeName` option is required.');
-        let error3 = undefined;
+        assert.equal(error2?.message, 'The `scopeName` option is required.');
+        let error3: Error|undefined = undefined;
         try {
           (shadyRender as any)(
               html`some content`, shadowRoot, {'missing scopeName': true});
         } catch (e) {
-          error3 = e;
+          error3 = e as Error;
         }
         assert.notEqual(error3, undefined);
-        assert.equal(error3.message, 'The `scopeName` option is required.');
+        assert.equal(error3!.message, 'The `scopeName` option is required.');
         document.body.removeChild(container);
       });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "es2017",
     "module": "es2015",
     "lib": ["es2017", "esnext.asynciterable", "dom"],
-    "types": ["chai", "mocha", "trusted-types"],
+    "types": ["chai", "mocha", "trusted-types", "web-ie11"],
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,


### PR DESCRIPTION
Part of getting the lit 1.x API docs running on the new site. We will analyze the lit-html-1.x branch from the lit.dev repo using a more recent version of TypeScript, so we need it to compile with no errors.

- Exceptions are `unknown` instead of `any` since 4.4 (https://devblogs.microsoft.com/typescript/announcing-typescript-4-4/#use-unknown-catch-variables). Fixed with some casts.

- `document.createTreeWalker` interface changed (https://github.com/microsoft/TypeScript/issues/33462). Fixed by installing `@types/web-ie11` which adds the legacy signature back.