### PR TITLE
[ssr] Replace escape-html dependency with our own version

### DIFF
--- a/.changeset/fresh-eggs-check.md
+++ b/.changeset/fresh-eggs-check.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/ssr': patch
+---
+
+Remove dependency on escape-html (which is not an ES module)

--- a/packages/labs/ssr/package-lock.json
+++ b/packages/labs/ssr/package-lock.json
@@ -9,7 +9,6 @@
 			"version": "1.0.0",
 			"license": "BSD-3-Clause",
 			"dependencies": {
-				"escape-html": "^1.0.3",
 				"node-fetch": "^2.6.0",
 				"parse5": "^6.0.1",
 				"resolve": "^1.10.1"
@@ -20,7 +19,6 @@
 				"@open-wc/testing-karma": "^4.0.9",
 				"@types/chai": "^4.2.11",
 				"@types/command-line-args": "^5.0.0",
-				"@types/escape-html": "^1.0.0",
 				"@types/koa": "^2.0.49",
 				"@types/koa__router": "^8.0.2",
 				"@types/koa-cors": "*",
@@ -2641,12 +2639,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@types/debounce/-/debounce-1.2.0.tgz",
 			"integrity": "sha512-bWG5wapaWgbss9E238T0R6bfo5Fh3OkeoSt245CM7JJwVwpw6MEBCbIxLq5z8KzsE3uJhzcIuQkyiZmzV3M/Dw==",
-			"dev": true
-		},
-		"node_modules/@types/escape-html": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@types/escape-html/-/escape-html-1.0.1.tgz",
-			"integrity": "sha512-4mI1FuUUZiuT95fSVqvZxp/ssQK9zsa86S43h9x3zPOSU9BBJ+BfDkXwuaU7BfsD+e7U0/cUUfJFk3iW2M4okA==",
 			"dev": true
 		},
 		"node_modules/@types/estree": {
@@ -5552,7 +5544,8 @@
 		"node_modules/escape-html": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+			"dev": true
 		},
 		"node_modules/escape-string-regexp": {
 			"version": "1.0.5",
@@ -12954,12 +12947,6 @@
 			"integrity": "sha512-bWG5wapaWgbss9E238T0R6bfo5Fh3OkeoSt245CM7JJwVwpw6MEBCbIxLq5z8KzsE3uJhzcIuQkyiZmzV3M/Dw==",
 			"dev": true
 		},
-		"@types/escape-html": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@types/escape-html/-/escape-html-1.0.1.tgz",
-			"integrity": "sha512-4mI1FuUUZiuT95fSVqvZxp/ssQK9zsa86S43h9x3zPOSU9BBJ+BfDkXwuaU7BfsD+e7U0/cUUfJFk3iW2M4okA==",
-			"dev": true
-		},
 		"@types/estree": {
 			"version": "0.0.39",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
@@ -15335,7 +15322,8 @@
 		"escape-html": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+			"dev": true
 		},
 		"escape-string-regexp": {
 			"version": "1.0.5",

--- a/packages/labs/ssr/package.json
+++ b/packages/labs/ssr/package.json
@@ -37,7 +37,6 @@
     "@open-wc/testing": "^3.0.0-next.1",
     "@types/chai": "^4.2.11",
     "@types/command-line-args": "^5.0.0",
-    "@types/escape-html": "^1.0.0",
     "@types/koa__router": "^8.0.2",
     "@types/koa-cors": "*",
     "@types/koa-static": "^4.0.1",
@@ -63,7 +62,6 @@
   "dependencies": {
     "@lit-labs/ssr-client": "^1.0.0",
     "@lit/reactive-element": "1.0.2",
-    "escape-html": "^1.0.3",
     "lit-element": "^3.0.0",
     "lit-html": "^2.0.0",
     "lit": "^2.0.0",

--- a/packages/labs/ssr/src/lib/element-renderer.ts
+++ b/packages/labs/ssr/src/lib/element-renderer.ts
@@ -6,15 +6,10 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-export type Constructor<T> = {new (): T};
-
-import {createRequire} from 'module';
-const require = createRequire(import.meta.url);
-
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const escapeHtml = require('escape-html') as typeof import('escape-html');
-
+import {escapeHtml} from './util/escape-html.js';
 import {RenderInfo} from './render-lit-html.js';
+
+export type Constructor<T> = {new (): T};
 
 export type ElementRendererConstructor = (new (
   tagName: string

--- a/packages/labs/ssr/src/lib/render-lit-html.ts
+++ b/packages/labs/ssr/src/lib/render-lit-html.ts
@@ -42,11 +42,7 @@ import {
   getElementRenderer,
 } from './element-renderer.js';
 
-import {createRequire} from 'module';
-const require = createRequire(import.meta.url);
-
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const escapeHtml = require('escape-html') as typeof import('escape-html');
+import {escapeHtml} from './util/escape-html.js';
 
 import {
   traverse,

--- a/packages/labs/ssr/src/lib/util/escape-html.ts
+++ b/packages/labs/ssr/src/lib/util/escape-html.ts
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const replacements = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  // Note &apos; was not defined in the HTML4 spec, and is not supported by very
+  // old browsers like IE8, so a codepoint entity is used instead.
+  "'": '&#39;',
+};
+
+/**
+ * Replaces characters which have special meaning in HTML (&<>"') with escaped
+ * HTML entities ("&amp;", "&lt;", etc.).
+ */
+export const escapeHtml = (str: string) =>
+  str.replace(
+    /[&<>"']/g,
+    (char) => replacements[char as keyof typeof replacements]
+  );


### PR DESCRIPTION
The `escape-html` package is not an ES module, and it's a pretty trivial function to just write ourselves. See https://unpkg.com/browse/escape-html@1.0.3/index.js for reference. This new implementation should have the exact same output.

Advantages: getting rid of the only non-esm dependency helps with running SSR in deno and service-workers, and drops our dependency surface area and package size.

Fixes https://github.com/lit/lit/issues/1998

