### PR TITLE
Remove completely blank lines in YAML blocks in workflows.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,15 +56,12 @@ jobs:
             ${{ steps.changesets.outputs.publishedPackages }}
           EOF
           )
-
           # Don't create a bundle commit if `lit` wasn't published.
           if [[ -z "$LIT_VERSION" ]]; then
             exit
           fi
-
           # Checkout the empty root commit (with tag `empty`).
           git checkout --detach empty
-
           # Copy in all of the bundles.
           cp ../packages/lit/lit.all.min.js .
           cp ../packages/lit/lit.all.min.js.map .
@@ -74,7 +71,6 @@ jobs:
           cp ../packages/lit/lit.min.js.map .
           cp ../packages/lit/lit.min.umd.js .
           cp ../packages/lit/lit.min.umd.js.map .
-
           # Stage the bundles, create the commit, tag it, and push.
           git add .
           git config user.name "Lit Release Bot"


### PR DESCRIPTION
I think that inserting a completely blank line in an indented YAML block requires explicitly filling in the indentation at the front with leading spaces for each blank line, which I didn't do when originally adding these workflow steps. In this PR, I've opted to remove them instead of adding whitespace because whitespace-only lines are not obvious without configuring your editor and they were only used before comments, which already provide some separation on their own.

Another point for Team Significant Whitespace Is Bad.