### PR TITLE
Improve docs to more clearly link to the options interface for queryAssignedNodes

### DIFF
--- a/.changeset/brave-planes-juggle.md
+++ b/.changeset/brave-planes-juggle.md
@@ -1,0 +1,5 @@
+---
+'@lit/reactive-element': patch
+---
+
+Update `@queryAssignedNodes` and `@queryAssignedElements` documentation for better lit.dev API generation.

--- a/packages/reactive-element/src/decorators/query-assigned-elements.ts
+++ b/packages/reactive-element/src/decorators/query-assigned-elements.ts
@@ -16,10 +16,16 @@ import {decorateProperty} from './base.js';
 import type {ReactiveElement} from '../reactive-element.js';
 import type {QueryAssignedNodesOptions} from './query-assigned-nodes.js';
 
+/**
+ * Options for the {@link queryAssignedElements} decorator. Extends from the
+ * options that can be passed into
+ * [HTMLSlotElement.assignedElements](https://developer.mozilla.org/en-US/docs/Web/API/HTMLSlotElement/assignedElements).
+ */
 export interface QueryAssignedElementsOptions
   extends QueryAssignedNodesOptions {
   /**
-   * CSS selector used to filter the elements returned.
+   * CSS selector used to filter the elements returned. For example, a selector
+   * of `".item"` will only include elements with the `item` class.
    */
   selector?: string;
 }
@@ -50,9 +56,7 @@ export interface QueryAssignedElementsOptions
  * Note, the type of this property should be annotated as `Array<HTMLElement>`.
  *
  * @param options Object that sets options for nodes to be returned. See
