### PR TITLE
Push bundles to lit/bundles during release.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -10,6 +10,10 @@ lerna-debug.log
 .DS_Store
 .vscode/
 
+# `/bundles` is used during the release step as the checkout location for the
+# bundles repo. (https://github.com/lit/bundles)
+/bundles
+
 packages/benchmarks/generated/
 packages/benchmarks/generator/build/
 packages/benchmarks/generator/generated/

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -76,14 +76,7 @@ jobs:
           cp ../packages/lit/lit.min.umd.js.map .
 
           # Stage the bundles, create the commit, tag it, and push.
-          git add lit.all.min.js
-          git add lit.all.min.js.map
-          git add lit.all.min.umd.js
-          git add lit.all.min.umd.js.map
-          git add lit.min.js
-          git add lit.min.js.map
-          git add lit.min.umd.js
-          git add lit.min.umd.js.map
+          git add .
           git config user.name "Lit Release Bot"
           git config user.email "lit-release-bot@google.com"
           git commit -m "Bundles for lit@${LIT_VERSION}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,3 +37,60 @@ jobs:
           HUSKY: 0
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Checkout bundles repo
+        uses: actions/checkout@v2
+        if: steps.changesets.outputs.published
+        with:
+          repository: lit/bundles
+          ref: empty
+          path: bundles
+          token: ${{ secrets.LIT_RELEASE_BOT_TOKEN }}
+
+      - name: Push bundles
+        if: steps.changesets.outputs.published
+        run: |
+          # Extract the version of `lit` that was published or the empty string.
+          LIT_VERSION=$(npm run --silent extract-published-lit-version <<EOF
+            ${{ steps.changesets.outputs.publishedPackages }}
+          EOF
+          )
+
+          # Don't create a bundle commit if `lit` wasn't published.
+          if [[ -z "$LIT_VERSION" ]]; then
+            exit
+          fi
+
+          # Enter the bundle repo directory.
+          pushd bundles
+
+          # Checkout the empty root commit (with tag `empty`).
+          git checkout --detach empty
+
+          # Copy in all of the bundles.
+          cp ../packages/lit/lit.all.min.js .
+          cp ../packages/lit/lit.all.min.js.map .
+          cp ../packages/lit/lit.all.min.umd.js .
+          cp ../packages/lit/lit.all.min.umd.js.map .
+          cp ../packages/lit/lit.min.js .
+          cp ../packages/lit/lit.min.js.map .
+          cp ../packages/lit/lit.min.umd.js .
+          cp ../packages/lit/lit.min.umd.js.map .
+
+          # Stage the bundles, create the commit, tag it, and push.
+          git add lit.all.min.js
+          git add lit.all.min.js.map
+          git add lit.all.min.umd.js
+          git add lit.all.min.umd.js.map
+          git add lit.min.js
+          git add lit.min.js.map
+          git add lit.min.umd.js
+          git add lit.min.umd.js.map
+          git config user.name "Lit Release Bot"
+          git config user.email "lit-release-bot@google.com"
+          git commit -m "Bundles for lit@${LIT_VERSION}"
+          git tag "v${LIT_VERSION}"
+          git push origin "v${LIT_VERSION}"
+
+          # Exit the bundle repo directory.
+          popd

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,6 +49,7 @@ jobs:
 
       - name: Push bundles
         if: steps.changesets.outputs.published
+        working-directory: bundles
         run: |
           # Extract the version of `lit` that was published or the empty string.
           LIT_VERSION=$(npm run --silent extract-published-lit-version <<EOF
@@ -60,9 +61,6 @@ jobs:
           if [[ -z "$LIT_VERSION" ]]; then
             exit
           fi
-
-          # Enter the bundle repo directory.
-          pushd bundles
 
           # Checkout the empty root commit (with tag `empty`).
           git checkout --detach empty
@@ -91,6 +89,3 @@ jobs:
           git commit -m "Bundles for lit@${LIT_VERSION}"
           git tag "v${LIT_VERSION}"
           git push origin "v${LIT_VERSION}"
-
-          # Exit the bundle repo directory.
-          popd

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ lerna-debug.log
 *.tsbuildinfo
 .DS_Store
 .vscode/
+
+# `/bundles` is used during the release step as the checkout location for the
+# bundles repo. (https://github.com/lit/bundles)
+/bundles

--- a/.prettierignore
+++ b/.prettierignore
@@ -10,6 +10,10 @@ lerna-debug.log
 .DS_Store
 .vscode/
 
+# `/bundles` is used during the release step as the checkout location for the
+# bundles repo. (https://github.com/lit/bundles)
+/bundles
+
 packages/benchmarks/generated/
 packages/benchmarks/generator/build/
 packages/benchmarks/generator/generated/

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "changeset": "changeset",
     "version": "npm run changeset version && npm run update-version-vars",
     "update-version-vars": "node scripts/update-version-variables.js",
+    "extract-published-lit-version": "node scripts/extract-published-lit-version.js",
     "release": "npm run bootstrap && npm run build && npm run changeset publish"
   },
   "devDependencies": {

--- a/scripts/extract-published-lit-version.js
+++ b/scripts/extract-published-lit-version.js
@@ -1,0 +1,22 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import * as fs from 'fs';
+import * as process from 'process';
+
+/**
+ * Takes the `publishedPackages` output of the `changesets/action` GitHub action
+ * on standard input and writes the version of `lit` that was published to
+ * standard output. If `lit` was not published, it writes the empty string.
+ *
+ * https://github.com/changesets/action#outputs
+ */
+
+const publishedPackages = JSON.parse(
+  fs.readFileSync(process.stdin.fd, 'utf-8')
+);
+const litVersion = publishedPackages.find((x) => x.name === 'lit')?.version;
+console.log(litVersion ?? '');


### PR DESCRIPTION
This PR adds a couple new steps to the release workflow which will push bundles to the [lit/bundles](https://github.com/lit/bundles) repo. New bundles are pushed whenever `lit` appears in [the `publishedPackages` output of `changesets/action`](https://github.com/changesets/action#outputs). lit/bundles currently contains a single empty commit with tag `empty`; the new steps check out the repo at that commit, copy in the bundles and their source maps, and then create and push a new commit tagged with the version of `lit` that was published.

[lit/bundles](https://github.com/lit/bundles) is currently private in case we need to trash the entire repo and try again. Also, this PR should finish the work for #2272, but I don't want to give GitHub the actual auto-close-on-merge phrase since we should watch it once or twice after merging before we make the repo public.