### PR TITLE
Add GitHub action that auto adds new issues to Lit project

### DIFF
--- a/.github/workflows/add-issues-to-project.yml
+++ b/.github/workflows/add-issues-to-project.yml
@@ -1,0 +1,15 @@
+# GitHub action that automatically adds newly filed issues to the Lit project.
+# See https://github.com/peter-evans/create-or-update-project-card for documentation.
+on:
+  issues:
+    types: [opened]
+jobs:
+  createCard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create project card
+        uses: peter-evans/create-or-update-project-card@v1
+        with:
+          project-location: lit
+          project-number: 4
+          column-name: No Status


### PR DESCRIPTION
Adds a GitHub action that automatically adds newly filed issues to the Lit project. See https://github.com/peter-evans/create-or-update-project-card for documentation.