- *     [MDN parameters section](https://developer.mozilla.org/en-US/docs/Web/API/HTMLSlotElement/assignedElements#parameters)
- *     for available options. Also accepts two more optional properties,
- *     `slot` and `selector`.
+ *     {@link QueryAssignedElementsOptions} for all available options.
  * @param options.slot Name of the slot. Undefined or empty string for the
  *     default slot.
  * @param options.selector Element results are filtered such that they match the

--- a/packages/reactive-element/src/decorators/query-assigned-elements.ts
+++ b/packages/reactive-element/src/decorators/query-assigned-elements.ts
@@ -17,8 +17,8 @@ import type {ReactiveElement} from '../reactive-element.js';
 import type {QueryAssignedNodesOptions} from './query-assigned-nodes.js';
 
 /**
- * Options for the {@link queryAssignedElements} decorator. Extends from the
- * options that can be passed into
+ * Options for the [[`queryAssignedElements`]] decorator. Extends the options
+ * that can be passed into
  * [HTMLSlotElement.assignedElements](https://developer.mozilla.org/en-US/docs/Web/API/HTMLSlotElement/assignedElements).
  */
 export interface QueryAssignedElementsOptions
@@ -35,6 +35,8 @@ export interface QueryAssignedElementsOptions
  * returns the `assignedElements` of the given `slot`. Provides a declarative
  * way to use
  * [`slot.assignedElements`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLSlotElement/assignedElements).
+ *
+ * Can be passed an optional [[`QueryAssignedElementsOptions`]] object.
  *
  * Example usage:
  * ```ts
@@ -54,9 +56,6 @@ export interface QueryAssignedElementsOptions
  * ```
  *
  * Note, the type of this property should be annotated as `Array<HTMLElement>`.
- *
- * @param options Object that sets options for nodes to be returned. See
- *     {@link QueryAssignedElementsOptions} for all available options.
  *
  * @category Decorator
  */

--- a/packages/reactive-element/src/decorators/query-assigned-elements.ts
+++ b/packages/reactive-element/src/decorators/query-assigned-elements.ts
@@ -57,10 +57,6 @@ export interface QueryAssignedElementsOptions
  *
  * @param options Object that sets options for nodes to be returned. See
  *     {@link QueryAssignedElementsOptions} for all available options.
- * @param options.slot Name of the slot. Undefined or empty string for the
- *     default slot.
- * @param options.selector Element results are filtered such that they match the
- *     given CSS selector.
  *
  * @category Decorator
  */

--- a/packages/reactive-element/src/decorators/query-assigned-nodes.ts
+++ b/packages/reactive-element/src/decorators/query-assigned-nodes.ts
@@ -15,9 +15,14 @@ import {decorateProperty} from './base.js';
 
 import type {ReactiveElement} from '../reactive-element.js';
 
+/**
+ * Options for the {@link queryAssignedNodes} decorator. Extends from the
+ * options that can be passed into
+ * [HTMLSlotElement.assignedNodes](https://developer.mozilla.org/en-US/docs/Web/API/HTMLSlotElement/assignedNodes).
+ */
 export interface QueryAssignedNodesOptions extends AssignedNodesOptions {
   /**
-   * Name of the slot. Leave empty for the default slot.
+   * Name of the slot to query. Leave empty for the default slot.
    */
   slot?: string;
 }
@@ -47,8 +52,7 @@ type TSDecoratorReturnType = void | any;
  * Note the type of this property should be annotated as `Array<Node>`.
  *
  * @param options Object that sets options for nodes to be returned. See
- *     [MDN parameters section](https://developer.mozilla.org/en-US/docs/Web/API/HTMLSlotElement/assignedNodes#parameters)
- *     for available options.
+ *     {@link QueryAssignedNodesOptions} for all available options.
  * @param options.slot Name of the slot. Undefined or empty string for the
  *     default slot.
  *

--- a/packages/reactive-element/src/decorators/query-assigned-nodes.ts
+++ b/packages/reactive-element/src/decorators/query-assigned-nodes.ts
@@ -53,8 +53,6 @@ type TSDecoratorReturnType = void | any;
  *
  * @param options Object that sets options for nodes to be returned. See
  *     {@link QueryAssignedNodesOptions} for all available options.
- * @param options.slot Name of the slot. Undefined or empty string for the
- *     default slot.
  *
  * @category Decorator
  */

--- a/packages/reactive-element/src/decorators/query-assigned-nodes.ts
+++ b/packages/reactive-element/src/decorators/query-assigned-nodes.ts
@@ -16,8 +16,8 @@ import {decorateProperty} from './base.js';
 import type {ReactiveElement} from '../reactive-element.js';
 
 /**
- * Options for the {@link queryAssignedNodes} decorator. Extends from the
- * options that can be passed into
+ * Options for the [[`queryAssignedNodes`]] decorator. Extends the options that
+ * can be passed into
  * [HTMLSlotElement.assignedNodes](https://developer.mozilla.org/en-US/docs/Web/API/HTMLSlotElement/assignedNodes).
  */
 export interface QueryAssignedNodesOptions extends AssignedNodesOptions {
@@ -35,6 +35,8 @@ type TSDecoratorReturnType = void | any;
  * A property decorator that converts a class property into a getter that
  * returns the `assignedNodes` of the given `slot`.
  *
+ * Can be passed an optional [[`QueryAssignedNodesOptions`]] object.
+ *
  * Example usage:
  * ```ts
  * class MyElement {
@@ -50,9 +52,6 @@ type TSDecoratorReturnType = void | any;
  * ```
  *
  * Note the type of this property should be annotated as `Array<Node>`.
- *
- * @param options Object that sets options for nodes to be returned. See
- *     {@link QueryAssignedNodesOptions} for all available options.
  *
  * @category Decorator
  */


### PR DESCRIPTION
Raised in https://github.com/lit/lit.dev/pull/623

This change makes the link to the options object clearer for both queryAssignedElements and queryAssignedNodes.

Initially wanted to link from the `@param options` jsdoc, but it's not yet supported on Lit.dev.

It's easier to document this currently with the TypeScript types and a link in the description documentation. Once https://github.com/lit/lit.dev/issues/503 is addressed we can update this with `@link` and `@param` providing the best of both worlds. 

Tested manually with lit.dev api generation.

This now shows up like so and the link can be clicked. Information is de-duped:
![Screen Shot 2021-12-14 at 2 33 13 PM](https://user-images.githubusercontent.com/15080861/146090026-19139ac0-e929-4309-a7d5-ebfdefdab30b.png)

