### PR TITLE
Improve queryAssignedElements decorator browser compatibility

### DIFF
--- a/.changeset/stupid-rockets-deliver.md
+++ b/.changeset/stupid-rockets-deliver.md
@@ -1,0 +1,5 @@
+---
+'@lit/reactive-element': patch
+---
+
+Fix `@queryAssignedElements` decorator so internal implementation is compatible with Lit's browser support matrix.

--- a/.changeset/stupid-rockets-deliver.md
+++ b/.changeset/stupid-rockets-deliver.md
@@ -2,4 +2,6 @@
 '@lit/reactive-element': patch
 ---
 
-Fix `@queryAssignedElements` decorator so internal implementation is compatible with Lit's browser support matrix.
+Fix `@queryAssignedElements` decorator so it is compatible with legacy browsers.
+Uses `HTMLSlotElement.assignedElements` if available with a graceful fallback
+on `HTMLSlotElement.assignedNodes` which is supported by polyfills.

--- a/packages/reactive-element/src/decorators/query-assigned-elements.ts
+++ b/packages/reactive-element/src/decorators/query-assigned-elements.ts
@@ -23,10 +23,10 @@ const slotAssignedElements =
   window.HTMLSlotElement?.prototype.assignedElements ??
   function slotAssignedElementsPolyfill(
     this: HTMLSlotElement,
-    opts: AssignedNodesOptions
+    opts?: AssignedNodesOptions
   ) {
     return this.assignedNodes(opts).filter(
-      (node) => node.nodeType === Node.ELEMENT_NODE
+      (node): node is Element => node.nodeType === Node.ELEMENT_NODE
     );
   };
 
