### PR TITLE
Fix choose directive jsdoc example code

### DIFF
--- a/.changeset/chilly-buckets-rescue.md
+++ b/.changeset/chilly-buckets-rescue.md
@@ -1,0 +1,5 @@
+---
+'lit-html': patch
+---
+
+Fix choose directive jsdoc code example.

--- a/packages/lit-html/src/directives/choose.ts
+++ b/packages/lit-html/src/directives/choose.ts
@@ -21,10 +21,10 @@
  * render() {
  *   return html`
  *     ${choose(this.section, [
- *       ['home', () => <h1>Home</h1>]
- *       ['about', () => <h1>About</h1>]
+ *       ['home', () => html`<h1>Home</h1>`],
+ *       ['about', () => html`<h1>About</h1>`]
  *     ],
- *     () => html`<h1>Error</h1>)}
+ *     () => html`<h1>Error</h1>`)}
  *   `;
  * }
  * ```


### PR DESCRIPTION
Fix missing html tagged template literals in the choose example code.

Mirrors: https://github.com/lit/lit.dev/pull/640.