### PR TITLE
[localize-tools] Improve handling of duplicate msg id

### DIFF
--- a/.changeset/many-singers-complain.md
+++ b/.changeset/many-singers-complain.md
@@ -4,4 +4,4 @@
 
 **BREAKING** Update analysis to consider messages with same id **and** description to be identical (but no longer checks for expressions to be same) and improve error message on finding incompatible duplicates.
 
-`lit-locazlie extract` will now error if multiple messages had the same text but different `desc` option. Be sure to add the same `desc` option for these messages to be considered the same translatable to message or add different `id` options to differentiate them.
+`lit-localize extract` will now error if multiple messages had the same text but different `desc` option. Be sure to add the same `desc` option for these messages to be considered the same translatable message or add different `id` options to differentiate them.

--- a/.changeset/many-singers-complain.md
+++ b/.changeset/many-singers-complain.md
@@ -1,0 +1,7 @@
+---
+'@lit/localize-tools': minor
+---
+
+**BREAKING** Update analysis to consider messages with same id **and** description to be identical (but no longer checks for expressions to be same) and improve error message on finding incompatible duplicates.
+
+`lit-locazlie extract` will now error if multiple messages had the same text but different `desc` option. Be sure to add the same `desc` option for these messages to be considered the same translatable to message or add different `id` options to differentiate them.

--- a/.changeset/modern-seas-jog.md
+++ b/.changeset/modern-seas-jog.md
@@ -1,0 +1,7 @@
+---
+'@lit/localize-tools': minor
+---
+
+**BREAKING** (XLB format only) Add index to `name` attribute for `<ph>` tags for tracking placeholder locations.
+
+XLB format users should run `lit-localize extract` to regenerate the `.xlb` file for the source locale and make sure the `<ph>` tags in other locale files have matching `name` attribute values to that of the newly generated source file.

