### PR TITLE
[@lit-labs/task] Refines when tasks are run

### DIFF
--- a/.changeset/smooth-tigers-train.md
+++ b/.changeset/smooth-tigers-train.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/task': minor
+---
+
+Tasks with no arguments now run by default. When a task runs can be customized by passing a `canRun` function.

--- a/.changeset/thick-tips-serve.md
+++ b/.changeset/thick-tips-serve.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/task': minor
+---
+
+Tasks now run whenever their arguments change. Disable this by setting `autoRun` to `false`, either on the task config or on the task itself. Tasks can be explicitly run by calling `run` and optionally passing custom args.

--- a/packages/labs/task/README.md
+++ b/packages/labs/task/README.md
@@ -8,16 +8,20 @@ Often a Lit element needs to request, process, and render remote data, for
 example when querying a REST API for data to be displayed. The `Task`
 controller provides a simple pattern for encapsulating this behavior in an
 easily reusable way. The controller integrates with a host Lit element. The
-user provides a task function and a dependencies function. Whenever the element
-updates, the dependencies are checked and if any have changed, the task is
-initiated. The controller requests an update of the element whenever the task
+user provides a task function and an arguments function. Whenever the element
+updates, the arguments are checked and if any have changed, the task is
+initiated. This behavior can be customized by passing a `canRun` function. It
+receives arguments of a default `canRun()` function, the task's status, and the
+values of the task's arguments.
+
+The controller requests an update of the element whenever the task
 status changes. Task status is provided via the `TaskStatus` object which has
 values for `INITIAL`, `PENDING`, `COMPLETE`, and `ERROR`. The task result is
 available via its `value` property, or via the `error` property when an error
 occurs. The task `render` method may also be used to easily render different
 task states. It accepts an object which optionally can implement methods for
 `initial`, `pending`, `complete(value)`, and `error(error)`. These methods
-typically return a Lit `TemplateResult` to render
+typically return a Lit `TemplateResult` to render.
 
 ## Installation
 

--- a/packages/labs/task/README.md
+++ b/packages/labs/task/README.md
@@ -10,9 +10,17 @@ controller provides a simple pattern for encapsulating this behavior in an
 easily reusable way. The controller integrates with a host Lit element. The
 user provides a task function and an arguments function. Whenever the element
 updates, the arguments are checked and if any have changed, the task is
-initiated. This behavior can be customized by passing a `canRun` function. It
-receives arguments of a default `canRun()` function, the task's status, and the
-values of the task's arguments.
+initiated.
+
+Sometimes it's important to control exactly when a task runs. For example,
+task arguments may have changed, but it should not run until an interaction
+event like a button click. For these types of use cases, the `autoRun` option
+can be set to `false`. This setting can be passed in the task configuration
+and/or be set on the `Task` itself. It defaults to `true`, but when `autoRun`
+is `false`, the task does not run automatically when arguments change.
+Instead, it can be run explicitly by calling `run(arg?)`. By default, `run()`
+uses the task's configured arguments function, but a custom array of arguments
+may be optionally passed.
 
 The controller requests an update of the element whenever the task
 status changes. Task status is provided via the `TaskStatus` object which has

--- a/packages/labs/task/src/task.ts
+++ b/packages/labs/task/src/task.ts
@@ -12,6 +12,9 @@ export type TaskFunction<D extends [...unknown[]], R = any> = (
 ) => R | typeof initialState | Promise<R | typeof initialState>;
 export type ArgsFunction<D extends [...unknown[]]> = () => D;
 
+// `DepsFunction` is being maintained for BC with its previous name.
+export {ArgsFunction as DepsFunction};
+
 /**
  * States for task status
  */
@@ -129,16 +132,13 @@ export class Task<T extends [...unknown[]] = any, R = any> {
   ) {
     this._host = host;
     this._host.addController(this);
-    if (typeof task === 'object') {
-      const taskConfig = task as TaskConfig<T, R>;
-      args = taskConfig.args;
-      task = taskConfig.task;
-      if (taskConfig.autoRun !== undefined) {
-        this.autoRun = taskConfig.autoRun;
-      }
+    const taskConfig =
+      typeof task === 'object' ? task : ({task, args} as TaskConfig<T, R>);
+    this._task = taskConfig.task;
+    this._getArgs = taskConfig.args;
+    if (taskConfig.autoRun !== undefined) {
+      this.autoRun = taskConfig.autoRun;
     }
-    this._task = task;
-    this._getArgs = args;
     this.taskComplete = new Promise((res, rej) => {
       this._resolveTaskComplete = res;
       this._rejectTaskComplete = rej;

--- a/packages/labs/task/src/task.ts
+++ b/packages/labs/task/src/task.ts
@@ -127,6 +127,12 @@ export class Task<T extends [...unknown[]] = any, R = any> {
 
   constructor(
     host: ReactiveControllerHost,
+    task: TaskFunction<T, R>,
+    args?: ArgsFunction<T>
+  );
+  constructor(host: ReactiveControllerHost, task: TaskConfig<T, R>);
+  constructor(
+    host: ReactiveControllerHost,
     task: TaskFunction<T, R> | TaskConfig<T, R>,
     args?: ArgsFunction<T>
   ) {


### PR DESCRIPTION
Fixes #2323 and #2317.
* Tasks automatically run whenever their arguments change. A task with no arguments does not run; a task with an empty array of arguments runs once; otherwise tasks runs when its arguments array members differs from is previous arguments. 
* The automatic running of tasks based on arguments can be disabled by setting `autoRun` to `false`. This can be done via the task config or by setting the property on the task itself.
* Call `run()` (optionally specifying task arguments) to explicitly run the task.