### PR TITLE
[reactive-element] Add queryAssignedElements decorator

### DIFF
--- a/.changeset/famous-feet-kneel.md
+++ b/.changeset/famous-feet-kneel.md
@@ -1,0 +1,9 @@
+---
+'lit': minor
+'lit-element': minor
+'lit-html': minor
+'@lit/reactive-element': minor
+'@lit/ts-transformers': minor
+---
+
+Add `queryAssignedElements` decorator for a declarative API that calls `HTMLSlotElement.assignedElements()` on a specified slot. `selector` option allows filtering returned elements by a CSS selector.

--- a/.changeset/famous-feet-kneel.md
+++ b/.changeset/famous-feet-kneel.md
@@ -1,9 +1,8 @@
 ---
 'lit': minor
 'lit-element': minor
-'lit-html': minor
 '@lit/reactive-element': minor
 '@lit/ts-transformers': minor
 ---
 
-Add `queryAssignedElements` decorator for a declarative API that calls `HTMLSlotElement.assignedElements()` on a specified slot. `selector` option allows filtering returned elements by a CSS selector.
+Add `queryAssignedElements` decorator for a declarative API that calls `HTMLSlotElement.assignedElements()` on a specified slot. `selector` option allows filtering returned elements with a CSS selector.

--- a/packages/labs/ssr/package.json
+++ b/packages/labs/ssr/package.json
@@ -66,6 +66,7 @@
     "lit": "^2.0.0",
     "lit-element": "^3.0.0",
     "lit-html": "^2.0.0",
+    "@lit/reactive-element": "1.0.2",
     "node-fetch": "^2.6.0",
     "parse5": "^6.0.1",
     "resolve": "^1.10.1"

--- a/packages/lit-element/package.json
+++ b/packages/lit-element/package.json
@@ -42,6 +42,10 @@
       "development": "./development/decorators/query-all.js",
       "default": "./decorators/query-all.js"
     },
+    "./decorators/query-assigned-elements.js": {
+      "development": "./development/decorators/query-assigned-elements.js",
+      "default": "./decorators/query-assigned-elements.js"
+    },
     "./decorators/query-assigned-nodes.js": {
       "development": "./development/decorators/query-assigned-nodes.js",
       "default": "./decorators/query-assigned-nodes.js"

--- a/packages/lit-element/src/decorators.ts
+++ b/packages/lit-element/src/decorators.ts
@@ -19,4 +19,5 @@ export * from '@lit/reactive-element/decorators/event-options.js';
 export * from '@lit/reactive-element/decorators/query.js';
 export * from '@lit/reactive-element/decorators/query-all.js';
 export * from '@lit/reactive-element/decorators/query-async.js';
+export * from '@lit/reactive-element/decorators/query-assigned-elements.js';
 export * from '@lit/reactive-element/decorators/query-assigned-nodes.js';

--- a/packages/lit-element/src/decorators/query-assigned-elements.ts
+++ b/packages/lit-element/src/decorators/query-assigned-elements.ts
@@ -1,0 +1,7 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+export * from '@lit/reactive-element/decorators/query-assigned-elements.js';

--- a/packages/lit/package.json
+++ b/packages/lit/package.json
@@ -38,6 +38,9 @@
     "./decorators/query-all.js": {
       "default": "./decorators/query-all.js"
     },
+    "./decorators/query-assigned-elements.js": {
+      "default": "./decorators/query-assigned-elements.js"
+    },
     "./decorators/query-assigned-nodes.js": {
       "default": "./decorators/query-assigned-nodes.js"
     },

--- a/packages/lit/src/decorators.ts
+++ b/packages/lit/src/decorators.ts
@@ -11,4 +11,5 @@ export * from '@lit/reactive-element/decorators/event-options.js';
 export * from '@lit/reactive-element/decorators/query.js';
 export * from '@lit/reactive-element/decorators/query-all.js';
 export * from '@lit/reactive-element/decorators/query-async.js';
+export * from '@lit/reactive-element/decorators/query-assigned-elements.js';
 export * from '@lit/reactive-element/decorators/query-assigned-nodes.js';

--- a/packages/lit/src/decorators/query-assigned-elements.ts
+++ b/packages/lit/src/decorators/query-assigned-elements.ts
@@ -1,0 +1,7 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+export * from '@lit/reactive-element/decorators/query-assigned-elements.js';

--- a/packages/reactive-element/package.json
+++ b/packages/reactive-element/package.json
@@ -49,6 +49,10 @@
       "development": "./development/decorators/query-all.js",
       "default": "./decorators/query-all.js"
     },