@@ -82,7 +82,7 @@ export function queryAssignedElements(options?: QueryAssignedElementsOptions) {
         const slotEl =
           this.renderRoot?.querySelector<HTMLSlotElement>(slotSelector);
         const elements =
-          slotEl !== null ? slotAssignedElements.call(slotEl, options) : [];
+          slotEl != null ? slotAssignedElements.call(slotEl, options) : [];
         if (selector) {
           return elements.filter((node) => node.matches(selector));
         }

--- a/packages/reactive-element/src/decorators/query-assigned-elements.ts
+++ b/packages/reactive-element/src/decorators/query-assigned-elements.ts
@@ -67,11 +67,18 @@ export function queryAssignedElements(options?: QueryAssignedElementsOptions) {
         const slotSelector = `slot${slot ? `[name=${slot}]` : ':not([name])'}`;
         const slotEl =
           this.renderRoot?.querySelector<HTMLSlotElement>(slotSelector);
-        const elements = slotEl?.assignedElements(options) ?? [];
+        // HTMLSlotElement.assignedElements would be preferred here, however
+        // there isn't a good path forward regarding browser polyfill support.
+        const elements = slotEl?.assignedNodes(options) ?? [];
         if (selector) {
-          return elements.filter((node) => node.matches(selector));
+          return elements.filter(
+            (node) =>
+              node.nodeType === Node.ELEMENT_NODE &&
+              (node as Element).matches(selector)
+          );
+        } else {
+          return elements.filter((node) => node.nodeType === Node.ELEMENT_NODE);
         }
-        return elements;
       },
       enumerable: true,
       configurable: true,

--- a/packages/reactive-element/src/decorators/query-assigned-elements.ts
+++ b/packages/reactive-element/src/decorators/query-assigned-elements.ts
@@ -20,15 +20,15 @@ import type {QueryAssignedNodesOptions} from './query-assigned-nodes.js';
  * A tiny module scoped polyfill for HTMLSlotElement.assignedElements.
  */
 const slotAssignedElements =
-  window.HTMLSlotElement?.prototype.assignedElements ??
-  function slotAssignedElementsPolyfill(
-    this: HTMLSlotElement,
-    opts?: AssignedNodesOptions
-  ) {
-    return this.assignedNodes(opts).filter(
-      (node): node is Element => node.nodeType === Node.ELEMENT_NODE
-    );
-  };
+  window.HTMLSlotElement?.prototype.assignedElements != null
+    ? (slot: HTMLSlotElement, opts?: AssignedNodesOptions) =>
+        slot.assignedElements(opts)
+    : (slot: HTMLSlotElement, opts?: AssignedNodesOptions) =>
+        slot
+          .assignedNodes(opts)
+          .filter(
+            (node): node is Element => node.nodeType === Node.ELEMENT_NODE
+          );
 
 /**
  * Options for the [[`queryAssignedElements`]] decorator. Extends the options
@@ -82,7 +82,7 @@ export function queryAssignedElements(options?: QueryAssignedElementsOptions) {
         const slotEl =
           this.renderRoot?.querySelector<HTMLSlotElement>(slotSelector);
         const elements =
-          slotEl != null ? slotAssignedElements.call(slotEl, options) : [];
+          slotEl != null ? slotAssignedElements(slotEl, options) : [];
         if (selector) {
           return elements.filter((node) => node.matches(selector));
         }

--- a/packages/reactive-element/src/decorators/query-assigned-nodes.ts
+++ b/packages/reactive-element/src/decorators/query-assigned-nodes.ts
@@ -12,6 +12,7 @@
  */
 
 import {decorateProperty} from './base.js';
+import {queryAssignedElements} from './query-assigned-elements.js';
 
 import type {ReactiveElement} from '../reactive-element.js';
 
@@ -114,7 +115,16 @@ export function queryAssignedNodes(
   } else {
     assignedNodesOptions = {flatten};
   }
-  selector ??= '';
+
+  // For backwards compatibility, queryAssignedNodes with a selector behaves
+  // exactly like queryAssignedElements with a selector.
+  if (selector) {
+    return queryAssignedElements({
+      slot: slot as string,
+      flatten,
+      selector,
+    });
+  }
 
   return decorateProperty({
     descriptor: (_name: PropertyKey) => ({
@@ -122,15 +132,7 @@ export function queryAssignedNodes(
         const slotSelector = `slot${slot ? `[name=${slot}]` : ':not([name])'}`;
         const slotEl =
           this.renderRoot?.querySelector<HTMLSlotElement>(slotSelector);
-        let nodes = slotEl?.assignedNodes(assignedNodesOptions) ?? [];
-        if (selector) {
-          nodes = nodes.filter(
-            (node) =>
-              node.nodeType === Node.ELEMENT_NODE &&
-              (node as Element).matches(selector as string)
-          );
-        }
-        return nodes;
+        return slotEl?.assignedNodes(assignedNodesOptions) ?? [];
       },
       enumerable: true,
       configurable: true,


### PR DESCRIPTION
### Context

Internally queryAssignedElements was using the newer `HTMLSlotElement.assignedElements` method. This newer method doesn't have ShadyDOM polyfill support, but would still leave some browsers unsupported if it did have polyfill support.

Using [Modern browser breakdown](https://lit.dev/docs/tools/requirements/#modern-browser-breakdown) as a guide, `assignedElements` is not supported until Firefox 66. This leaves Firefox versions 64 and 65 without support.

tl;dr `queryAssignedElements` doesn't work on older browsers.

### How

Gracefully fallback on `assignedNodes` if required.  The behavior of the decorator remains unchanged.

### Testing

This is a private implementation change, so the existing unit tests should cover this. No functional changes.
Also testing via cl/420366110

Size of decorators before changes (on main):

```
Name                                   Size     Minified  Gzipped  Brotli   
----------------------------------------------------------------------------
decorators/query-assigned-elements.js  74 B     73 B      87 B     62 B     
decorators/query-assigned-nodes.js     71 B     70 B      86 B     63 B 

decorators/query-assigned-elements.js (DEV)  519 B     518 B     380 B    323 B
decorators/query-assigned-nodes.js (DEV)     593 B     592 B     442 B    362 B 
```

Size of decorators after change:

```
Name                                   Size      Minified  Gzipped  Brotli   
-----------------------------------------------------------------------------
decorators/query-assigned-elements.js  74 B    73 B      87 B     62 B     
decorators/query-assigned-nodes.js     71 B    70 B      86 B     63 B

decorators/query-assigned-elements.js (DEV)  685 B     684 B     464 B    391 B    
decorators/query-assigned-nodes.js (DEV)     606 B     605 B     421 B    361 B 
```

The release size is the same after this change, only dev has slightly increased in size.