### PR TITLE
Add a devlog events system

### DIFF
--- a/.changeset/chilly-spies-brush.md
+++ b/.changeset/chilly-spies-brush.md
@@ -1,6 +1,0 @@
----
-'lit-html': patch
-'@lit/reactive-element': patch
----
-
-Added a devlog events system that may be used for debugging and visualizing Lit's internals.

--- a/.changeset/chilly-spies-brush.md
+++ b/.changeset/chilly-spies-brush.md
@@ -1,0 +1,6 @@
+---
+'lit-html': patch
+'@lit/reactive-element': patch
+---
+
+Added a devlog events system that may be used for debugging and visualizing Lit's internals.

--- a/.changeset/perfect-pens-itch.md
+++ b/.changeset/perfect-pens-itch.md
@@ -1,0 +1,7 @@
+---
+'lit-element': minor
+'lit-html': minor
+'@lit/reactive-element': minor
+---
+
+Added a devlog events system that may be used for debugging and visualizing Lit's internals.

--- a/packages/lit-element/src/lit-element.ts
+++ b/packages/lit-element/src/lit-element.ts
@@ -51,6 +51,34 @@ import {render, RenderOptions, noChange, RootPart} from 'lit-html';
 export * from '@lit/reactive-element';
 export * from 'lit-html';
 