+    "./decorators/query-assigned-elements.js": {
+      "development": "./development/decorators/query-assigned-elements.js",
+      "default": "./decorators/query-assigned-elements.js"
+    },
     "./decorators/query-assigned-nodes.js": {
       "development": "./development/decorators/query-assigned-nodes.js",
       "default": "./decorators/query-assigned-nodes.js"

--- a/packages/reactive-element/src/decorators.ts
+++ b/packages/reactive-element/src/decorators.ts
@@ -19,4 +19,5 @@ export * from './decorators/event-options.js';
 export * from './decorators/query.js';
 export * from './decorators/query-all.js';
 export * from './decorators/query-async.js';
+export * from './decorators/query-assigned-elements.js';
 export * from './decorators/query-assigned-nodes.js';

--- a/packages/reactive-element/src/decorators/query-assigned-elements.ts
+++ b/packages/reactive-element/src/decorators/query-assigned-elements.ts
@@ -1,0 +1,80 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * IMPORTANT: For compatibility with tsickle and the Closure JS compiler, all
+ * property decorators (but not class decorators) in this file that have
+ * an @ExportDecoratedItems annotation must be defined as a regular function,
+ * not an arrow function.
+ */
+
+import {ReactiveElement} from '../reactive-element.js';
+import {decorateProperty} from './base.js';
+
+export interface QueryAssignedElementsOptions extends AssignedNodesOptions {
+  /**
+   * A string name of the slot. Leave empty for the default slot.
+   */
+  slotName?: string;
+  /**
+   * A string which filters the results to elements that match the given css
+   * selector.
+   */
+  selector?: string;
+}
+
+/**
+ * A property decorator that converts a class property into a getter that
+ * returns the `assignedElements` of the given `slot`. Provides a declarative
+ * way to use
+ * [`slot.assignedElements`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLSlotElement/assignedElements).
+ *
+ * @param options Object that sets options for nodes to be returned. See
+ *     [MDN parameters section](https://developer.mozilla.org/en-US/docs/Web/API/HTMLSlotElement/assignedElements#parameters)
+ *     for available options. Also accepts two more optional properties,
+ *     `slotName` and `selector`.
+ * @param options.slotName Name of the slot. Undefined or empty string for the
+ *     default slot.
+ * @param options.selector Element results are filtered such that they match the
+ *     given css selector.
+ *
+ * ```ts
+ * class MyElement {
+ *   @queryAssignedElements({ slotName: 'list' })
+ *   listItems;
+ *   @queryAssignedElements()
+ *   unnamedSlotEls;
+ *
+ *   render() {
+ *     return html`
+ *       <slot name="list"></slot>
+ *       <slot></slot>
+ *     `;
+ *   }
+ * }
+ * ```
+ * @category Decorator
+ */
+export function queryAssignedElements(options?: QueryAssignedElementsOptions) {
+  const {slotName, selector} = options ?? {};
+  return decorateProperty({
+    descriptor: (_name: PropertyKey) => ({
+      get(this: ReactiveElement) {
+        const slotSelector = `slot${
+          slotName ? `[name=${slotName}]` : ':not([name])'
+        }`;
+        const slot = this.renderRoot?.querySelector(slotSelector);
+        const elements = (slot as HTMLSlotElement).assignedElements(options);
+        if (selector) {
+          return elements.filter((node) => node.matches(selector));
+        }
+        return elements;
+      },
+      enumerable: true,
+      configurable: true,
+    }),
+  });
+}

--- a/packages/reactive-element/src/decorators/query-assigned-elements.ts
+++ b/packages/reactive-element/src/decorators/query-assigned-elements.ts
@@ -18,7 +18,7 @@ export interface QueryAssignedElementsOptions extends AssignedNodesOptions {
   /**
    * A string name of the slot. Leave empty for the default slot.
    */
-  slotName?: string;
+  slot?: string;
   /**
    * A string which filters the results to elements that match the given css
    * selector.
@@ -35,15 +35,15 @@ export interface QueryAssignedElementsOptions extends AssignedNodesOptions {
  * @param options Object that sets options for nodes to be returned. See
  *     [MDN parameters section](https://developer.mozilla.org/en-US/docs/Web/API/HTMLSlotElement/assignedElements#parameters)
  *     for available options. Also accepts two more optional properties,
- *     `slotName` and `selector`.
- * @param options.slotName Name of the slot. Undefined or empty string for the
+ *     `slot` and `selector`.
+ * @param options.slot Name of the slot. Undefined or empty string for the
  *     default slot.
  * @param options.selector Element results are filtered such that they match the
  *     given css selector.
  *
  * ```ts
  * class MyElement {
- *   @queryAssignedElements({ slotName: 'list' })
+ *   @queryAssignedElements({ slot: 'list' })
  *   listItems;
  *   @queryAssignedElements()
  *   unnamedSlotEls;
@@ -59,15 +59,13 @@ export interface QueryAssignedElementsOptions extends AssignedNodesOptions {
  * @category Decorator
  */
 export function queryAssignedElements(options?: QueryAssignedElementsOptions) {
-  const {slotName, selector} = options ?? {};
+  const {slot, selector} = options ?? {};
   return decorateProperty({
     descriptor: (_name: PropertyKey) => ({
       get(this: ReactiveElement) {
-        const slotSelector = `slot${
-          slotName ? `[name=${slotName}]` : ':not([name])'
-        }`;
-        const slot = this.renderRoot?.querySelector(slotSelector);
-        const elements = (slot as HTMLSlotElement).assignedElements(options);
+        const slotSelector = `slot${slot ? `[name=${slot}]` : ':not([name])'}`;
+        const slotEl = this.renderRoot?.querySelector(slotSelector);
+        const elements = (slotEl as HTMLSlotElement).assignedElements(options);
         if (selector) {
           return elements.filter((node) => node.matches(selector));
         }

--- a/packages/reactive-element/src/decorators/query-assigned-elements.ts
+++ b/packages/reactive-element/src/decorators/query-assigned-elements.ts
@@ -16,12 +16,11 @@ import {decorateProperty} from './base.js';
 
 export interface QueryAssignedElementsOptions extends AssignedNodesOptions {
   /**
-   * A string name of the slot. Leave empty for the default slot.
+   * Name of the slot. Leave empty for the default slot.
    */
   slot?: string;
   /**
-   * A string which filters the results to elements that match the given css
-   * selector.
+   * CSS selector used to filter the elements returned.
    */
   selector?: string;
 }
@@ -32,6 +31,8 @@ export interface QueryAssignedElementsOptions extends AssignedNodesOptions {
  * way to use
  * [`slot.assignedElements`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLSlotElement/assignedElements).
  *
+ * Note, the type of this property should be annotated as `Array<HTMLElement>`.
+ *
  * @param options Object that sets options for nodes to be returned. See
  *     [MDN parameters section](https://developer.mozilla.org/en-US/docs/Web/API/HTMLSlotElement/assignedElements#parameters)
  *     for available options. Also accepts two more optional properties,
@@ -39,14 +40,14 @@ export interface QueryAssignedElementsOptions extends AssignedNodesOptions {
  * @param options.slot Name of the slot. Undefined or empty string for the
  *     default slot.
  * @param options.selector Element results are filtered such that they match the
- *     given css selector.
+ *     given CSS selector.
  *
  * ```ts
  * class MyElement {
  *   @queryAssignedElements({ slot: 'list' })
- *   listItems;
+ *   listItems!: Array<HTMLElement>;
  *   @queryAssignedElements()
- *   unnamedSlotEls;
+ *   unnamedSlotEls?: Array<HTMLElement>;
  *
  *   render() {
  *     return html`
@@ -64,8 +65,9 @@ export function queryAssignedElements(options?: QueryAssignedElementsOptions) {
     descriptor: (_name: PropertyKey) => ({
       get(this: ReactiveElement) {
         const slotSelector = `slot${slot ? `[name=${slot}]` : ':not([name])'}`;
-        const slotEl = this.renderRoot?.querySelector(slotSelector);
-        const elements = (slotEl as HTMLSlotElement).assignedElements(options);
+        const slotEl =
+          this.renderRoot?.querySelector<HTMLSlotElement>(slotSelector);
+        const elements = slotEl?.assignedElements(options) ?? [];
         if (selector) {
           return elements.filter((node) => node.matches(selector));
         }

--- a/packages/reactive-element/src/test/decorators/queryAssignedElements_test.ts
+++ b/packages/reactive-element/src/test/decorators/queryAssignedElements_test.ts
@@ -1,0 +1,195 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {queryAssignedElements} from '../../decorators/query-assigned-elements.js';
+import {
+  canTestReactiveElement,
+  generateElementName,
+  RenderingElement,
+  html,
+} from '../test-helpers.js';
+import {assert} from '@esm-bundle/chai';
+
+const flush =
+  window.ShadyDOM && window.ShadyDOM.flush ? window.ShadyDOM.flush : () => {};
+
+(canTestReactiveElement ? suite : suite.skip)('@queryAssignedElements', () => {
+  let container: HTMLElement;
+  let el: C;
+
+  class D extends RenderingElement {
+    @queryAssignedElements() defaultAssigned!: Element[];
+
+    @queryAssignedElements({slotName: 'footer', flatten: true})
+    footerAssigned!: Element[];
+
+    @queryAssignedElements({slotName: 'footer', flatten: false})
+    footerNotFlattenedSlot!: Element[];
+
+    @queryAssignedElements({
+      slotName: 'footer',
+      flatten: true,
+      selector: '.item',
+    })
+    footerAssignedFiltered!: Element[];
+
+    override render() {
+      return html`
+        <slot></slot>
+        <slot name="footer"></slot>
+      `;
+    }
+  }
+  customElements.define('assigned-elements-el', D);
+
+  class E extends RenderingElement {
+    @queryAssignedElements() defaultAssigned!: Element[];
+
+    @queryAssignedElements({slotName: 'header'}) headerAssigned!: Element[];
+
+    override render() {
+      return html`
+        <slot name="header"></slot>
+        <slot></slot>
+      `;
+    }
+  }
+  customElements.define('assigned-elements-el-2', E);
+
+  const defaultSymbol = Symbol('default');
+  const headerSymbol = Symbol('header');
+  class S extends RenderingElement {
+    @queryAssignedElements() [defaultSymbol]!: Element[];
+
+    @queryAssignedElements({slotName: 'header'}) [headerSymbol]!: Element[];
+
+    override render() {
+      return html`
+        <slot name="header"></slot>
+        <slot></slot>
+      `;
+    }
+  }
+  customElements.define('assigned-elements-el-symbol', S);
+
+  // Note, there are 2 elements here so that the `flatten` option of
+  // the decorator can be tested.
+  class C extends RenderingElement {
+    div!: HTMLDivElement;
+    div2!: HTMLDivElement;
+    div3!: HTMLDivElement;
+    assignedEls!: D;
+    assignedEls2!: E;
+    assignedEls3!: S;
+    @queryAssignedElements() missingSlotAssignedElements!: Element[];
+
+    override render() {
+      return html`
+        <assigned-elements-el
+          ><div id="div1">A</div>
+          <slot slot="footer"></slot
+        ></assigned-elements-el>
+        <assigned-elements-el-2><div id="div2">B</div></assigned-elements-el-2>
+        <assigned-elements-el-symbol
+          ><div id="div3">B</div></assigned-elements-el-symbol
+        >
+      `;
+    }
+
+    override firstUpdated() {
+      this.div = this.renderRoot.querySelector('#div1') as HTMLDivElement;
+      this.div2 = this.renderRoot.querySelector('#div2') as HTMLDivElement;
+      this.div3 = this.renderRoot.querySelector('#div3') as HTMLDivElement;
+      this.assignedEls = this.renderRoot.querySelector(
+        'assigned-elements-el'
+      ) as D;
+      this.assignedEls2 = this.renderRoot.querySelector(
+        'assigned-elements-el-2'
+      ) as E;
+      this.assignedEls3 = this.renderRoot.querySelector(
+        'assigned-elements-el-symbol'
+      ) as S;
+    }
+  }
+  customElements.define(generateElementName(), C);
+
+  setup(async () => {
+    container = document.createElement('div');
+    container.id = 'test-container';
+    document.body.appendChild(container);
+    el = new C();
+    container.appendChild(el);
+    await el.updateComplete;
+    await el.assignedEls.updateComplete;
+  });
+
+  teardown(() => {
+    if (container !== undefined) {
+      container.parentElement!.removeChild(container);
+      (container as any) = undefined;
+    }
+  });
+
+  test('returns assignedElements for slot', () => {
+    // Note, `defaultAssigned` does not `flatten` so we test that the property
+    // reflects current state and state when nodes are added or removed.
+    assert.deepEqual(el.assignedEls.defaultAssigned, [el.div]);
+    const child = document.createElement('div');
+    const text1 = document.createTextNode('');
+    el.assignedEls.appendChild(text1);
+    el.assignedEls.appendChild(child);
+    const text2 = document.createTextNode('');
+    el.assignedEls.appendChild(text2);
+    flush();
+    assert.deepEqual(el.assignedEls.defaultAssigned, [el.div, child]);
+    el.assignedEls.removeChild(child);
+    flush();
+    assert.deepEqual(el.assignedEls.defaultAssigned, [el.div]);
+  });
+
+  test('returns assignedElements for unnamed slot that is not first slot', () => {
+    assert.deepEqual(el.assignedEls2.defaultAssigned, [el.div2]);
+  });
+
+  test('returns assignedElements for unnamed slot via symbol property', () => {
+    assert.deepEqual(el.assignedEls3[defaultSymbol], [el.div3]);
+  });
+
+  test('returns flattened assignedElements for slot', () => {
+    assert.deepEqual(el.assignedEls.footerAssigned, []);
+    const child1 = document.createElement('div');
+    const child2 = document.createElement('div');
+    el.appendChild(child1);
+    el.appendChild(child2);
+    flush();
+    assert.deepEqual(el.assignedEls.footerAssigned, [child1, child2]);
+
+    assert.equal(el.assignedEls.footerNotFlattenedSlot.length, 1);
+    assert.equal(el.assignedEls.footerNotFlattenedSlot?.[0]?.tagName, 'SLOT');
+
+    el.removeChild(child2);
+    flush();
+    assert.deepEqual(el.assignedEls.footerAssigned, [child1]);
+  });
+
+  test('always returns an array, even if the slot is not rendered', () => {
+    assert.isArray(el.missingSlotAssignedElements);
+  });
+
+  test('returns assignedElements for slot filtered by selector', () => {
+    assert.deepEqual(el.assignedEls.footerAssignedFiltered, []);
+    const child1 = document.createElement('div');
+    const child2 = document.createElement('div');
+    child2.classList.add('item');
+    el.appendChild(child1);
+    el.appendChild(child2);
+    flush();
+    assert.deepEqual(el.assignedEls.footerAssignedFiltered, [child2]);
+    el.removeChild(child2);
+    flush();
+    assert.deepEqual(el.assignedEls.footerAssignedFiltered, []);
+  });
+});

--- a/packages/reactive-element/src/test/decorators/queryAssignedElements_test.ts
+++ b/packages/reactive-element/src/test/decorators/queryAssignedElements_test.ts
@@ -46,9 +46,10 @@ const flush =
     }
   }
 
+  const defaultSymbol = Symbol('default');
   @customElement('assigned-elements-el-2')
   class E extends RenderingElement {
-    @queryAssignedElements() defaultAssigned!: Element[];
+    @queryAssignedElements() [defaultSymbol]!: Element[];
 
     @queryAssignedElements({slot: 'header'}) headerAssigned!: Element[];
 
@@ -57,17 +58,6 @@ const flush =
         <slot name="header"></slot>
         <slot></slot>
       `;
-    }
-  }
-
-  const defaultSymbol = Symbol('default');
-
-  @customElement('assigned-elements-el-symbol')
-  class S extends RenderingElement {
-    @queryAssignedElements() [defaultSymbol]!: Element[];
-
-    override render() {
-      return html` <slot></slot> `;
     }
   }
 
@@ -80,7 +70,6 @@ const flush =
     div3!: HTMLDivElement;
     assignedEls!: D;
     assignedEls2!: E;
-    assignedEls3!: S;
     @queryAssignedElements() missingSlotAssignedElements!: Element[];
 
     override render() {
@@ -90,9 +79,6 @@ const flush =
           <slot slot="footer"></slot
         ></assigned-elements-el>
         <assigned-elements-el-2><div id="div2">B</div></assigned-elements-el-2>
-        <assigned-elements-el-symbol
-          ><div id="div3">B</div></assigned-elements-el-symbol
-        >
       `;
     }
 
@@ -106,9 +92,6 @@ const flush =
       this.assignedEls2 = this.renderRoot.querySelector(
         'assigned-elements-el-2'
       ) as E;
-      this.assignedEls3 = this.renderRoot.querySelector(
-        'assigned-elements-el-symbol'
-      ) as S;
     }
   }
 
@@ -141,11 +124,7 @@ const flush =
   });
 
   test('returns assignedElements for unnamed slot that is not first slot', () => {
-    assert.deepEqual(el.assignedEls2.defaultAssigned, [el.div2]);
-  });
-
-  test('returns assignedElements for unnamed slot via symbol property', () => {
-    assert.deepEqual(el.assignedEls3[defaultSymbol], [el.div3]);
+    assert.deepEqual(el.assignedEls2[defaultSymbol], [el.div2]);
   });
 
   test('returns flattened assignedElements for slot', () => {

--- a/packages/ts-transformers/README.md
+++ b/packages/ts-transformers/README.md
@@ -71,16 +71,17 @@ customElements.define('simple-greeting', SimpleGreeting);
 
 #### Supported decorators
 
-| Decorator             | Transformer behavior                                                                  |
-| --------------------- | ------------------------------------------------------------------------------------- |
-| `@customElement`      | Adds a `customElements.define` call                                                   |
-| `@property`           | Adds an entry to `static properties`, and moves initializers to the `constructor`     |
-| `@state`              | Same as `@property` with `{state: true}`                                              |
-| `@query`              | Defines a getter that calls `querySelector`                                           |
-| `@querySelectorAll`   | Defines a getter that calls `querySelectorAll`                                        |
-| `@queryAsync`         | Defines an `async` getter that awaits `updateComplete` and then calls `querySelector` |
-| `@queryAssignedNodes` | Defines a getter that calls `querySelector('slot[name=foo]').assignedNodes`           |
-| `@localized`          | Adds an `updateWhenLocaleChanges` call to the constructor                             |
+| Decorator                | Transformer behavior                                                                  |
+| ------------------------ | ------------------------------------------------------------------------------------- |
+| `@customElement`         | Adds a `customElements.define` call                                                   |
+| `@property`              | Adds an entry to `static properties`, and moves initializers to the `constructor`     |
+| `@state`                 | Same as `@property` with `{state: true}`                                              |
+| `@query`                 | Defines a getter that calls `querySelector`                                           |
+| `@querySelectorAll`      | Defines a getter that calls `querySelectorAll`                                        |
+| `@queryAsync`            | Defines an `async` getter that awaits `updateComplete` and then calls `querySelector` |
+| `@queryAssignedElements` | Defines a getter that calls `querySelector('slot[name=foo]').assignedElements`        |
+| `@queryAssignedNodes`    | Defines a getter that calls `querySelector('slot[name=foo]').assignedNodes`           |
+| `@localized`             | Adds an `updateWhenLocaleChanges` call to the constructor                             |
 
 ### preserveBlankLinesTransformer
 

--- a/packages/ts-transformers/src/idiomatic-decorators.ts
+++ b/packages/ts-transformers/src/idiomatic-decorators.ts
@@ -12,6 +12,7 @@ import {StateVisitor} from './internal/decorators/state.js';
 import {QueryVisitor} from './internal/decorators/query.js';
 import {QueryAllVisitor} from './internal/decorators/query-all.js';
 import {QueryAsyncVisitor} from './internal/decorators/query-async.js';
+import {QueryAssignedElementsVisitor} from './internal/decorators/query-assigned-elements.js';
 import {QueryAssignedNodesVisitor} from './internal/decorators/query-assigned-nodes.js';
 import {EventOptionsVisitor} from './internal/decorators/event-options.js';
 import {LocalizedVisitor} from './internal/decorators/localized.js';
@@ -65,6 +66,7 @@ export function idiomaticDecoratorsTransformer(
       new QueryVisitor(context),
       new QueryAllVisitor(context),
       new QueryAsyncVisitor(context),
+      new QueryAssignedElementsVisitor(context),
       new QueryAssignedNodesVisitor(context),
       new EventOptionsVisitor(context, program),
       new LocalizedVisitor(context),

--- a/packages/ts-transformers/src/internal/decorators/query-assigned-elements.ts
+++ b/packages/ts-transformers/src/internal/decorators/query-assigned-elements.ts
@@ -1,0 +1,256 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import ts from 'typescript';
+
+import type {LitClassContext} from '../lit-class-context.js';
+import type {MemberDecoratorVisitor} from '../visitor.js';
+
+/**
+ * Transform:
+ *
+ *   @queryAssignedElements({slotName: 'list', selector: '.item'})
+ *   listItems
+ *
+ * Into:
+ *
+ *   get listItems() {
+ *     return this.renderRoot
+ *       ?.querySelector('slot[name=list]')
+ *       ?.assignedElements()
+ *       ?.filter((node) => node.matches('.item')
+ *   }
+ */
+export class QueryAssignedElementsVisitor implements MemberDecoratorVisitor {
+  readonly kind = 'memberDecorator';
+  readonly decoratorName = 'queryAssignedElements';
+
+  private readonly _factory: ts.NodeFactory;
+
+  constructor({factory}: ts.TransformationContext) {
+    this._factory = factory;
+  }
+
+  visit(
+    litClassContext: LitClassContext,
+    property: ts.ClassElement,
+    decorator: ts.Decorator
+  ) {
+    if (!ts.isPropertyDeclaration(property)) {
+      return;
+    }
+    if (!ts.isCallExpression(decorator.expression)) {
+      return;
+    }
+    if (!ts.isIdentifier(property.name)) {
+      return;
+    }
+    const name = property.name.text;
+    const [arg0] = decorator.expression.arguments;
+    if (arg0 && !ts.isObjectLiteralExpression(arg0)) {
+      throw new Error(
+        `queryAssignedElements argument is expected to be an inlined ` +
+          `object literal. Instead received: '${arg0.getText()}'`
+      );
+    }
+    if (arg0 && arg0.properties.some((p) => !ts.isPropertyAssignment(p))) {
+      throw new Error(
+        `queryAssignedElements object literal argument can only include ` +
+          `property assignment. For example: '{ slotName: "example" }' is ` +
+          `supported, whilst '{ ...otherOpts }' is unsupported.`
+      );
+    }
+    const {slotName, selector} = this._retrieveSlotAndSelector(arg0);
+    litClassContext.litFileContext.replaceAndMoveComments(
+      property,
+      this._createQueryAssignedElementsGetter(
+        name,
+        slotName,
+        selector,
+        this._filterAssignedElementsOptions(arg0)
+      )
+    );
+  }
+
+  private _retrieveSlotAndSelector(opts?: ts.ObjectLiteralExpression): {
+    slotName: string;
+    selector: string;
+  } {
+    if (!opts) {
+      return {slotName: '', selector: ''};
+    }
+    const findStringLiteralFor = (key: string): string => {
+      const propAssignment = opts.properties.find(
+        (p) => p.name && ts.isIdentifier(p.name) && p.name.text === key
+      );
+      if (!propAssignment) {
+        return '';
+      }
+      if (
+        propAssignment &&
+        ts.isPropertyAssignment(propAssignment) &&
+        ts.isStringLiteral(propAssignment.initializer)
+      ) {
+        return propAssignment.initializer.text;
+      }
+      throw new Error(
+        `queryAssignedElements object literal property '${key}' must be a ` +
+          `string literal.`
+      );
+    };
+    return {
+      slotName: findStringLiteralFor('slotName'),
+      selector: findStringLiteralFor('selector'),
+    };
+  }
+
+  /**
+   * queryAssignedElements options contains a superset of the options that
+   * `HTMLSlotElement.assignedElements` accepts. This method takes the original
+   * optional options passed into `queryAssignedElements` and filters out any
+   * decorator specific property assignments.
+   *
+   * Given:
+   *
+   * ```ts
+   * { slotName: 'example', flatten: false }
+   * ```
+   *
+   * returns:
+   *
+   * ```ts
+   * { flatten: false }
+   * ```
+   *
+   * Returns `undefined` instead of an empty object literal if no property
+   * assignments are left after filtering, such that we don't generate code
+   * like `HTMLSlotElement.assignedElements({})`.
+   */
+  private _filterAssignedElementsOptions(
+    opts?: ts.ObjectLiteralExpression
+  ): ts.ObjectLiteralExpression | undefined {
+    if (!opts) {
+      return;
+    }
+    const assignedElementsProperties = opts.properties.filter(
+      (p) =>
+        p.name &&
+        ts.isIdentifier(p.name) &&
+        !['slotName', 'selector'].includes(p.name.text)
+    );
+    if (assignedElementsProperties.length === 0) {
+      return;
+    }
+    return this._factory.updateObjectLiteralExpression(
+      opts,
+      assignedElementsProperties
+    );
+  }
+
+  private _createQueryAssignedElementsGetter(
+    name: string,
+    slotName: string,
+    selector: string,
+    assignedElsOptions?: ts.ObjectLiteralExpression
+  ) {
+    const factory = this._factory;
+
+    const slotSelector = `slot${
+      slotName ? `[name=${slotName}]` : ':not([name])'
+    }`;
+
+    const assignedElementsOptions = assignedElsOptions
+      ? [assignedElsOptions]
+      : [];
+
+    // this.renderRoot?.querySelector(<selector>)?.assignedElements(<options>)
+    const assignedElements = factory.createCallChain(
+      factory.createPropertyAccessChain(
+        factory.createCallChain(
+          factory.createPropertyAccessChain(
+            factory.createPropertyAccessExpression(
+              factory.createThis(),
+              factory.createIdentifier('renderRoot')
+            ),
+            factory.createToken(ts.SyntaxKind.QuestionDotToken),
+            factory.createIdentifier('querySelector')
+          ),
+          undefined,
+          undefined,
+          [factory.createStringLiteral(slotSelector)]
+        ),
+        factory.createToken(ts.SyntaxKind.QuestionDotToken),
+        factory.createIdentifier('assignedElements')
+      ),
+      undefined,
+      undefined,
+      assignedElementsOptions
+    );
+
+    const returnExpression = !selector
+      ? assignedElements
+      : // <assignedElements>?.filter((node) => node.matches(<selector>))
+        factory.createCallChain(
+          factory.createPropertyAccessChain(
+            assignedElements,
+            factory.createToken(ts.SyntaxKind.QuestionDotToken),
+            factory.createIdentifier('filter')
+          ),
+          undefined,
+          undefined,
+          [
+            factory.createArrowFunction(
+              undefined,
+              undefined,
+              [
+                factory.createParameterDeclaration(
+                  undefined,
+                  undefined,
+                  undefined,
+                  factory.createIdentifier('node'),
+                  undefined,
+                  undefined,
+                  undefined
+                ),
+              ],
+              undefined,
+              factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
+              factory.createCallExpression(
+                factory.createPropertyAccessExpression(
+                  factory.createIdentifier('node'),
+                  factory.createIdentifier('matches')
+                ),
+                undefined,
+                [factory.createStringLiteral(selector)]
+              )
+            ),
+          ]
+        );
+
+    // { return <returnExpression> }
+    const getterBody = factory.createBlock(
+      [
+        factory.createReturnStatement(
+          factory.createBinaryExpression(
+            returnExpression,
+            factory.createToken(ts.SyntaxKind.QuestionQuestionToken),
+            factory.createArrayLiteralExpression([], false)
+          )
+        ),
+      ],
+      true
+    );
+
+    return factory.createGetAccessorDeclaration(
+      undefined,
+      undefined,
+      factory.createIdentifier(name),
+      [],
+      undefined,
+      getterBody
+    );
+  }
+}

--- a/packages/ts-transformers/src/internal/decorators/query-assigned-elements.ts
+++ b/packages/ts-transformers/src/internal/decorators/query-assigned-elements.ts
@@ -12,7 +12,7 @@ import type {MemberDecoratorVisitor} from '../visitor.js';
 /**
  * Transform:
  *
- *   @queryAssignedElements({slotName: 'list', selector: '.item'})
+ *   @queryAssignedElements({slot: 'list', selector: '.item'})
  *   listItems
  *
  * Into:
@@ -59,16 +59,16 @@ export class QueryAssignedElementsVisitor implements MemberDecoratorVisitor {
     if (arg0 && arg0.properties.some((p) => !ts.isPropertyAssignment(p))) {
       throw new Error(
         `queryAssignedElements object literal argument can only include ` +
-          `property assignment. For example: '{ slotName: "example" }' is ` +
+          `property assignment. For example: '{ slot: "example" }' is ` +
           `supported, whilst '{ ...otherOpts }' is unsupported.`
       );
     }
-    const {slotName, selector} = this._retrieveSlotAndSelector(arg0);
+    const {slot, selector} = this._retrieveSlotAndSelector(arg0);
     litClassContext.litFileContext.replaceAndMoveComments(
       property,
       this._createQueryAssignedElementsGetter(
         name,
-        slotName,
+        slot,
         selector,
         this._filterAssignedElementsOptions(arg0)
       )
@@ -76,11 +76,11 @@ export class QueryAssignedElementsVisitor implements MemberDecoratorVisitor {
   }
 
   private _retrieveSlotAndSelector(opts?: ts.ObjectLiteralExpression): {
-    slotName: string;
+    slot: string;
     selector: string;
   } {
     if (!opts) {
-      return {slotName: '', selector: ''};
+      return {slot: '', selector: ''};
     }
     const findStringLiteralFor = (key: string): string => {
       const propAssignment = opts.properties.find(
@@ -102,7 +102,7 @@ export class QueryAssignedElementsVisitor implements MemberDecoratorVisitor {
       );
     };
     return {
-      slotName: findStringLiteralFor('slotName'),
+      slot: findStringLiteralFor('slot'),
       selector: findStringLiteralFor('selector'),
     };
   }
@@ -116,7 +116,7 @@ export class QueryAssignedElementsVisitor implements MemberDecoratorVisitor {
    * Given:
    *
    * ```ts
-   * { slotName: 'example', flatten: false }
+   * { slot: 'example', flatten: false }
    * ```
    *
    * returns:
@@ -139,7 +139,7 @@ export class QueryAssignedElementsVisitor implements MemberDecoratorVisitor {
       (p) =>
         p.name &&
         ts.isIdentifier(p.name) &&
-        !['slotName', 'selector'].includes(p.name.text)
+        !['slot', 'selector'].includes(p.name.text)
     );
     if (assignedElementsProperties.length === 0) {
       return;
@@ -152,15 +152,13 @@ export class QueryAssignedElementsVisitor implements MemberDecoratorVisitor {
 
   private _createQueryAssignedElementsGetter(
     name: string,
-    slotName: string,
+    slot: string,
     selector: string,
     assignedElsOptions?: ts.ObjectLiteralExpression
   ) {
     const factory = this._factory;
 
-    const slotSelector = `slot${
-      slotName ? `[name=${slotName}]` : ':not([name])'
-    }`;
+    const slotSelector = `slot${slot ? `[name=${slot}]` : ':not([name])'}`;
 
     const assignedElementsOptions = assignedElsOptions
       ? [assignedElsOptions]

--- a/packages/ts-transformers/src/tests/idiomatic-decorators-test.ts
+++ b/packages/ts-transformers/src/tests/idiomatic-decorators-test.ts
@@ -605,7 +605,7 @@ const tests = (test: uvu.Test<uvu.Context>, options: ts.CompilerOptions) => {
 
     class MyElement extends LitElement {
       // listItems comment
-      @queryAssignedElements({ slotName: 'list' })
+      @queryAssignedElements({ slot: 'list' })
       listItems: HTMLElement[];
     }
     `;
@@ -632,7 +632,7 @@ const tests = (test: uvu.Test<uvu.Context>, options: ts.CompilerOptions) => {
 
     class MyElement extends LitElement {
       // listItems comment
-      @queryAssignedElements({ slotName: 'list', flatten: true })
+      @queryAssignedElements({ slot: 'list', flatten: true })
       listItems: NodeListOf<HTMLElement>;
     }
     `;
@@ -659,7 +659,7 @@ const tests = (test: uvu.Test<uvu.Context>, options: ts.CompilerOptions) => {
 
     class MyElement extends LitElement {
       // listItems comment
-      @queryAssignedElements({slotName: 'list', flatten: false, selector: '.item'})
+      @queryAssignedElements({slot: 'list', flatten: false, selector: '.item'})
       listItems: NodeListOf<HTMLElement>;
     }
     `;
@@ -692,7 +692,7 @@ const tests = (test: uvu.Test<uvu.Context>, options: ts.CompilerOptions) => {
 
     class MyElement extends LitElement {
       // listItems comment
-      @queryAssignedElements({slotName: 'list', flatten: isFlatten, selector: '.item'})
+      @queryAssignedElements({slot: 'list', flatten: isFlatten, selector: '.item'})
       listItems: HTMLElement[];
     }
     `;
@@ -721,7 +721,7 @@ const tests = (test: uvu.Test<uvu.Context>, options: ts.CompilerOptions) => {
     import {LitElement} from 'lit';
     import {queryAssignedElements} from 'lit/decorators.js';
 
-    const someIdentifier = {slotName: 'list'};
+    const someIdentifier = {slot: 'list'};
 
     class MyElement extends LitElement {
       // listItems comment
@@ -742,7 +742,7 @@ const tests = (test: uvu.Test<uvu.Context>, options: ts.CompilerOptions) => {
 
     class MyElement extends LitElement {
       // listItems comment
-      @queryAssignedElements({slotName: 'list', ...{}})
+      @queryAssignedElements({slot: 'list', ...{}})
       listItems: HTMLElement[];
     }
     `;
@@ -757,11 +757,11 @@ const tests = (test: uvu.Test<uvu.Context>, options: ts.CompilerOptions) => {
     import {LitElement} from 'lit';
     import {queryAssignedElements} from 'lit/decorators.js';
 
-    const slotName = "shorthandSyntaxInvalid";
+    const slot = "shorthandSyntaxInvalid";
 
     class MyElement extends LitElement {
       // listItems comment
-      @queryAssignedElements({slotName})
+      @queryAssignedElements({slot})
       listItems: HTMLElement[];
     }
     `;
@@ -771,22 +771,22 @@ const tests = (test: uvu.Test<uvu.Context>, options: ts.CompilerOptions) => {
     );
   });
 
-  test('@queryAssignedElements (fail if slotName or selector not literal)', () => {
+  test('@queryAssignedElements (fail if slot or selector not literal)', () => {
     const input = `
     import {LitElement} from 'lit';
     import {queryAssignedElements} from 'lit/decorators.js';
 
-    const slotName = 'list';
+    const slot = 'list';
 
     class MyElement extends LitElement {
       // listItems comment
-      @queryAssignedElements({slotName: slotName})
+      @queryAssignedElements({slot: slot})
       listItems: HTMLElement[];
     }
     `;
     assert.throws(
       () => checkTransform(input, '', options),
-      /property 'slotName' must be a string literal/
+      /property 'slot' must be a string literal/
     );
   });
 

--- a/packages/ts-transformers/src/tests/idiomatic-decorators-test.ts
+++ b/packages/ts-transformers/src/tests/idiomatic-decorators-test.ts
@@ -617,7 +617,7 @@ const tests = (test: uvu.Test<uvu.Context>, options: ts.CompilerOptions) => {
       // listItems comment
       get listItems() {
         return this.renderRoot
-          ?.querySelector(\`slot[name=\${"list"}]\`)
+          ?.querySelector(\`slot[name=list]\`)
           ?.assignedElements() ?? [];
       }
     }
@@ -632,7 +632,7 @@ const tests = (test: uvu.Test<uvu.Context>, options: ts.CompilerOptions) => {
 
     class MyElement extends LitElement {
       // listItems comment
-      @queryAssignedElements({ slot: 'list', flatten: true })
+      @queryAssignedElements({ slot: \`list\`, flatten: true })
       listItems: NodeListOf<HTMLElement>;
     }
     `;
@@ -644,7 +644,7 @@ const tests = (test: uvu.Test<uvu.Context>, options: ts.CompilerOptions) => {
       // listItems comment
       get listItems() {
         return this.renderRoot
-          ?.querySelector(\`slot[name=\${"list"}]\`)
+          ?.querySelector(\`slot[name=list]\`)
           ?.assignedElements({flatten: true}) ?? [];
       }
     }
@@ -671,7 +671,7 @@ const tests = (test: uvu.Test<uvu.Context>, options: ts.CompilerOptions) => {
       // listItems comment
       get listItems() {
         return this.renderRoot
-          ?.querySelector(\`slot[name=\${"list"}]\`)
+          ?.querySelector(\`slot[name=list]\`)
           ?.assignedElements({ flatten: false })
           ?.filter((node) => node.matches('.item')
           ) ?? [];
@@ -706,7 +706,7 @@ const tests = (test: uvu.Test<uvu.Context>, options: ts.CompilerOptions) => {
       // listItems comment
       get listItems() {
         return this.renderRoot
-          ?.querySelector(\`slot[name=\${"list"}]\`)
+          ?.querySelector(\`slot[name=list]\`)
           ?.assignedElements({ flatten: isFlatten })
           ?.filter((node) => node.matches(".item")
           ) ?? [];


### PR DESCRIPTION
Fixes: https://github.com/lit/lit/issues/2292

Adds `queryAssignedElements` decorator and tests (that similarly match the `queryAssignedNodes` tests).

This change proposes a new options bag API which lets us avoid needing to use and empty string if targeting an unnamed slot.

Note that there is temporarily an asymmetry between this decorator and `queryAssignedNodes` which will be addressed with https://github.com/lit/lit/issues/2332.

### How

 - The first commit introduces the new decorator, with tests matching closely what the `queryAssignedNodes` tests. In fact the fixture is almost identical.
 - Then I add the imports closely following the `query-assigned-nodes` references in the codebase.
 - Finally I updated the ts-transformer such that it can transform queryAssignedElements into JS.

### Testing

Change is tested with unit tests, as well as transformer tests.

