### PR TITLE
Use graphql API directly to automate adding issues to project

### DIFF
--- a/.github/workflows/add-issues-to-project.yml
+++ b/.github/workflows/add-issues-to-project.yml
@@ -1,5 +1,7 @@
 # GitHub action that automatically adds newly filed issues to the Lit project.
-# See https://github.com/leonsteinhaeuser/project-beta-automations for documentation.
+#
+# Based on the example at
+# https://docs.github.com/en/issues/trying-out-the-new-projects-experience/automating-projects#example-workflow-authenticating-with-a-personal-access-token
 on:
   issues:
     types: [opened]
@@ -7,10 +9,35 @@ jobs:
   add-issue-to-project:
     runs-on: ubuntu-latest
     steps:
-      - name: Add issue to Lit project
-        uses: leonsteinhaeuser/project-beta-automations@v1.1.0
-        with:
-          gh_token: ${{ secrets.LIT_ROBOT_AUTOMATION_PAT }}
-          organization: lit
-          project_id: 4
-          resource_node_id: ${{ github.event.issue.node_id }}
+      # Finds the global entity ID for the project and adds it to an environment variable
+      # for the next step to consume.
+      - name: Get project ID
+        env:
+          GITHUB_TOKEN: ${{ secrets.LIT_ROBOT_AUTOMATION_PAT }}
+          ORGANIZATION: lit
+          PROJECT_NUMBER: 4
+        run: |
+          gh api graphql -f query='
+            query($organization: String!, $project_number: Int!) {
+              organization(login: $organization){
+                projectNext(number: $project_number) {
+                  id
+                }
+              }
+            }' -f organization=$ORGANIZATION -F project_number=$PROJECT_NUMBER > project_data.json
+            
+          echo 'PROJECT_ID='$(jq '.data.organization.projectNext.id' project_data.json) >> $GITHUB_ENV
+          
+      - name: Add issue to project
+        env:
+          GITHUB_TOKEN: ${{ secrets.LIT_ROBOT_AUTOMATION_PAT }}
+          ISSUE_ID: ${{ github.event.issue.node_id }}
+        run: |
+          gh api graphql -f query='
+            mutation($project_id:ID!, $issue_id:ID!) {
+              addProjectNextItem(input: {projectId: $project_id, contentId: $issue_id}) {
+                projectNextItem {
+                  id
+                }
+              }
+            }' -f project_id=$PROJECT_ID -f issue_id=$ISSUE_ID


### PR DESCRIPTION
The workflow I was trying from https://github.com/leonsteinhaeuser/project-beta-automations didn't work (filed https://github.com/leonsteinhaeuser/project-beta-automations/issues/27).

But I realized we could use the graphql API directly to get more control here. This new action is based on the example at https://docs.github.com/en/issues/trying-out-the-new-projects-experience/automating-projects#example-workflow-authenticating-with-a-personal-access-token, just slightly modified and simplified.

I've tested this in my personal repo and it works, so hopefully it will work for us too.