+import {LitUnstable} from 'lit-html';
+import {ReactiveUnstable} from '@lit/reactive-element';
+
+/**
+ * Contains types that are part of the unstable debug API.
+ *
+ * Everything in this API is not stable and may change or be removed in the future,
+ * even on patch releases.
+ */
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace Unstable {
+  /**
+   * When Lit is running in dev mode and `window.emitLitDebugLogEvents` is true,
+   * we will emit 'lit-debug' events to window, with live details about the update and render
+   * lifecycle. These can be useful for writing debug tooling and visualizations.
+   *
+   * Please be aware that running with window.emitLitDebugLogEvents has performance overhead,
+   * making certain operations that are normally very cheap (like a no-op render) much slower,
+   * because we must copy data and dispatch events.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  export namespace DebugLog {
+    export type Entry =
+      | LitUnstable.DebugLog.Entry
+      | ReactiveUnstable.DebugLog.Entry;
+  }
+}
+
 // For backwards compatibility export ReactiveElement as UpdatingElement. Note,
 // IE transpilation requires exporting like this.
 export const UpdatingElement = ReactiveElement;

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -201,7 +201,10 @@ const debugLogEvent = DEV_MODE
       }
     }
   : undefined;
-let debugLogId = 0;
+// Used for connecting beginRender and endRender events when there are nested
+// renders when errors are thrown preventing an endRender event from being
+// called.
+let debugLogRenderId = 0;
 
 /**
  * `true` if we're building for google3 with temporary back-compat helpers.
@@ -614,7 +617,7 @@ export const render = (
   container: HTMLElement | DocumentFragment,
   options?: RenderOptions
 ): RootPart => {
-  const renderId = DEV_MODE ? debugLogId++ : 0;
+  const renderId = DEV_MODE ? debugLogRenderId++ : 0;
   const partOwnerNode = options?.renderBefore ?? container;
   // This property needs to remain unminified.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -18,7 +18,7 @@ const ENABLE_SHADYDOM_NOPATCH = true;
  * even on patch releases.
  */
 // eslint-disable-next-line @typescript-eslint/no-namespace
-export namespace Unstable {
+export namespace LitUnstable {
   /**
    * When Lit is running in dev mode and `window.emitLitDebugLogEvents` is true,
    * we will emit 'lit-debug' events to window, with live details about the update and render
@@ -189,12 +189,14 @@ interface DebugLoggingWindow {
  * Compiled out of prod mode builds.
  */
 const debugLogEvent = DEV_MODE
-  ? (event: Unstable.DebugLog.Entry) => {
+  ? (event: LitUnstable.DebugLog.Entry) => {
       const shouldEmit = (window as unknown as DebugLoggingWindow)
         .emitLitDebugLogEvents;
       if (shouldEmit) {
         window.dispatchEvent(
-          new CustomEvent<Unstable.DebugLog.Entry>('lit-debug', {detail: event})
+          new CustomEvent<LitUnstable.DebugLog.Entry>('lit-debug', {
+            detail: event,
+          })
         );
       }
     }

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -12,6 +12,196 @@ const ENABLE_EXTRA_SECURITY_HOOKS = true;
 const ENABLE_SHADYDOM_NOPATCH = true;
 
 /**
+ * Contains types that are part of the unstable debug API.
+ *
+ * Everything in this API is not stable and may change or be removed in the future,
+ * even on patch releases.
+ */
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace Unstable {
+  /**
+   * When Lit is running in dev mode and `window.emitLitDebugLogEvents` is true,
+   * we will emit 'lit-debug' events to window, with live details about the update and render
+   * lifecycle. These can be useful for writing debug tooling and visualizations.
+   *
+   * Please be aware that running with window.emitLitDebugLogEvents has performance overhead,
+   * making certain operations that are normally very cheap (like a no-op render) much slower,
+   * because we must copy data and dispatch events.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  export namespace DebugLog {
+    export type Entry =
+      | TemplatePrep
+      | TemplateInstantiated
+      | TemplateInstantiatedAndUpdated
+      | TemplateUpdating
+      | BeginRender
+      | EndRender
+      | CommitPartEntry
+      | SetPartValue;
+    export interface TemplatePrep {
+      kind: 'template prep';
+      template: Template;
+      strings: TemplateStringsArray;
+      clonableTemplate: HTMLTemplateElement;
+      parts: TemplatePart[];
+    }
+    export interface BeginRender {
+      kind: 'begin render';
+      id: number;
+      value: unknown;
+      container: HTMLElement | DocumentFragment;
+      options: RenderOptions | undefined;
+      part: ChildPart | undefined;
+    }
+    export interface EndRender {
+      kind: 'end render';
+      id: number;
+      value: unknown;
+      container: HTMLElement | DocumentFragment;
+      options: RenderOptions | undefined;
+      part: ChildPart;
+    }
+    export interface TemplateInstantiated {
+      kind: 'template instantiated';
+      template: Template | CompiledTemplate;
+      instance: TemplateInstance;
+      options: RenderOptions | undefined;
+      fragment: Node;
+      parts: Array<Part | undefined>;
+      values: unknown[];
+    }
+    export interface TemplateInstantiatedAndUpdated {
+      kind: 'template instantiated and updated';
+      template: Template | CompiledTemplate;
+      instance: TemplateInstance;
+      options: RenderOptions | undefined;
+      fragment: Node;
+      parts: Array<Part | undefined>;
+      values: unknown[];
+    }
+    export interface TemplateUpdating {
+      kind: 'template updating';
+      template: Template | CompiledTemplate;
+      instance: TemplateInstance;
+      options: RenderOptions | undefined;
+      parts: Array<Part | undefined>;
+      values: unknown[];
+    }
+    export interface SetPartValue {
+      kind: 'set part';
+      part: Part;
+      value: unknown;
+      valueIndex: number;
+      values: unknown[];
+      templateInstance: TemplateInstance;
+    }
+
+    export type CommitPartEntry =
+      | CommitNothingToChildEntry
+      | CommitText
+      | CommitNode
+      | CommitAttribute
+      | CommitProperty
+      | CommitBooleanAttribute
+      | CommitEventListener
+      | CommitToElementBinding;
+
+    export interface CommitNothingToChildEntry {
+      kind: 'commit nothing to child';
+      start: ChildNode;
+      end: ChildNode | null;
+      parent: Disconnectable | undefined;
+      options: RenderOptions | undefined;
+    }
+
+    export interface CommitText {
+      kind: 'commit text';
+      node: Text;
+      value: unknown;
+      options: RenderOptions | undefined;
+    }
+
+    export interface CommitNode {
+      kind: 'commit node';
+      start: Node;
+      parent: Disconnectable | undefined;
+      value: Node;
+      options: RenderOptions | undefined;
+    }
+
+    export interface CommitAttribute {
+      kind: 'commit attribute';
+      element: Element;
+      name: string;
+      value: unknown;
+      options: RenderOptions | undefined;
+    }
+
+    export interface CommitProperty {
+      kind: 'commit property';
+      element: Element;
+      name: string;
+      value: unknown;
+      options: RenderOptions | undefined;
+    }
+
+    export interface CommitBooleanAttribute {
+      kind: 'commit boolean attribute';
+      element: Element;
+      name: string;
+      value: boolean;
+      options: RenderOptions | undefined;
+    }
+
+    export interface CommitEventListener {
+      kind: 'commit event listener';
+      element: Element;
+      name: string;
+      value: unknown;
+      oldListener: unknown;
+      options: RenderOptions | undefined;
+      // True if we're removing the old event listener (e.g. because settings changed, or value is nothing)
+      removeListener: boolean;
+      // True if we're adding a new event listener (e.g. because first render, or settings changed)
+      addListener: boolean;
+    }
+
+    export interface CommitToElementBinding {
+      kind: 'commit to element binding';
+      element: Element;
+      value: unknown;
+      options: RenderOptions | undefined;
+    }
+  }
+}
+
+interface DebugLoggingWindow {
+  // Even in dev mode, we generally don't want to emit these events, as that's
+  // another level of cost, so only emit them when DEV_MODE is true _and_ when
+  // window.emitLitDebugEvents is true.
+  emitLitDebugLogEvents?: boolean;
+}
+
+/**
+ * Useful for visualizing and logging insights into what the Lit template system is doing.
+ *
+ * Compiled out of prod mode builds.
+ */
+const debugLogEvent = DEV_MODE
+  ? (event: Unstable.DebugLog.Entry) => {
+      const shouldEmit = (window as unknown as DebugLoggingWindow)
+        .emitLitDebugLogEvents;
+      if (shouldEmit) {
+        window.dispatchEvent(
+          new CustomEvent<Unstable.DebugLog.Entry>('lit-debug', {detail: event})
+        );
+      }
+    }
+  : undefined;
+let debugLogId = 0;
+
+/**
  * `true` if we're building for google3 with temporary back-compat helpers.
  * This export is not present in prod builds.
  * @internal
@@ -422,10 +612,19 @@ export const render = (
   container: HTMLElement | DocumentFragment,
   options?: RenderOptions
 ): RootPart => {
+  const renderId = DEV_MODE ? debugLogId++ : 0;
   const partOwnerNode = options?.renderBefore ?? container;
   // This property needs to remain unminified.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let part: ChildPart = (partOwnerNode as any)['_$litPart$'];
+  debugLogEvent?.({
+    kind: 'begin render',
+    id: renderId,
+    value,
+    container,
+    options,
+    part,
+  });
   if (part === undefined) {
     const endNode = options?.renderBefore ?? null;
     // Internal modification: don't clear container to match lit-html 2.0
@@ -452,6 +651,14 @@ export const render = (
     );
   }
   part._$setValue(value);
+  debugLogEvent?.({
+    kind: 'end render',
+    id: renderId,
+    value,
+    container,
+    options,
+    part,
+  });
   return part as RootPart;
 };
 
@@ -833,6 +1040,13 @@ class Template {
       }
       nodeIndex++;
     }
+    debugLogEvent?.({
+      kind: 'template prep',
+      template: this,
+      clonableTemplate: this.el,
+      parts: this.parts,
+      strings,
+    });
   }
 
   // Overridden via `litHtmlPolyfillSupport` to provide platform support.
@@ -984,6 +1198,14 @@ class TemplateInstance implements Disconnectable {
     let i = 0;
     for (const part of this._parts) {
       if (part !== undefined) {
+        debugLogEvent?.({
+          kind: 'set part',
+          part,
+          value: values[i],
+          valueIndex: i,
+          values,
+          templateInstance: this,
+        });
         if ((part as AttributePart).strings !== undefined) {
           (part as AttributePart)._$setValue(values, part as AttributePart, i);
           // The number of values the part consumes is part.strings.length - 1
@@ -1170,6 +1392,13 @@ class ChildPart implements Disconnectable {
       // fallback content.
       if (value === nothing || value == null || value === '') {
         if (this._$committedValue !== nothing) {
+          debugLogEvent?.({
+            kind: 'commit nothing to child',
+            start: this._$startNode,
+            end: this._$endNode,
+            parent: this._$parent,
+            options: this.options,
+          });
           this._$clear();
         }
         this._$committedValue = nothing;
@@ -1223,6 +1452,13 @@ class ChildPart implements Disconnectable {
           throw new Error(message);
         }
       }
+      debugLogEvent?.({
+        kind: 'commit node',
+        start: this._$startNode,
+        parent: this._$parent,
+        value: value.cloneNode(true),
+        options: this.options,
+      });
       this._$committedValue = this._insert(value);
     }
   }
@@ -1242,6 +1478,12 @@ class ChildPart implements Disconnectable {
         }
         value = this._textSanitizer(value);
       }
+      debugLogEvent?.({
+        kind: 'commit text',
+        node,
+        value,
+        options: this.options,
+      });
       (node as Text).data = value as string;
     } else {
       if (ENABLE_EXTRA_SECURITY_HOOKS) {
@@ -1250,14 +1492,26 @@ class ChildPart implements Disconnectable {
         // When setting text content, for security purposes it matters a lot
         // what the parent is. For example, <style> and <script> need to be
         // handled with care, while <span> does not. So first we need to put a
-        // text node into the document, then we can sanitize its contentx.
+        // text node into the document, then we can sanitize its content.
         if (this._textSanitizer === undefined) {
           this._textSanitizer = createSanitizer(textNode, 'data', 'property');
         }
         value = this._textSanitizer(value);
+        debugLogEvent?.({
+          kind: 'commit text',
+          node: textNode,
+          value,
+          options: this.options,
+        });
         textNode.data = value as string;
       } else {
         this._commitNode(d.createTextNode(value as string));
+        debugLogEvent?.({
+          kind: 'commit text',
+          node: wrap(this._$startNode).nextSibling as Text,
+          value,
+          options: this.options,
+        });
       }
     }
     this._$committedValue = value;
@@ -1280,11 +1534,37 @@ class ChildPart implements Disconnectable {
           type);
 
     if ((this._$committedValue as TemplateInstance)?._$template === template) {
+      debugLogEvent?.({
+        kind: 'template updating',
+        template,
+        instance: this._$committedValue as TemplateInstance,
+        parts: (this._$committedValue as TemplateInstance)._parts,
+        options: this.options,
+        values,
+      });
       (this._$committedValue as TemplateInstance)._update(values);
     } else {
       const instance = new TemplateInstance(template as Template, this);
       const fragment = instance._clone(this.options);
+      debugLogEvent?.({
+        kind: 'template instantiated',
+        template,
+        instance,
+        parts: instance._parts,
+        options: this.options,
+        fragment,
+        values,
+      });
       instance._update(values);
+      debugLogEvent?.({
+        kind: 'template instantiated and updated',
+        template,
+        instance,
+        parts: instance._parts,
+        options: this.options,
+        fragment,
+        values,
+      });
       this._commitNode(fragment);
       this._$committedValue = instance;
     }
@@ -1566,6 +1846,13 @@ class AttributePart implements Disconnectable {
         }
         value = this._sanitizer(value ?? '');
       }
+      debugLogEvent?.({
+        kind: 'commit attribute',
+        element: this.element,
+        name: this.name,
+        value,
+        options: this.options,
+      });
       (wrap(this.element) as Element).setAttribute(
         this.name,
         (value ?? '') as string
@@ -1590,6 +1877,13 @@ class PropertyPart extends AttributePart {
       }
       value = this._sanitizer(value);
     }
+    debugLogEvent?.({
+      kind: 'commit property',
+      element: this.element,
+      name: this.name,
+      value,
+      options: this.options,
+    });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (this.element as any)[this.name] = value === nothing ? undefined : value;
   }
@@ -1609,6 +1903,13 @@ class BooleanAttributePart extends AttributePart {
 
   /** @internal */
   override _commitValue(value: unknown) {
+    debugLogEvent?.({
+      kind: 'commit boolean attribute',
+      element: this.element,
+      name: this.name,
+      value: !!(value && value !== nothing),
+      options: this.options,
+    });
     if (value && value !== nothing) {
       (wrap(this.element) as Element).setAttribute(
         this.name,
@@ -1687,6 +1988,16 @@ class EventPart extends AttributePart {
       newListener !== nothing &&
       (oldListener === nothing || shouldRemoveListener);
 
+    debugLogEvent?.({
+      kind: 'commit event listener',
+      element: this.element,
+      name: this.name,
+      value: newListener,
+      options: this.options,
+      removeListener: shouldRemoveListener,
+      addListener: shouldAddListener,
+      oldListener,
+    });
     if (shouldRemoveListener) {
       this.element.removeEventListener(
         this.name,
@@ -1749,6 +2060,12 @@ class ElementPart implements Disconnectable {
   }
 
   _$setValue(value: unknown): void {
+    debugLogEvent?.({
+      kind: 'commit to element binding',
+      element: this.element,
+      value,
+      options: this.options,
+    });
     resolveDirective(this, value);
   }
 }

--- a/packages/reactive-element/src/reactive-element.ts
+++ b/packages/reactive-element/src/reactive-element.ts
@@ -106,7 +106,7 @@ if (DEV_MODE) {
  * even on patch releases.
  */
 // eslint-disable-next-line @typescript-eslint/no-namespace
-export namespace Unstable {
+export namespace ReactiveUnstable {
   /**
    * When Lit is running in dev mode and `window.emitLitDebugLogEvents` is true,
    * we will emit 'lit-debug' events to window, with live details about the update and render
@@ -138,12 +138,12 @@ interface DebugLoggingWindow {
  * Compiled out of prod mode builds.
  */
 const debugLogEvent = DEV_MODE
-  ? (event: Unstable.DebugLog.Entry) => {
+  ? (event: ReactiveUnstable.DebugLog.Entry) => {
       const shouldEmit = (window as unknown as DebugLoggingWindow)
         .emitLitDebugLogEvents;
       if (shouldEmit) {
         window.dispatchEvent(
-          new CustomEvent<Unstable.DebugLog.Entry>('lit-debug', {
+          new CustomEvent<ReactiveUnstable.DebugLog.Entry>('lit-debug', {
             detail: event,
           })
         );

--- a/packages/reactive-element/src/reactive-element.ts
+++ b/packages/reactive-element/src/reactive-element.ts
@@ -99,6 +99,58 @@ if (DEV_MODE) {
   });
 }
 
+/**
+ * Contains types that are part of the unstable debug API.
+ *
+ * Everything in this API is not stable and may change or be removed in the future,
+ * even on patch releases.
+ */
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace Unstable {
+  /**
+   * When Lit is running in dev mode and `window.emitLitDebugLogEvents` is true,
+   * we will emit 'lit-debug' events to window, with live details about the update and render
+   * lifecycle. These can be useful for writing debug tooling and visualizations.
+   *
+   * Please be aware that running with window.emitLitDebugLogEvents has performance overhead,
+   * making certain operations that are normally very cheap (like a no-op render) much slower,
+   * because we must copy data and dispatch events.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  export namespace DebugLog {
+    export type Entry = Update;
+    export interface Update {
+      kind: 'update';
+    }
+  }
+}
+
+interface DebugLoggingWindow {
+  // Even in dev mode, we generally don't want to emit these events, as that's
+  // another level of cost, so only emit them when DEV_MODE is true _and_ when
+  // window.emitLitDebugEvents is true.
+  emitLitDebugLogEvents?: boolean;
+}
+
+/**
+ * Useful for visualizing and logging insights into what the Lit template system is doing.
+ *
+ * Compiled out of prod mode builds.
+ */
+const debugLogEvent = DEV_MODE
+  ? (event: Unstable.DebugLog.Entry) => {
+      const shouldEmit = (window as unknown as DebugLoggingWindow)
+        .emitLitDebugLogEvents;
+      if (shouldEmit) {
+        window.dispatchEvent(
+          new CustomEvent<Unstable.DebugLog.Entry>('lit-debug', {
+            detail: event,
+          })
+        );
+      }
+    }
+  : undefined;
+
 /*
  * When using Closure Compiler, JSCompiler_renameProperty(property, object) is
  * replaced at compile time by the munged name for object[property]. We cannot
@@ -1172,6 +1224,7 @@ export abstract class ReactiveElement
     if (!this.isUpdatePending) {
       return;
     }
+    debugLogEvent?.({kind: 'update'});
     // create renderRoot before first update.
     if (!this.hasUpdated) {
       // Produce warning if any class properties are shadowed by class fields


### PR DESCRIPTION
When running Lit in dev mode, and when window.emitLitDebugLogEvents is true, we will emit 'lit-debug' events on window. These events will be fired during rendering and as part of the ReactiveElement update lifecycle, giving internal information about rendering that may be useful for debug tools and visualizers.

Production builds will not be affected, all of the devlog code is compiled out when DEV_MODE is false.

Note that this is an unstable API which may change or even be removed in the future, even on patch releases.