### PR TITLE
WIP: ReactElement base class

### DIFF
--- a/packages/labs/react/src/react-element.ts
+++ b/packages/labs/react/src/react-element.ts
@@ -1,0 +1,82 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {ReactiveElement, PropertyValues} from '@lit/reactive-element';
+export * from '@lit/reactive-element';
+export * from '@lit/reactive-element/decorators';
+import type * as ReactModule from 'react';
+import type * as ReactDOMModule from 'react-dom';
+
+type React = typeof ReactModule;
+type ReactDOM = typeof ReactDOMModule;
+
+/**
+ * A base class for wrapping React components as reactive web components.
+ *
+ * @example
+ *
+ * ```ts
+ * import {MyComponent} from './my-component.js';
+ *
+ * @customElement('my-element')
+ * export class MyElement extends ReactElement {
+ *   @property()
+ *   foo: string;
+ *
+ *   render() {
+ *     return <MyComponent foo={this.foo} onBar={this._onBar}></MyComponent>;
+ *   }
+ *
+ *   private _onBar = (data: BarData) => {
+ *     this.dispatchEvent(new BarEvent(data));
+ *   }
+ * }
+ *
+ * class BarEvent extends Event {
+ *   data: BarData;
+ *   constructor(data: BarData) {
+ *     super('bar-event', {bubbles: true, composed: true});
+ *     this.data = data;
+ *   }
+ * }
+ * ```
+ *
+ * This class defaults to loading `React` and `ReactDOM` off of `window`. You
+ * can change this by setting the static `React` and `ReactDOM` references.
+ * This is useful if you're using the CJS build of React with a bundler so that
+ * you can import React:
+ *
+ * ```ts
+ * import * as React from 'react';
+ * import * as ReactDOM from 'react-dom';
+ *
+ * export class MyElement extends ReactElement {
+ *   static React = React;
+ *   static ReactDOM = ReactDOM;
+ * }
+ * ```
+ */
+export class ReactElement extends ReactiveElement {
+  static ReactDOM: ReactDOM = window.ReactDOM;
+  static React: React = window.React;
+
+  override update(changedProperties: PropertyValues) {
+    const vdom = this.render();
+    super.update(changedProperties);
+    const reactDOM = (this.constructor as typeof ReactElement).ReactDOM;
+    reactDOM.render(vdom, this.renderRoot);
+  }
+
+  protected render():
+    | React.ReactElement
+    | React.DOMElement<
+        React.HTMLAttributes<unknown> | React.SVGAttributes<unknown>,
+        Element
+      > {
+    const react = (this.constructor as typeof ReactElement).React;
+    return react.createElement(react.Fragment);
+  }
+}


### PR DESCRIPTION
Addresses #2353 

WIP: This is the very first cut of this code, ported from a similar base class for Preact: https://stackblitz.com/edit/preact-element?file=preact-element.ts

I presume there will be more to figure out to make this robust, especially:

- Basics
  - Does React work well in a shadow root? Do we have to do anything to get React's delegating event handlers wired up?
  - Do we need to do anything special with children / slots?
- Events
  - Can we make creating events for event-props more automatic?
  - What happens for components that change behavior based on the presence of an event callback? We can't quite do the same in the DOM where we don't know if there are any listeners and always have to fire the event. Is there a pattern we can recommend? Can we find examples?
- Suspense
  - Can we catch Suspense errors and turn them into [Pending Task](https://github.com/webcomponents-cg/community-protocols/blob/main/proposals/pending-task.md) events?
  - Should Suspense delay the `updateComplete` Promise?
- Context
  - Can we map the [Context Protocol](https://github.com/webcomponents-cg/community-protocols/blob/main/proposals/context.md) into React contexts? (we should also investigate the inverse for `createComponent()`)