--- a/packages/localize-tools/src/formatters/xlb.ts
+++ b/packages/localize-tools/src/formatters/xlb.ts
@@ -76,7 +76,6 @@ class XlbFormatter implements Formatter {
       const contents: Array<string | Placeholder> = [];
       for (let j = 0; j < msg.childNodes.length; j++) {
         const child = msg.childNodes[j];
-        let phIdx = 0;
         if (child.nodeType === doc.TEXT_NODE) {
           contents.push(child.nodeValue || '');
         } else if (
@@ -91,8 +90,9 @@ class XlbFormatter implements Formatter {
           ) {
             throw new KnownError(`Expected <ph> to have exactly one text node`);
           }
-          const index =
-            Number((child as Element).getAttribute('name')) || phIdx++;
+          const index = Number(
+            getNonEmptyAttributeOrThrow(child as Element, 'name')
+          );
           contents.push({untranslatable: phText.nodeValue || '', index});
         } else {
           throw new KnownError(

--- a/packages/localize-tools/src/formatters/xlb.ts
+++ b/packages/localize-tools/src/formatters/xlb.ts
@@ -76,6 +76,7 @@ class XlbFormatter implements Formatter {
       const contents: Array<string | Placeholder> = [];
       for (let j = 0; j < msg.childNodes.length; j++) {
         const child = msg.childNodes[j];
+        let phIdx = 0;
         if (child.nodeType === doc.TEXT_NODE) {
           contents.push(child.nodeValue || '');
         } else if (
@@ -90,7 +91,9 @@ class XlbFormatter implements Formatter {
           ) {
             throw new KnownError(`Expected <ph> to have exactly one text node`);
           }
-          contents.push({untranslatable: phText.nodeValue || ''});
+          const index =
+            Number((child as Element).getAttribute('name')) || phIdx++;
+          contents.push({untranslatable: phText.nodeValue || '', index});
         } else {
           throw new KnownError(
             `Unexpected node in <msg>: ${child.nodeType} ${child.nodeName}`
@@ -127,12 +130,14 @@ class XlbFormatter implements Formatter {
       }
       indent(messagesNode, 2);
       messagesNode.appendChild(messageNode);
+      let phIdx = 0;
       for (const content of contents) {
         if (typeof content === 'string') {
           messageNode.appendChild(doc.createTextNode(content));
         } else {
           const {untranslatable} = content;
           const ph = doc.createElement('ph');
+          ph.setAttribute('name', String(phIdx++));
           ph.appendChild(doc.createTextNode(untranslatable));
           messageNode.appendChild(ph);
         }

--- a/packages/localize-tools/src/formatters/xliff.ts
+++ b/packages/localize-tools/src/formatters/xliff.ts
@@ -116,7 +116,9 @@ export class XliffFormatter implements Formatter {
             child as Element,
             'equiv-text'
           );
-          const index = getNonEmptyAttributeOrThrow(child as Element, 'id');
+          const index = Number(
+            getNonEmptyAttributeOrThrow(child as Element, 'id')
+          );
           contents.push({untranslatable: phText, index});
         } else if (
           child.nodeType === doc.ELEMENT_NODE &&
@@ -132,7 +134,9 @@ export class XliffFormatter implements Formatter {
               `Expected <${child.nodeName}> to have exactly one text node`
             );
           }
-          const index = getNonEmptyAttributeOrThrow(child as Element, 'id');
+          const index = Number(
+            getNonEmptyAttributeOrThrow(child as Element, 'id')
+          );
           contents.push({untranslatable: phText.nodeValue || '', index});
         } else {
           throw new KnownError(

--- a/packages/localize-tools/src/formatters/xliff.ts
+++ b/packages/localize-tools/src/formatters/xliff.ts
@@ -116,7 +116,8 @@ export class XliffFormatter implements Formatter {
             child as Element,
             'equiv-text'
           );
-          contents.push({untranslatable: phText});
+          const index = getNonEmptyAttributeOrThrow(child as Element, 'id');
+          contents.push({untranslatable: phText, index});
         } else if (
           child.nodeType === doc.ELEMENT_NODE &&
           child.nodeName === 'ph'
@@ -131,7 +132,8 @@ export class XliffFormatter implements Formatter {
               `Expected <${child.nodeName}> to have exactly one text node`
             );
           }
-          contents.push({untranslatable: phText.nodeValue || ''});
+          const index = getNonEmptyAttributeOrThrow(child as Element, 'id');
+          contents.push({untranslatable: phText.nodeValue || '', index});
         } else {
           throw new KnownError(
             `Unexpected node in <trans-unit>: ${child.nodeType} ${child.nodeName}`

--- a/packages/localize-tools/src/messages.ts
+++ b/packages/localize-tools/src/messages.ts
@@ -66,6 +66,7 @@ export interface Bundle {
  */
 export interface Placeholder {
   untranslatable: string;
+  index?: string;
   // TODO(aomarks) Placeholders can also have names and examples, to help the
   // translator understand the meaning of the placeholder. We could
   // automatically add names for common markup patterns like START_BOLD and

--- a/packages/localize-tools/src/messages.ts
+++ b/packages/localize-tools/src/messages.ts
@@ -66,7 +66,7 @@ export interface Bundle {
  */
 export interface Placeholder {
   untranslatable: string;
-  index?: number;
+  index: number;
   // TODO(aomarks) Placeholders can also have names and examples, to help the
   // translator understand the meaning of the placeholder. We could
   // automatically add names for common markup patterns like START_BOLD and

--- a/packages/localize-tools/src/messages.ts
+++ b/packages/localize-tools/src/messages.ts
@@ -66,7 +66,7 @@ export interface Bundle {
  */
 export interface Placeholder {
   untranslatable: string;
-  index?: string;
+  index?: number;
   // TODO(aomarks) Placeholders can also have names and examples, to help the
   // translator understand the meaning of the placeholder. We could
   // automatically add names for common markup patterns like START_BOLD and

--- a/packages/localize-tools/src/modes/runtime.ts
+++ b/packages/localize-tools/src/modes/runtime.ts
@@ -228,17 +228,7 @@ function makeMessageString(
   const placeholderOrderKey = (
     placeholder: Placeholder,
     placeholderRelativeExpressionIdx: number
-  ) =>
-    JSON.stringify([
-      // TODO(aomarks) For XLIFF files, we have a unique numeric ID for each
-      // placeholder that would be preferable to use as the key here over the
-      // placeholder text itself. However, we don't currently have that ID for
-      // XLB. To add it to XLB, we need to do some research into the correct XML
-      // representation, and then make a breaking change. See
-      // https://github.com/lit/lit/issues/1897.
-      placeholder.untranslatable,
-      placeholderRelativeExpressionIdx,
-    ]);
+  ) => JSON.stringify([placeholder.index, placeholderRelativeExpressionIdx]);
 
   let absIdx = 0;
   for (const content of canon.contents) {

--- a/packages/localize-tools/src/modes/runtime.ts
+++ b/packages/localize-tools/src/modes/runtime.ts
@@ -245,7 +245,7 @@ function makeMessageString(
     if (typeof content === 'string') {
       continue;
     }
-    const template = parseStringAsTemplateLiteral(content.untranslatable);
+    const {template} = parseStringAsTemplateLiteral(content.untranslatable);
     if (ts.isNoSubstitutionTemplateLiteral(template)) {
       continue;
     }
@@ -259,7 +259,7 @@ function makeMessageString(
     if (typeof content === 'string') {
       fragments.push(escapeTextContentToEmbedInTemplateLiteral(content));
     } else {
-      const template = parseStringAsTemplateLiteral(content.untranslatable);
+      const {template} = parseStringAsTemplateLiteral(content.untranslatable);
       if (ts.isNoSubstitutionTemplateLiteral(template)) {
         fragments.push(template.text);
       } else {

--- a/packages/localize-tools/src/modes/runtime.ts
+++ b/packages/localize-tools/src/modes/runtime.ts
@@ -245,7 +245,7 @@ function makeMessageString(
     if (typeof content === 'string') {
       continue;
     }
-    const {template} = parseStringAsTemplateLiteral(content.untranslatable);
+    const template = parseStringAsTemplateLiteral(content.untranslatable);
     if (ts.isNoSubstitutionTemplateLiteral(template)) {
       continue;
     }
@@ -259,7 +259,7 @@ function makeMessageString(
     if (typeof content === 'string') {
       fragments.push(escapeTextContentToEmbedInTemplateLiteral(content));
     } else {
-      const {template} = parseStringAsTemplateLiteral(content.untranslatable);
+      const template = parseStringAsTemplateLiteral(content.untranslatable);
       if (ts.isNoSubstitutionTemplateLiteral(template)) {
         fragments.push(template.text);
       } else {

--- a/packages/localize-tools/src/modes/transform.ts
+++ b/packages/localize-tools/src/modes/transform.ts
@@ -334,12 +334,12 @@ class Transformer {
     const {tag, contents} = templateResult.result;
     let {template} = templateResult.result;
 
-    const placeholdersByIndex = new Map<string, Placeholder>();
+    const placeholdersByIndex = new Map<number, Placeholder>();
     {
       let idx = 0;
       for (const content of contents) {
         if (typeof content === 'object') {
-          placeholdersByIndex.set(String(idx++), content);
+          placeholdersByIndex.set(idx++, content);
         }
       }
     }

--- a/packages/localize-tools/src/modes/transform.ts
+++ b/packages/localize-tools/src/modes/transform.ts
@@ -373,13 +373,6 @@ class Transformer {
             if (typeof content === 'string') {
               return escapeTextContentToEmbedInTemplateLiteral(content);
             }
-            if (content.index === undefined) {
-              throw new Error(
-                `Missing index in translation placeholder.` +
-                  `\nLocale: ${this.locale}` +
-                  `\nPlaceholder: ${content.untranslatable}`
-              );
-            }
             const sourcePlaceholderIdx = content.index;
             const matchingPlaceholder =
               placeholdersByIndex.get(sourcePlaceholderIdx);

--- a/packages/localize-tools/src/program-analysis.ts
+++ b/packages/localize-tools/src/program-analysis.ts
@@ -692,10 +692,8 @@ function contentEqual(
     }
     return a === b;
   }
-  if (typeof a === 'object') {
-    if (typeof b !== 'object') {
-      return false;
-    }
+  if (typeof a === 'object' && typeof b !== 'object') {
+    return false;
   }
   return true;
 }

--- a/packages/localize-tools/src/tests/analysis.unit.test.ts
+++ b/packages/localize-tools/src/tests/analysis.unit.test.ts
@@ -342,7 +342,28 @@ test('error: different message contents', () => {
       },
     ],
     [
-      '__DUMMY__.ts(4,5): error TS2324: Message ids must have the same default text wherever they are used',
+      '__DUMMY__.ts(3,5): error TS2324: The translation message with ID greeting was defined in 2 places, but with different strings or descriptions. If these messages should be translated together, make sure their strings and descriptions are identical, and consider factoring out a common variable or function. If they should be translated separately, add one or more {id: "..."} overrides to distinguish them.',
+    ]
+  );
+});
+
+test('error: same message contents with different desc', () => {
+  const src = `
+    import {msg} from '@lit/localize';
+    msg('Hello World', {desc: 'greeting'});
+    msg('Hello World', {desc: 'greeting2'});
+  `;
+  checkAnalysis(
+    src,
+    [
+      {
+        name: 's3d58dee72d4e0c27',
+        contents: ['Hello World'],
+        desc: 'greeting',
+      },
+    ],
+    [
+      '__DUMMY__.ts(3,5): error TS2324: The translation message with ID s3d58dee72d4e0c27 was defined in 2 places, but with different strings or descriptions. If these messages should be translated together, make sure their strings and descriptions are identical, and consider factoring out a common variable or function. If they should be translated separately, add one or more {id: "..."} overrides to distinguish them.',
     ]
   );
 });

--- a/packages/localize-tools/src/tests/analysis.unit.test.ts
+++ b/packages/localize-tools/src/tests/analysis.unit.test.ts
@@ -347,6 +347,22 @@ test('error: different message contents', () => {
   );
 });
 
+test('same message contents with different expression is not error', () => {
+  const src = `
+    import {msg, str} from '@lit/localize';
+    const name = "friend";
+    const otherName = "pal";
+    msg(str\`Hello \${name}\`);
+    msg(str\`Hello \${otherName}\`);
+  `;
+  checkAnalysis(src, [
+    {
+      name: 'saed7d3734ce7f09d',
+      contents: ['Hello ', {untranslatable: '${name}'}],
+    },
+  ]);
+});
+
 test('error: same message contents with different desc', () => {
   const src = `
     import {msg} from '@lit/localize';

--- a/packages/localize-tools/src/tests/analysis.unit.test.ts
+++ b/packages/localize-tools/src/tests/analysis.unit.test.ts
@@ -116,9 +116,9 @@ test('HTML message', () => {
     {
       name: 'greeting',
       contents: [
-        {untranslatable: '<b>'},
+        {untranslatable: '<b>', index: 0},
         'Hello World',
-        {untranslatable: '</b>'},
+        {untranslatable: '</b>', index: 1},
       ],
     },
   ]);
@@ -133,9 +133,9 @@ test('HTML message (auto ID)', () => {
     {
       name: 'hc468c061c2d171f4',
       contents: [
-        {untranslatable: '<b>'},
+        {untranslatable: '<b>', index: 0},
         'Hello World',
-        {untranslatable: '</b>'},
+        {untranslatable: '</b>', index: 1},
       ],
     },
   ]);
@@ -150,9 +150,9 @@ test('HTML message with comment', () => {
     {
       name: 'greeting',
       contents: [
-        {untranslatable: '<b><!-- greeting -->'},
+        {untranslatable: '<b><!-- greeting -->', index: 0},
         'Hello World',
-        {untranslatable: '</b>'},
+        {untranslatable: '</b>', index: 1},
       ],
     },
   ]);
@@ -167,7 +167,7 @@ test('parameterized string message', () => {
   checkAnalysis(src, [
     {
       name: 'greeting',
-      contents: ['Hello ', {untranslatable: '${name}'}],
+      contents: ['Hello ', {untranslatable: '${name}', index: 0}],
     },
   ]);
 });
@@ -181,7 +181,7 @@ test('parameterized string message (auto ID)', () => {
   checkAnalysis(src, [
     {
       name: 'saed7d3734ce7f09d',
-      contents: ['Hello ', {untranslatable: '${name}'}],
+      contents: ['Hello ', {untranslatable: '${name}', index: 0}],
     },
   ]);
 });
@@ -196,9 +196,9 @@ test('parameterized HTML message', () => {
     {
       name: 'greeting',
       contents: [
-        {untranslatable: '<b>'},
+        {untranslatable: '<b>', index: 0},
         'Hello ',
-        {untranslatable: '${friend}</b>'},
+        {untranslatable: '${friend}</b>', index: 1},
       ],
     },
   ]);
@@ -358,7 +358,7 @@ test('same message contents with different expression is not error', () => {
   checkAnalysis(src, [
     {
       name: 'saed7d3734ce7f09d',
-      contents: ['Hello ', {untranslatable: '${name}'}],
+      contents: ['Hello ', {untranslatable: '${name}', index: 0}],
     },
   ]);
 });

--- a/packages/localize-tools/src/tests/transform.unit.test.ts
+++ b/packages/localize-tools/src/tests/transform.unit.test.ts
@@ -141,9 +141,9 @@ test('html(msg(html)) translated', () => {
           name: 'foo',
           contents: [
             'Hola ',
-            {untranslatable: '<i>'},
+            {untranslatable: '<i>', index: '0'},
             'Mundo',
-            {untranslatable: '</i>'},
+            {untranslatable: '</i>', index: '1'},
           ],
         },
       ],
@@ -166,7 +166,7 @@ test('msg(string(expr)) translated', () => {
       messages: [
         {
           name: 'foo',
-          contents: ['Hola ', {untranslatable: '${name}'}, '!'],
+          contents: ['Hola ', {untranslatable: '${name}', index: '0'}, '!'],
         },
       ],
     }
@@ -188,7 +188,7 @@ test('msg(string(string)) translated', () => {
       messages: [
         {
           name: 'foo',
-          contents: ['Hola ', {untranslatable: '${"World"}'}, '!'],
+          contents: ['Hola ', {untranslatable: '${"World"}', index: '0'}, '!'],
         },
       ],
     }
@@ -210,7 +210,11 @@ test('msg(html(expr)) translated', () => {
       messages: [
         {
           name: 'foo',
-          contents: ['Hola ', {untranslatable: '<b>${name}</b>'}, '!'],
+          contents: [
+            'Hola ',
+            {untranslatable: '<b>${name}</b>', index: '0'},
+            '!',
+          ],
         },
       ],
     }
@@ -232,31 +236,9 @@ test('msg(html(string)) translated', () => {
       messages: [
         {
           name: 'foo',
-          contents: ['Hola ', {untranslatable: '<b>${"World"}</b>'}, '!'],
-        },
-      ],
-    }
-  );
-});
-
-test('msg(html(html))', () => {
-  checkTransform(
-    'msg(html`Hello <b>${html`<i>World</i>`}</b>!`, {id: "foo"});',
-    'html`Hello <b><i>World</i></b>!`;'
-  );
-});
-
-test('msg(html(html)) translated', () => {
-  checkTransform(
-    'msg(html`Hello <b>${html`<i>World</i>`}</b>!`, {id: "foo"});',
-    'html`Hola <b><i>World</i></b>!`;',
-    {
-      messages: [
-        {
-          name: 'foo',
           contents: [
             'Hola ',
-            {untranslatable: '<b>${html`<i>World</i>`}</b>'},
+            {untranslatable: '<b>${"World"}</b>', index: '0'},
             '!',
           ],
         },
@@ -264,6 +246,33 @@ test('msg(html(html)) translated', () => {
     }
   );
 });
+
+// TODO(aomarks) Uncomment with fix for #2426
+// test('msg(html(html))', () => {
+//   checkTransform(
+//     'msg(html`Hello <b>${html`<i>World</i>`}</b>!`, {id: "foo"});',
+//     'html`Hello <b><i>World</i></b>!`;'
+//   );
+// });
+
+// test('msg(html(html)) translated', () => {
+//   checkTransform(
+//     'msg(html`Hello <b>${html`<i>World</i>`}</b>!`, {id: "foo"});',
+//     'html`Hola <b><i>World</i></b>!`;',
+//     {
+//       messages: [
+//         {
+//           name: 'foo',
+//           contents: [
+//             'Hola ',
+//             {untranslatable: '<b>${html`<i>World</i>`}</b>', index: '0'},
+//             '!',
+//           ],
+//         },
+//       ],
+//     }
+//   );
+// });
 
 test('msg(string(msg(string)))', () => {
   checkTransform(
@@ -282,7 +291,7 @@ test('msg(string(msg(string))) translated', () => {
           name: 'foo',
           contents: [
             'Hola ',
-            {untranslatable: '${msg("World", {id: "bar"})}'},
+            {untranslatable: '${msg("World", {id: "bar"})}', index: '0'},
             '!',
           ],
         },
@@ -298,15 +307,15 @@ test('msg(string(msg(string))) translated', () => {
 test('msg(string(<b>msg(string)</b>)) translated', () => {
   checkTransform(
     'msg(str`Hello <b>${msg("World", {id: "bar"})}</b>!`, {id: "foo"});',
-    '`Hola <b>Mundo</b>!`;',
+    '`Hola &lt;b&gt;Mundo&lt;/b&gt;!`;',
     {
       messages: [
         {
           name: 'foo',
           contents: [
-            'Hola ',
-            {untranslatable: '<b>${msg("World", {id: "bar"})}</b>'},
-            '!',
+            'Hola <b>',
+            {untranslatable: '${msg("World", {id: "bar"})}', index: '0'},
+            '</b>!',
           ],
         },
         {

--- a/packages/localize-tools/src/tests/transform.unit.test.ts
+++ b/packages/localize-tools/src/tests/transform.unit.test.ts
@@ -247,6 +247,32 @@ test('msg(html(string)) translated', () => {
   );
 });
 
+test('multiple expression-placeholders and order switching', () => {
+  checkTransform(
+    `const x = 'x';
+    const y = 'y';
+    const z = 'z';
+    msg(html\`a \${x}\${y} b \${z}\`, {id: "foo"});`,
+    `const x = 'x';
+    const y = 'y';
+    const z = 'z';
+    html\`B \${z} A \${x}\${y}\`;`,
+    {
+      messages: [
+        {
+          name: 'foo',
+          contents: [
+            'B ',
+            {untranslatable: 'N/A-1', index: 1},
+            ' A ',
+            {untranslatable: 'N/A-0', index: 0},
+          ],
+        },
+      ],
+    }
+  );
+});
+
 // TODO(aomarks) Uncomment with fix for #2426
 // test('msg(html(html))', () => {
 //   checkTransform(

--- a/packages/localize-tools/src/tests/transform.unit.test.ts
+++ b/packages/localize-tools/src/tests/transform.unit.test.ts
@@ -141,9 +141,9 @@ test('html(msg(html)) translated', () => {
           name: 'foo',
           contents: [
             'Hola ',
-            {untranslatable: '<i>', index: '0'},
+            {untranslatable: '<i>', index: 0},
             'Mundo',
-            {untranslatable: '</i>', index: '1'},
+            {untranslatable: '</i>', index: 1},
           ],
         },
       ],
@@ -166,7 +166,7 @@ test('msg(string(expr)) translated', () => {
       messages: [
         {
           name: 'foo',
-          contents: ['Hola ', {untranslatable: '${name}', index: '0'}, '!'],
+          contents: ['Hola ', {untranslatable: '${name}', index: 0}, '!'],
         },
       ],
     }
@@ -188,7 +188,7 @@ test('msg(string(string)) translated', () => {
       messages: [
         {
           name: 'foo',
-          contents: ['Hola ', {untranslatable: '${"World"}', index: '0'}, '!'],
+          contents: ['Hola ', {untranslatable: '${"World"}', index: 0}, '!'],
         },
       ],
     }
@@ -212,7 +212,7 @@ test('msg(html(expr)) translated', () => {
           name: 'foo',
           contents: [
             'Hola ',
-            {untranslatable: '<b>${name}</b>', index: '0'},
+            {untranslatable: '<b>${name}</b>', index: 0},
             '!',
           ],
         },
@@ -238,7 +238,7 @@ test('msg(html(string)) translated', () => {
           name: 'foo',
           contents: [
             'Hola ',
-            {untranslatable: '<b>${"World"}</b>', index: '0'},
+            {untranslatable: '<b>${"World"}</b>', index: 0},
             '!',
           ],
         },
@@ -265,7 +265,7 @@ test('msg(html(string)) translated', () => {
 //           name: 'foo',
 //           contents: [
 //             'Hola ',
-//             {untranslatable: '<b>${html`<i>World</i>`}</b>', index: '0'},
+//             {untranslatable: '<b>${html`<i>World</i>`}</b>', index: 0},
 //             '!',
 //           ],
 //         },
@@ -291,7 +291,7 @@ test('msg(string(msg(string))) translated', () => {
           name: 'foo',
           contents: [
             'Hola ',
-            {untranslatable: '${msg("World", {id: "bar"})}', index: '0'},
+            {untranslatable: '${msg("World", {id: "bar"})}', index: 0},
             '!',
           ],
         },
@@ -314,7 +314,7 @@ test('msg(string(<b>msg(string)</b>)) translated', () => {
           name: 'foo',
           contents: [
             'Hola <b>',
-            {untranslatable: '${msg("World", {id: "bar"})}', index: '0'},
+            {untranslatable: '${msg("World", {id: "bar"})}', index: 0},
             '</b>!',
           ],
         },

--- a/packages/localize-tools/src/typescript.ts
+++ b/packages/localize-tools/src/typescript.ts
@@ -100,10 +100,9 @@ export function escapeTextContentToEmbedInTemplateLiteral(
  * (backticks should not be included), and return its TypeScript AST node
  * representation.
  */
-export function parseStringAsTemplateLiteral(templateLiteralBody: string): {
-  file: ts.SourceFile;
-  template: ts.TemplateLiteral;
-} {
+export function parseStringAsTemplateLiteral(
+  templateLiteralBody: string
+): ts.TemplateLiteral {
   const file = ts.createSourceFile(
     '__DUMMY__.ts',
     '`' + templateLiteralBody + '`',
@@ -122,5 +121,5 @@ export function parseStringAsTemplateLiteral(templateLiteralBody: string): {
   if (!ts.isTemplateLiteral(expression)) {
     throw new Error('Internal error: expected template literal expression');
   }
-  return {file, template: expression};
+  return expression;
 }

--- a/packages/localize-tools/src/typescript.ts
+++ b/packages/localize-tools/src/typescript.ts
@@ -100,9 +100,10 @@ export function escapeTextContentToEmbedInTemplateLiteral(
  * (backticks should not be included), and return its TypeScript AST node
  * representation.
  */
-export function parseStringAsTemplateLiteral(
-  templateLiteralBody: string
-): ts.TemplateLiteral {
+export function parseStringAsTemplateLiteral(templateLiteralBody: string): {
+  file: ts.SourceFile;
+  template: ts.TemplateLiteral;
+} {
   const file = ts.createSourceFile(
     '__DUMMY__.ts',
     '`' + templateLiteralBody + '`',
@@ -121,5 +122,5 @@ export function parseStringAsTemplateLiteral(
   if (!ts.isTemplateLiteral(expression)) {
     throw new Error('Internal error: expected template literal expression');
   }
-  return expression;
+  return {file, template: expression};
 }

--- a/packages/localize-tools/testdata/build-runtime-xlb/goldens/xlb/es-419.xlb
+++ b/packages/localize-tools/testdata/build-runtime-xlb/goldens/xlb/es-419.xlb
@@ -2,14 +2,14 @@
 <localizationbundle locale="es-419">
   <messages>
     <msg name="s8c0ec8d1fb9e6e32">Hola Mundo!</msg>
-    <msg name="s00ad08ebae1e0f74">Hola <ph>${user}</ph>!</msg>
-    <msg name="h3c44aff2d5f5ef6b">Hola <ph>&lt;b></ph>Mundo<ph>&lt;/b></ph>!</msg>
-    <msg name="h82ccc38d4d46eaa9">Hola <ph>&lt;b>${user}&lt;/b></ph>!</msg>
-    <msg name="h99e74f744fda7e25">Clic <ph>&lt;a href="${url}"></ph>aquí<ph>&lt;/a></ph>!</msg>
-    <msg name="hc1c6bfa4414cb3e3">[SALT] Clic <ph>&lt;a href="${'https://www.example.com/'}"></ph>aquí<ph>&lt;/a></ph>!</msg>
-    <msg name="h349c3c4777670217">[SALT] Hola <ph>&lt;b>${msg('World')}&lt;/b></ph>!</msg>
+    <msg name="s00ad08ebae1e0f74">Hola <ph name="0">${user}</ph>!</msg>
+    <msg name="h3c44aff2d5f5ef6b">Hola <ph name="0">&lt;b></ph>Mundo<ph name="1">&lt;/b></ph>!</msg>
+    <msg name="h82ccc38d4d46eaa9">Hola <ph name="0">&lt;b>${user}&lt;/b></ph>!</msg>
+    <msg name="h99e74f744fda7e25">Clic <ph name="0">&lt;a href="${url}"></ph>aquí<ph name="1">&lt;/a></ph>!</msg>
+    <msg name="hc1c6bfa4414cb3e3">[SALT] Clic <ph name="0">&lt;a href="${'https://www.example.com/'}"></ph>aquí<ph name="1">&lt;/a></ph>!</msg>
+    <msg name="h349c3c4777670217">[SALT] Hola <ph name="0">&lt;b>${msg('World')}&lt;/b></ph>!</msg>
     <msg name="s0f19e6c4e521dd53">Mundo</msg>
-    <msg name="hbe936ff3da20ffdf">Hola <ph>&lt;b>&lt;!-- comment --></ph>Mundo<ph>&lt;/b></ph>!</msg>
+    <msg name="hbe936ff3da20ffdf">Hola <ph name="0">&lt;b>&lt;!-- comment --></ph>Mundo<ph name="1">&lt;/b></ph>!</msg>
     <msg name="myId">Hola Mundo</msg>
     <msg name="s03c68d79ad36e8d4" desc="Description of 0">described 0</msg>
     <msg name="s03c68e79ad36ea87" desc="Parent description / Description of 1">described 1</msg>

--- a/packages/localize-tools/testdata/build-runtime-xlb/input/xlb/es-419.xlb
+++ b/packages/localize-tools/testdata/build-runtime-xlb/input/xlb/es-419.xlb
@@ -2,14 +2,14 @@
 <localizationbundle locale="es-419">
   <messages>
     <msg name="s8c0ec8d1fb9e6e32">Hola Mundo!</msg>
-    <msg name="s00ad08ebae1e0f74">Hola <ph>${user}</ph>!</msg>
-    <msg name="h3c44aff2d5f5ef6b">Hola <ph>&lt;b></ph>Mundo<ph>&lt;/b></ph>!</msg>
-    <msg name="h82ccc38d4d46eaa9">Hola <ph>&lt;b>${user}&lt;/b></ph>!</msg>
-    <msg name="h99e74f744fda7e25">Clic <ph>&lt;a href="${url}"></ph>aquí<ph>&lt;/a></ph>!</msg>
-    <msg name="hc1c6bfa4414cb3e3">[SALT] Clic <ph>&lt;a href="${'https://www.example.com/'}"></ph>aquí<ph>&lt;/a></ph>!</msg>
-    <msg name="h349c3c4777670217">[SALT] Hola <ph>&lt;b>${msg('World')}&lt;/b></ph>!</msg>
+    <msg name="s00ad08ebae1e0f74">Hola <ph name="0">${user}</ph>!</msg>
+    <msg name="h3c44aff2d5f5ef6b">Hola <ph name="0">&lt;b></ph>Mundo<ph name="1">&lt;/b></ph>!</msg>
+    <msg name="h82ccc38d4d46eaa9">Hola <ph name="0">&lt;b>${user}&lt;/b></ph>!</msg>
+    <msg name="h99e74f744fda7e25">Clic <ph name="0">&lt;a href="${url}"></ph>aquí<ph name="1">&lt;/a></ph>!</msg>
+    <msg name="hc1c6bfa4414cb3e3">[SALT] Clic <ph name="0">&lt;a href="${'https://www.example.com/'}"></ph>aquí<ph name="1">&lt;/a></ph>!</msg>
+    <msg name="h349c3c4777670217">[SALT] Hola <ph name="0">&lt;b>${msg('World')}&lt;/b></ph>!</msg>
     <msg name="s0f19e6c4e521dd53">Mundo</msg>
-    <msg name="hbe936ff3da20ffdf">Hola <ph>&lt;b>&lt;!-- comment --></ph>Mundo<ph>&lt;/b></ph>!</msg>
+    <msg name="hbe936ff3da20ffdf">Hola <ph name="0">&lt;b>&lt;!-- comment --></ph>Mundo<ph name="1">&lt;/b></ph>!</msg>
     <msg name="myId">Hola Mundo</msg>
     <msg name="s03c68d79ad36e8d4" desc="Description of 0">described 0</msg>
     <msg name="s03c68e79ad36ea87" desc="Parent description / Description of 1">described 1</msg>

--- a/packages/localize-tools/testdata/build-runtime-xliff/goldens/xliff/es-419.xlf
+++ b/packages/localize-tools/testdata/build-runtime-xliff/goldens/xliff/es-419.xlf
@@ -40,7 +40,7 @@
 </trans-unit>
 <trans-unit id="hf979404a36e879cb">
   <source>a:<x id="0" equiv-text="${'A'}"/> b:<x id="1" equiv-text="${'B'}"/> c:<x id="2" equiv-text="${'C'}"/></source>
-  <target>c:<x id="0" equiv-text="${'C'}"/> a:<x id="1" equiv-text="${'A'}"/> b:<x id="2" equiv-text="${'B'}"/></target>
+  <target>c:<x id="2" equiv-text="${'C'}"/> a:<x id="0" equiv-text="${'A'}"/> b:<x id="1" equiv-text="${'B'}"/></target>
 </trans-unit>
 <trans-unit id="myId">
   <source>Hello World</source>

--- a/packages/localize-tools/testdata/build-runtime-xliff/input/xliff/es-419.xlf
+++ b/packages/localize-tools/testdata/build-runtime-xliff/input/xliff/es-419.xlf
@@ -40,7 +40,7 @@
 </trans-unit>
 <trans-unit id="hf979404a36e879cb">
   <source>a:<x id="0" equiv-text="${'A'}"/> b:<x id="1" equiv-text="${'B'}"/> c:<x id="2" equiv-text="${'C'}"/></source>
-  <target>c:<x id="0" equiv-text="${'C'}"/> a:<x id="1" equiv-text="${'A'}"/> b:<x id="2" equiv-text="${'B'}"/></target>
+  <target>c:<x id="2" equiv-text="${'C'}"/> a:<x id="0" equiv-text="${'A'}"/> b:<x id="1" equiv-text="${'B'}"/></target>
 </trans-unit>
 <trans-unit id="myId">
   <source>Hello World</source>

--- a/packages/localize-tools/testdata/extract-xlb-fresh/goldens/xlb/en.xlb
+++ b/packages/localize-tools/testdata/extract-xlb-fresh/goldens/xlb/en.xlb
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <localizationbundle locale="en">
   <messages>
-    <msg name="he7b474847636149b" desc="Description of Hello $(name)">Hello <ph>&lt;b>${name}</ph>!<ph>&lt;/b></ph></msg>
+    <msg name="he7b474847636149b" desc="Description of Hello $(name)">Hello <ph name="0">&lt;b>${name}</ph>!<ph name="1">&lt;/b></ph></msg>
     <msg name="s8c0ec8d1fb9e6e32" desc="Description of Hello World">Hello World!</msg>
   </messages>
 </localizationbundle>


### PR DESCRIPTION
Fixes #2140 and #1897.

- For messages to be considered same:
  - No longer check for expressions to be identical.
  - Do check that desc be identical.
- Display a more helpful aggregate error message for all messages with the same id.
- For XLB format, add placeholder index to `name` attribute of `<ph>` tags.
- Utilize the placeholder indexes embedded in tags for determining placeholder locations during transform mode.