### PR TITLE
Fix missing decorators/query-assigned-elements.js file

### DIFF
--- a/.changeset/brown-swans-flow.md
+++ b/.changeset/brown-swans-flow.md
@@ -1,0 +1,7 @@
+---
+'lit': patch
+'lit-element': patch
+'@lit/reactive-element': patch
+---
+
+Fix missing decorators/query-assigned-elements.js file

--- a/packages/lit-element/rollup.config.js
+++ b/packages/lit-element/rollup.config.js
@@ -21,6 +21,7 @@ export default litProdConfig({
     'decorators/property',
     'decorators/query',
     'decorators/query-all',
+    'decorators/query-assigned-elements',
     'decorators/query-assigned-nodes',
     'decorators/query-async',
   ],

--- a/packages/lit/rollup.config.js
+++ b/packages/lit/rollup.config.js
@@ -16,6 +16,7 @@ export default litProdConfig({
     'decorators/property',
     'decorators/query',
     'decorators/query-all',
+    'decorators/query-assigned-elements',
     'decorators/query-assigned-nodes',
     'decorators/query-async',
     'decorators/state',

--- a/packages/reactive-element/rollup.config.js
+++ b/packages/reactive-element/rollup.config.js
@@ -21,6 +21,7 @@ export default litProdConfig({
     'decorators/property',
     'decorators/query',
     'decorators/query-all',
+    'decorators/query-assigned-elements',
     'decorators/query-assigned-nodes',
     'decorators/query-async',
   ],


### PR DESCRIPTION
We forgot to update the `rollup.config.js` files to include the new `query-assigned-elements.js` decorator file in the NPM packages.

May help with https://github.com/lit/lit/issues/2383, but I think this is a new problem on top of an existing Deno-related problem with Skypack.