### PR TITLE
Add missing caret to SSR's reactive-element dependency range

### DIFF
--- a/.changeset/twelve-yaks-hide.md
+++ b/.changeset/twelve-yaks-hide.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/ssr': patch
+---
+
+Unpin SSR's dependency on reactive-element

--- a/packages/labs/ssr/package.json
+++ b/packages/labs/ssr/package.json
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@lit-labs/ssr-client": "^1.0.0",
-    "@lit/reactive-element": "1.1.0",
+    "@lit/reactive-element": "^1.1.0",
     "lit-element": "^3.1.0",
     "lit-html": "^2.1.0",
     "lit": "^2.1.0",


### PR DESCRIPTION
Not sure why this was pinned to 1.1.0 -- it should use a ^ range like everything else.