### PR TITLE
[reactive-element] New queryAssignedNodes API and deprecate current API

### DIFF
--- a/.changeset/hot-penguins-behave.md
+++ b/.changeset/hot-penguins-behave.md
@@ -1,0 +1,9 @@
+---
+'@lit/reactive-element': patch
+'@lit/ts-transformers': patch
+---
+
+Deprecate `@queryAssignedNodes` API in preference for the new options object API which
+mirrors the `@queryAssignedElements` API. Update the documentation for both
+`@queryAssignedNodes` and `@queryAssignedElements` to better document the expected
+return type annotation.

--- a/packages/reactive-element/src/decorators/query-assigned-elements.ts
+++ b/packages/reactive-element/src/decorators/query-assigned-elements.ts
@@ -11,19 +11,10 @@
  * not an arrow function.
  */
 
-import {ReactiveElement} from '../reactive-element.js';
 import {decorateProperty} from './base.js';
 
-export interface QueryAssignedElementsOptions extends AssignedNodesOptions {
-  /**
-   * Name of the slot. Leave empty for the default slot.
-   */
-  slot?: string;
-  /**
-   * CSS selector used to filter the elements returned.
-   */
-  selector?: string;
-}
+import type {ReactiveElement} from '../reactive-element.js';
+import type {QueryAssignedNodesOptions} from './query-assigned-nodes.js';
 
 /**
  * A property decorator that converts a class property into a getter that
@@ -59,7 +50,7 @@ export interface QueryAssignedElementsOptions extends AssignedNodesOptions {
  * ```
  * @category Decorator
  */
