### PR TITLE
[ssr] Fix unknown element attribute rendering

### DIFF
--- a/.changeset/khaki-squids-join.md
+++ b/.changeset/khaki-squids-join.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/ssr': patch
+---
+
+Fix bug where static attributes did not render for unknown elements

--- a/packages/labs/ssr/src/lib/render-lit-html.ts
+++ b/packages/labs/ssr/src/lib/render-lit-html.ts
@@ -692,10 +692,8 @@ function* renderTemplateResult(
           op.staticAttributes
         );
         // Set static attributes to the element renderer
-        if (instance !== undefined) {
-          for (const [name, value] of op.staticAttributes) {
-            instance?.setAttribute(name, value);
-          }
+        for (const [name, value] of op.staticAttributes) {
+          instance.setAttribute(name, value);
         }
         renderInfo.customElementInstanceStack.push(instance);
         renderInfo.customElementRendered?.(op.tagName);
@@ -703,21 +701,24 @@ function* renderTemplateResult(
       }
       case 'custom-element-attributes': {
         const instance = getLast(renderInfo.customElementInstanceStack);
-        if (instance !== undefined) {
-          // Perform any connect-time work via the renderer (e.g. reflecting any
-          // properties to attributes, for example)
-          if (instance.connectedCallback) {
-            instance.connectedCallback();
-          }
-          // Render out any attributes on the instance (both static and those
-          // that may have been dynamically set by the renderer)
-          yield* instance.renderAttributes();
-          // If this element is nested in another, add the `defer-hydration`
-          // attribute, so that it does not enable before the host element
-          // hydrates
-          if (renderInfo.customElementHostStack.length > 0) {
-            yield ' defer-hydration';
-          }
+        if (instance === undefined) {
+          throw new Error(
+            `Internal error: ${op.type} outside of custom element context`
+          );
+        }
+        // Perform any connect-time work via the renderer (e.g. reflecting any
+        // properties to attributes, for example)
+        if (instance.connectedCallback) {
+          instance.connectedCallback();
+        }
+        // Render out any attributes on the instance (both static and those
+        // that may have been dynamically set by the renderer)
+        yield* instance.renderAttributes();
+        // If this element is nested in another, add the `defer-hydration`
+        // attribute, so that it does not enable before the host element
+        // hydrates
+        if (renderInfo.customElementHostStack.length > 0) {
+          yield ' defer-hydration';
         }
         break;
       }
@@ -736,7 +737,12 @@ function* renderTemplateResult(
       }
       case 'custom-element-shadow': {
         const instance = getLast(renderInfo.customElementInstanceStack);
-        if (instance !== undefined && instance.renderShadow !== undefined) {
+        if (instance === undefined) {
+          throw new Error(
+            `Internal error: ${op.type} outside of custom element context`
+          );
+        }
+        if (instance.renderShadow !== undefined) {
           renderInfo.customElementHostStack.push(instance);
           const shadowContents = instance.renderShadow(renderInfo);
           // Only emit a DSR if renderShadow() emitted something (returning

--- a/packages/labs/ssr/src/test/integration/tests/basic.ts
+++ b/packages/labs/ssr/src/test/integration/tests/basic.ts
@@ -4301,6 +4301,55 @@ export const tests: {[name: string]: SSRTest} = {
   },
 
   /******************************************************
+   * Unknown element/renderer tests
+   ******************************************************/
+
+  'Unregistered custom element: Attributes': () => {
+    return {
+      render() {
+        return html`
+          <x-unregistered
+            attr1
+            attr2="attr2val"
+            attr3=${'attr3val'}
+          ></x-unregistered>
+        `;
+      },
+      expectations: [
+        {
+          args: [],
+          html: '<x-unregistered attr1 attr2="attr2val" attr3="attr3val"></x-unregistered>',
+        },
+      ],
+      stableSelectors: ['x-unregistered'],
+    };
+  },
+
+  'Custom element with no renderer: Attributes': () => {
+    return {
+      registerElements() {
+        customElements.define('x-norenderer', class extends HTMLElement {});
+      },
+      render() {
+        return html`
+          <x-norenderer
+            attr1
+            attr2="attr2val"
+            attr3=${'attr3val'}
+          ></x-norenderer>
+        `;
+      },
+      expectations: [
+        {
+          args: [],
+          html: '<x-norenderer attr1 attr2="attr2val" attr3="attr3val"></x-norenderer>',
+        },
+      ],
+      stableSelectors: ['x-norenderer'],
+    };
+  },
+
+  /******************************************************
    * LitElement tests
    ******************************************************/
 


### PR DESCRIPTION
Fixes a bug where static attributes on custom elements would not render if the custom element was unregistered or did not have a renderer.

I considered a few ways to solve this and picked [2]. Open to switching to [1] or doing something else:

1. Don't emit `custom-element-*` opcodes at all for un-renderable elements. However, this would make `getTemplateOpcodes` dependent on `renderInfo`, and it seemed kind of nice to preserve the feature of `getTemplateOpcodes` being only a function of the template. If we did this, seems like we'd want to add the renderer `instance` to the `custom-element-open` opcode, so that we don't look up the renderer twice.

2. Add a new `FallbackRenderer` class which just tracks and renders attributes. **This is what I picked**, since it seemed pretty undisprutive, and it's sort of nice to not have to handle the `undefined` case as specially in the opcode render loop.

3. Add special tracking for unrenderable elements using a bag of attributes directly in the `customElementInstanceStack` stack, and add fallback logic to render static attributes in the `custom-element-attributes` switch case. This just seemed like a less clean way of writing [2].

Fixes https://github.com/lit/lit/issues/2321