### PR TITLE
Use new lit-robot PAT for automating adding issues to Lit project

### DIFF
--- a/.github/workflows/add-issues-to-project.yml
+++ b/.github/workflows/add-issues-to-project.yml
@@ -10,6 +10,7 @@ jobs:
       - name: Create project card
         uses: peter-evans/create-or-update-project-card@v1
         with:
+          token: ${{ secrets.LIT_ROBOT_AUTOMATION_PAT }}
           project-location: lit
           project-number: 4
           column-name: No Status


### PR DESCRIPTION
I've created a new https://github.com/lit-robot account and added a personal access token (PAT) to the Lit org's secrets. We can use this for other general purpose automation too if needed. 

This is required for the action that automatically adds newly filed issues to the Lit project board because the default `GITHUB_TOKEN` token only has permission for this repo, not for the whole org, but our project board is org-scoped.