-export function queryAssignedElements(options?: QueryAssignedElementsOptions) {
+export function queryAssignedElements(options?: QueryAssignedNodesOptions) {
   const {slot, selector} = options ?? {};
   return decorateProperty({
     descriptor: (_name: PropertyKey) => ({

--- a/packages/reactive-element/src/decorators/query-assigned-elements.ts
+++ b/packages/reactive-element/src/decorators/query-assigned-elements.ts
@@ -22,6 +22,23 @@ import type {QueryAssignedNodesOptions} from './query-assigned-nodes.js';
  * way to use
  * [`slot.assignedElements`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLSlotElement/assignedElements).
  *
+ * Example usage:
+ * ```ts
+ * class MyElement {
+ *   @queryAssignedElements({ slot: 'list' })
+ *   listItems!: Array<HTMLElement>;
+ *   @queryAssignedElements()
+ *   unnamedSlotEls!: Array<HTMLElement>;
+ *
+ *   render() {
+ *     return html`
+ *       <slot name="list"></slot>
+ *       <slot></slot>
+ *     `;
+ *   }
+ * }
+ * ```
+ *
  * Note, the type of this property should be annotated as `Array<HTMLElement>`.
  *
  * @param options Object that sets options for nodes to be returned. See
@@ -33,21 +50,6 @@ import type {QueryAssignedNodesOptions} from './query-assigned-nodes.js';
  * @param options.selector Element results are filtered such that they match the
  *     given CSS selector.
  *
- * ```ts
- * class MyElement {
- *   @queryAssignedElements({ slot: 'list' })
- *   listItems!: Array<HTMLElement>;
- *   @queryAssignedElements()
- *   unnamedSlotEls?: Array<HTMLElement>;
- *
- *   render() {
- *     return html`
- *       <slot name="list"></slot>
- *       <slot></slot>
- *     `;
- *   }
- * }
- * ```
  * @category Decorator
  */
 export function queryAssignedElements(options?: QueryAssignedNodesOptions) {

--- a/packages/reactive-element/src/decorators/query-assigned-elements.ts
+++ b/packages/reactive-element/src/decorators/query-assigned-elements.ts
@@ -16,6 +16,14 @@ import {decorateProperty} from './base.js';
 import type {ReactiveElement} from '../reactive-element.js';
 import type {QueryAssignedNodesOptions} from './query-assigned-nodes.js';
 
+export interface QueryAssignedElementsOptions
+  extends QueryAssignedNodesOptions {
+  /**
+   * CSS selector used to filter the elements returned.
+   */
+  selector?: string;
+}
+
 /**
  * A property decorator that converts a class property into a getter that
  * returns the `assignedElements` of the given `slot`. Provides a declarative
@@ -52,7 +60,7 @@ import type {QueryAssignedNodesOptions} from './query-assigned-nodes.js';
  *
  * @category Decorator
  */
-export function queryAssignedElements(options?: QueryAssignedNodesOptions) {
+export function queryAssignedElements(options?: QueryAssignedElementsOptions) {
   const {slot, selector} = options ?? {};
   return decorateProperty({
     descriptor: (_name: PropertyKey) => ({

--- a/packages/reactive-element/src/decorators/query-assigned-nodes.ts
+++ b/packages/reactive-element/src/decorators/query-assigned-nodes.ts
@@ -26,7 +26,7 @@ export interface QueryAssignedNodesOptions extends AssignedNodesOptions {
   selector?: string;
 }
 
-// Note TypeScript requires the return type to be `void|any`.
+// TypeScript requires the decorator return type to be `void|any`.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type TSDecoratorReturnType = void | any;
 
@@ -34,8 +34,22 @@ type TSDecoratorReturnType = void | any;
  * A property decorator that converts a class property into a getter that
  * returns the `assignedNodes` of the given `slot`.
  *
+ * Example usage:
+ * ```ts
+ * class MyElement {
+ *   @queryAssignedNodes({slot: 'list', flatten: true, selector: '.item'})
+ *   listItems!: Array<HTMLElement>;
+ *
+ *   render() {
+ *     return html`
+ *       <slot name="list"></slot>
+ *     `;
+ *   }
+ * }
+ * ```
+ *
  * Note the type of this property should be annotated as `Array<Node>` if used
- * without a `selector` or `Array<HTMLElement> if a selector is provided.
+ * without a `selector` or `Array<HTMLElement>` if a selector is provided.
  *
  * @param options Object that sets options for nodes to be returned. See
  *     [MDN parameters section](https://developer.mozilla.org/en-US/docs/Web/API/HTMLSlotElement/assignedNodes#parameters)
@@ -45,18 +59,6 @@ type TSDecoratorReturnType = void | any;
  *     default slot.
  * @param options.selector A CSS selector used to filter the elements returned.
  *
- * ```ts
- * class MyElement {
- *   @queryAssignedNodes('list', true, '.item')
- *   listItems?: Array<HTMLElement>;
- *
- *   render() {
- *     return html`
- *       <slot name="list"></slot>
- *     `;
- *   }
- * }
- * ```
  * @category Decorator
  */
 export function queryAssignedNodes(
@@ -67,13 +69,11 @@ export function queryAssignedNodes(
  * A property decorator that converts a class property into a getter that
  * returns the `assignedNodes` of the given named `slot`.
  *
- * Note the type of this property should be annotated as `Array<Node>` if used
- * without a `selector` or `Array<HTMLElement> if a selector is provided.
- *
+ * Example usage:
  * ```ts
  * class MyElement {
  *   @queryAssignedNodes('list', true, '.item')
- *   listItems?: Array<HTMLElement>;
+ *   listItems!: Array<HTMLElement>;
  *
  *   render() {
  *     return html`
@@ -82,6 +82,9 @@ export function queryAssignedNodes(
  *   }
  * }
  * ```
+ *
+ * Note the type of this property should be annotated as `Array<Node>` if used
+ * without a `selector` or `Array<HTMLElement>` if a selector is provided.
  *
  * @param slotName A string name of the slot.
  * @param flatten A boolean which when true flattens the assigned nodes,

--- a/packages/reactive-element/src/test/decorators/queryAssignedNodes_test.ts
+++ b/packages/reactive-element/src/test/decorators/queryAssignedNodes_test.ts
@@ -5,6 +5,7 @@
  */
 
 import {queryAssignedNodes} from '../../decorators/query-assigned-nodes.js';
+import {queryAssignedElements} from '../../decorators/query-assigned-elements.js';
 import {
   canTestReactiveElement,
   generateElementName,
@@ -31,7 +32,8 @@ const flush =
     // Testing backwards compatible deprecated API.
     @queryAssignedNodes('footer', true, '.item')
     _footerAssignedItems!: HTMLElement[];
-    @queryAssignedNodes({slot: 'footer', flatten: true, selector: '.item'})
+    // Legacy selector can be transformed into queryAssignedElements.
+    @queryAssignedElements({slot: 'footer', flatten: true, selector: '.item'})
     footerAssignedItems!: HTMLElement[];
 
     override render() {

--- a/packages/reactive-element/src/test/decorators/queryAssignedNodes_test.ts
+++ b/packages/reactive-element/src/test/decorators/queryAssignedNodes_test.ts
@@ -23,11 +23,16 @@ const flush =
   class D extends RenderingElement {
     @queryAssignedNodes() defaultAssigned!: Node[];
 
-    // The `true` on the decorator indicates that results should be flattened.
-    @queryAssignedNodes('footer', true) footerAssigned!: Node[];
+    // Testing backwards compatible deprecated API.
+    @queryAssignedNodes('footer', true) _footerAssigned!: Node[];
+    @queryAssignedNodes({slot: 'footer', flatten: true})
+    footerAssigned!: Node[];
 
+    // Testing backwards compatible deprecated API.
     @queryAssignedNodes('footer', true, '.item')
-    footerAssignedItems!: Element[];
+    _footerAssignedItems!: HTMLElement[];
+    @queryAssignedNodes({slot: 'footer', flatten: true, selector: '.item'})
+    footerAssignedItems!: HTMLElement[];
 
     override render() {
       return html`
@@ -41,8 +46,6 @@ const flush =
   class E extends RenderingElement {
     @queryAssignedNodes() defaultAssigned!: Node[];
 
-    @queryAssignedNodes('header') headerAssigned!: Node[];
-
     override render() {
       return html`
         <slot name="header"></slot>
@@ -53,11 +56,9 @@ const flush =
   customElements.define('assigned-nodes-el-2', E);
 
   const defaultSymbol = Symbol('default');
-  const headerSymbol = Symbol('header');
+
   class S extends RenderingElement {
     @queryAssignedNodes() [defaultSymbol]!: Node[];
-
-    @queryAssignedNodes('header') [headerSymbol]!: Node[];
 
     override render() {
       return html`
@@ -111,19 +112,14 @@ const flush =
 
   setup(async () => {
     container = document.createElement('div');
-    container.id = 'test-container';
-    document.body.appendChild(container);
+    document.body.append(container);
     el = new C();
     container.appendChild(el);
-    await el.updateComplete;
-    await el.assignedNodesEl.updateComplete;
+    await new Promise((r) => setTimeout(r, 0));
   });
 
   teardown(() => {
-    if (container !== undefined) {
-      container.parentElement!.removeChild(container);
-      (container as any) = undefined;
-    }
+    container?.remove();
   });
 
   test('returns assignedNodes for slot', () => {
@@ -135,10 +131,9 @@ const flush =
     ]);
     const child = document.createElement('div');
     const text1 = document.createTextNode('');
-    el.assignedNodesEl.appendChild(text1);
-    el.assignedNodesEl.appendChild(child);
+    el.assignedNodesEl.append(text1, child);
     const text2 = document.createTextNode('');
-    el.assignedNodesEl.appendChild(text2);
+    el.assignedNodesEl.append(text2);
     flush();
     assert.deepEqual(el.assignedNodesEl.defaultAssigned, [
       el.div,
@@ -147,7 +142,7 @@ const flush =
       child,
       text2,
     ]);
-    el.assignedNodesEl.removeChild(child);
+    child.remove();
     flush();
     assert.deepEqual(el.assignedNodesEl.defaultAssigned, [
       el.div,
@@ -169,15 +164,17 @@ const flush =
     // Note, `defaultAssigned` does `flatten` so we test that the property
     // reflects current state and state when nodes are added or removed to
     // the light DOM of the element containing the element under test.
+    assert.deepEqual(el.assignedNodesEl._footerAssigned, []);
     assert.deepEqual(el.assignedNodesEl.footerAssigned, []);
     const child1 = document.createElement('div');
     const child2 = document.createElement('div');
-    el.appendChild(child1);
-    el.appendChild(child2);
+    el.append(child1, child2);
     flush();
+    assert.deepEqual(el.assignedNodesEl._footerAssigned, [child1, child2]);
     assert.deepEqual(el.assignedNodesEl.footerAssigned, [child1, child2]);
-    el.removeChild(child2);
+    child2.remove();
     flush();
+    assert.deepEqual(el.assignedNodesEl._footerAssigned, [child1]);
     assert.deepEqual(el.assignedNodesEl.footerAssigned, [child1]);
   });
 
@@ -185,34 +182,40 @@ const flush =
     // Note, `defaultAssigned` does `flatten` so we test that the property
     // reflects current state and state when nodes are added or removed to
     // the light DOM of the element containing the element under test.
+    assert.deepEqual(el.assignedNodesEl._footerAssignedItems, []);
     assert.deepEqual(el.assignedNodesEl.footerAssignedItems, []);
     const child1 = document.createElement('div');
     const child2 = document.createElement('div');
     child2.classList.add('item');
-    el.appendChild(child1);
-    el.appendChild(child2);
+    el.append(child1, child2);
     flush();
+    assert.deepEqual(el.assignedNodesEl._footerAssignedItems, [child2]);
     assert.deepEqual(el.assignedNodesEl.footerAssignedItems, [child2]);
-    el.removeChild(child2);
+    child2.remove();
     flush();
+    assert.deepEqual(el.assignedNodesEl._footerAssignedItems, []);
     assert.deepEqual(el.assignedNodesEl.footerAssignedItems, []);
   });
 
   test('returns assignedNodes for slot that contains text nodes filtered by selector', () => {
+    assert.deepEqual(el.assignedNodesEl._footerAssignedItems, []);
     assert.deepEqual(el.assignedNodesEl.footerAssignedItems, []);
     const child1 = document.createElement('div');
     const child2 = document.createElement('div');
     const text1 = document.createTextNode('');
     const text2 = document.createTextNode('');
     child2.classList.add('item');
+    el.append(child1, text1, child2, text2);
     el.appendChild(child1);
     el.appendChild(text1);
     el.appendChild(child2);
     el.appendChild(text2);
     flush();
+    assert.deepEqual(el.assignedNodesEl._footerAssignedItems, [child2]);
     assert.deepEqual(el.assignedNodesEl.footerAssignedItems, [child2]);
     el.removeChild(child2);
     flush();
+    assert.deepEqual(el.assignedNodesEl._footerAssignedItems, []);
     assert.deepEqual(el.assignedNodesEl.footerAssignedItems, []);
   });
 

--- a/packages/ts-transformers/src/internal/decorators/query-assigned-nodes.ts
+++ b/packages/ts-transformers/src/internal/decorators/query-assigned-nodes.ts
@@ -47,10 +47,6 @@ export class QueryAssignedNodesVisitor extends QueryAssignedElementsVisitor {
     }
     super.visit(litClassContext, property, decorator);
   }
-
-  override getSelectorFilter(selector: ts.Expression): ts.Expression {
-    return getSelectorFilter(this._factory, selector);
-  }
 }
 
 class QueryAssignedLegacyNodesVisitor {
@@ -178,7 +174,28 @@ class QueryAssignedLegacyNodesVisitor {
               ],
               undefined,
               factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
-              getSelectorFilter(factory, factory.createStringLiteral(selector))
+              factory.createBinaryExpression(
+                factory.createBinaryExpression(
+                  factory.createPropertyAccessExpression(
+                    factory.createIdentifier('node'),
+                    factory.createIdentifier('nodeType')
+                  ),
+                  factory.createToken(ts.SyntaxKind.EqualsEqualsEqualsToken),
+                  factory.createPropertyAccessExpression(
+                    factory.createIdentifier('Node'),
+                    factory.createIdentifier('ELEMENT_NODE')
+                  )
+                ),
+                factory.createToken(ts.SyntaxKind.AmpersandAmpersandToken),
+                factory.createCallExpression(
+                  factory.createPropertyAccessExpression(
+                    factory.createIdentifier('node'),
+                    factory.createIdentifier('matches')
+                  ),
+                  undefined,
+                  [factory.createStringLiteral(selector)]
+                )
+              )
             ),
           ]
         );
@@ -206,36 +223,4 @@ class QueryAssignedLegacyNodesVisitor {
       getterBody
     );
   }
-}
-
-/**
- * Returns TS representing:
- *   `node.nodeType === Node.ELEMENT_NODE && node.matches(<selector>)`
- */
-function getSelectorFilter(
-  factory: ts.NodeFactory,
-  selector: ts.Expression
-): ts.Expression {
-  return factory.createBinaryExpression(
-    factory.createBinaryExpression(
-      factory.createPropertyAccessExpression(
-        factory.createIdentifier('node'),
-        factory.createIdentifier('nodeType')
-      ),
-      factory.createToken(ts.SyntaxKind.EqualsEqualsEqualsToken),
-      factory.createPropertyAccessExpression(
-        factory.createIdentifier('Node'),
-        factory.createIdentifier('ELEMENT_NODE')
-      )
-    ),
-    factory.createToken(ts.SyntaxKind.AmpersandAmpersandToken),
-    factory.createCallExpression(
-      factory.createPropertyAccessExpression(
-        factory.createIdentifier('node'),
-        factory.createIdentifier('matches')
-      ),
-      undefined,
-      [selector]
-    )
-  );
 }

--- a/packages/ts-transformers/src/tests/idiomatic-decorators-test.ts
+++ b/packages/ts-transformers/src/tests/idiomatic-decorators-test.ts
@@ -907,37 +907,6 @@ const tests = (test: uvu.Test<uvu.Context>, options: ts.CompilerOptions) => {
     checkTransform(input, expected, options);
   });
 
-  test('@queryAssignedNodes (with selector)', () => {
-    const input = `
-    import {LitElement} from 'lit';
-    import {queryAssignedNodes} from 'lit/decorators.js';
-
-    class MyElement extends LitElement {
-      // listItems comment
-      @queryAssignedNodes({slot: 'list', flatten: false, selector: '.item'})
-      listItems: NodeListOf<HTMLElement>;
-    }
-    `;
-
-    const expected = `
-    import {LitElement} from 'lit';
-
-    class MyElement extends LitElement {
-      // listItems comment
-      get listItems() {
-        return this.renderRoot
-          ?.querySelector(\`slot[name=list]\`)
-          ?.assignedNodes({ flatten: false })
-          ?.filter((node) =>
-            node.nodeType === Node.ELEMENT_NODE &&
-              node.matches('.item')
-          ) ?? [];
-      }
-    }
-    `;
-    checkTransform(input, expected, options);
-  });
-
   test('@queryAssignedNodes (with assignedNodes identifier)', () => {
     // It doesn't matter if the HTMLSlotElement.assignedNodes options are
     // using an identifer as we don't need to extract them.
@@ -949,7 +918,7 @@ const tests = (test: uvu.Test<uvu.Context>, options: ts.CompilerOptions) => {
 
     class MyElement extends LitElement {
       // listItems comment
-      @queryAssignedNodes({slot: 'list', flatten: isFlatten, selector: '.item'})
+      @queryAssignedNodes({slot: 'list', flatten: isFlatten})
       listItems: HTMLElement[];
     }
     `;
@@ -964,11 +933,7 @@ const tests = (test: uvu.Test<uvu.Context>, options: ts.CompilerOptions) => {
       get listItems() {
         return this.renderRoot
           ?.querySelector(\`slot[name=list]\`)
-          ?.assignedNodes({ flatten: isFlatten })
-          ?.filter((node) =>
-            node.nodeType === Node.ELEMENT_NODE &&
-              node.matches('.item')
-          ) ?? [];
+          ?.assignedNodes({ flatten: isFlatten }) ?? [];
       }
     }
     `;
@@ -981,11 +946,10 @@ const tests = (test: uvu.Test<uvu.Context>, options: ts.CompilerOptions) => {
     import {queryAssignedNodes} from 'lit/decorators.js';
 
     const slot = 'list';
-    const selector = '.item';
 
     class MyElement extends LitElement {
       // listItems comment
-      @queryAssignedNodes({slot: slot, selector: selector})
+      @queryAssignedNodes({slot: slot})
       listItems: HTMLElement[];
     }
     `;
@@ -994,18 +958,13 @@ const tests = (test: uvu.Test<uvu.Context>, options: ts.CompilerOptions) => {
     import {LitElement} from 'lit';
 
     const slot = 'list';
-    const selector = '.item';
 
     class MyElement extends LitElement {
       // listItems comment
       get listItems() {
         return this.renderRoot
           ?.querySelector(\`slot[name=\${slot}]\`)
-          ?.assignedNodes()
-          ?.filter((node) =>
-            node.nodeType === Node.ELEMENT_NODE &&
-              node.matches(selector)
-          ) ?? [];
+          ?.assignedNodes() ?? [];
       }
     }
     `;
@@ -1018,12 +977,11 @@ const tests = (test: uvu.Test<uvu.Context>, options: ts.CompilerOptions) => {
     import {queryAssignedNodes} from 'lit/decorators.js';
 
     const slot = 'list';
-    const selector = '.item';
     const flatten: boolean = false;
 
     class MyElement extends LitElement {
       // listItems comment
-      @queryAssignedNodes({slot, selector, flatten})
+      @queryAssignedNodes({slot, flatten})
       listItems: HTMLElement[];
     }
     `;
@@ -1032,7 +990,6 @@ const tests = (test: uvu.Test<uvu.Context>, options: ts.CompilerOptions) => {
     import {LitElement} from 'lit';
 
     const slot = 'list';
-    const selector = '.item';
     const flatten = false;
 
     class MyElement extends LitElement {
@@ -1040,11 +997,7 @@ const tests = (test: uvu.Test<uvu.Context>, options: ts.CompilerOptions) => {
       get listItems() {
         return this.renderRoot
           ?.querySelector(\`slot[name=\${slot}]\`)
-          ?.assignedNodes({ flatten })
-          ?.filter((node) =>
-            node.nodeType === Node.ELEMENT_NODE &&
-              node.matches(selector)
-          ) ?? [];
+          ?.assignedNodes({ flatten }) ?? [];
       }
     }
     `;
@@ -1058,7 +1011,7 @@ const tests = (test: uvu.Test<uvu.Context>, options: ts.CompilerOptions) => {
 
     class MyElement extends LitElement {
       // listItems comment
-      @queryAssignedNodes({slot: "li" + "st", selector: "." + "item", flatten: true || false})
+      @queryAssignedNodes({slot: "li" + "st", flatten: true || false})
       listItems: HTMLElement[];
     }
     `;
@@ -1071,11 +1024,7 @@ const tests = (test: uvu.Test<uvu.Context>, options: ts.CompilerOptions) => {
       get listItems() {
         return this.renderRoot
           ?.querySelector(\`slot[name=\${"li" + "st"}]\`)
-          ?.assignedNodes({ flatten: true || false })
-          ?.filter((node) =>
-            node.nodeType === Node.ELEMENT_NODE &&
-              node.matches("." + "item")
-          ) ?? [];
+          ?.assignedNodes({ flatten: true || false }) ?? [];
       }
     }
     `;


### PR DESCRIPTION
Addresses: https://github.com/lit/lit/issues/2332 and https://github.com/lit/lit/issues/2171

Following the inclusion of [queryAssignedElements](https://github.com/lit/lit/pull/2327), this change adds a new API and deprecates the old `@queryAssignedNodes` API.

Note the new `queryAssignedNodes` options does not include `selector`.  If using `selector` please use `@queryAssignedElements`. `@queryAssignedNodes('', false, '.item')` is functionally identical to `@queryAssignedElements({slot: '', flatten: false, selector: '.item'})` or `@queryAssignedElements({selector: '.item'})`.

### Features

- Updated the interface in both TypeScript and jsdocs to deprecate the previous API, and document the new API. The deprecated API contains information about upgrading to use the new API and also mentions `@queryAssignedElements`.
- `@queryAssignedNodes` supports both APIs.
- Transformers:
   - `queryAssignedNodes` visitor refactored slightly so that it continues to work on legacy documentation examples.
   - `queryAssignedElements` visitor refactored so it can be easily extended. It works almost exactly the same as `queryAssignedElements` but with `assignedNodes` method and the generated selector modified.
 - Manually tested lit.dev API documentation generation and ensured that examples render correctly for both `@queryAssignedElements` and `@queryAssignedNodes`.

### Testing

 - VS Code editor experience tested manually (and with tests). Both APIs are tested and documented, and the deprecated API gets marked or crossed out by the IDE.
![Screen Shot 2021-12-06 at 5 44 30 PM](https://user-images.githubusercontent.com/15080861/144950673-c8f942c4-b738-4745-b87f-5affdbb74795.png)
 - Functional unit tests and ts-transformer tests.
 - Manually tested and built Lit.dev to check that it renders the correct overloading documentation.


### Manual testing screenshots on Lit.dev API

Screenshots showing the fixed `@queryAssignedElements` and `@queryAssignedNodes` generated API.

<img width="835" alt="Screen Shot 2021-12-07 at 1 05 14 PM" src="https://user-images.githubusercontent.com/15080861/145106173-0e904c44-c875-4a83-910f-1b9bf0a28708.png">
<img width="835" alt="Screen Shot 2021-12-07 at 1 05 21 PM" src="https://user-images.githubusercontent.com/15080861/145106184-4d501398-8c25-460b-939e-044e0a3bdff4.png">
<img width="839" alt="Screen Shot 2021-12-07 at 1 05 30 PM" src="https://user-images.githubusercontent.com/15080861/145106274-c3e5f05e-10ba-4c35-940f-356169d0da53.png">
<img width="837" alt="Screen Shot 2021-12-07 at 1 05 38 PM" src="https://user-images.githubusercontent.com/15080861/145106286-56a763c6-e51b-4ed4-8e16-fb0838b560aa.png">

