### PR TITLE
Add a license header to the `keyed` directive.

### DIFF
--- a/.changeset/famous-cows-shout.md
+++ b/.changeset/famous-cows-shout.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add a license header to the `keyed` directive.

--- a/packages/lit-html/src/directives/keyed.ts
+++ b/packages/lit-html/src/directives/keyed.ts
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
 import {nothing} from '../lit-html.js';
 import {
   directive,


### PR DESCRIPTION
This file is missing a license header.