### PR TITLE
Provide better paths for sources in the bundles' source maps.

### DIFF
--- a/packages/lit/rollup.config.js
+++ b/packages/lit/rollup.config.js
@@ -6,6 +6,27 @@
 
 import {litProdConfig} from '../../rollup-common.js';
 import {createRequire} from 'module';
+import * as path from 'path';
+
+/**
+ * Takes a `relativeSourcePath` and `sourcemapPath` - with the same semantics as
+ * those provided to the function given to Rollup's
+ * [`output.sourcemapPathTransform` config option][1] - and produces a relative
+ * path to the source file from the `packages` directory of this repo.
+ *
+ * [1]: https://rollupjs.org/guide/en/#outputsourcemappathtransform
+ */
+const makeRelativeToPackagesDir = (relativeSourcePath, sourcemapPath) => {
+  const absoluteSourcePath = path.resolve(
+    path.join(path.dirname(sourcemapPath), relativeSourcePath)
+  );
+  const absolutePackagesDirPath = path.resolve(path.join(__dirname, '..'));
+  const relativePackagesDirToSourcePath = path.relative(
+    absolutePackagesDirPath,
+    absoluteSourcePath
+  );
+  return relativePackagesDirToSourcePath;
+};
 
 export default litProdConfig({
   packageName: createRequire(import.meta.url)('./package.json').name,
@@ -58,11 +79,30 @@ export default litProdConfig({
       file: 'index',
       output: 'lit.min',
       format: 'es',
+      sourcemapPathTransform: (relativeSourcePath, sourcemapPath) => {
+        // Convert the paths of the sources to appear as descendants of a
+        // directory with the same name as the bundle. (By default, the paths in
+        // the source map are relative paths from the bundle to the included
+        // sources as they were on disk at the time the bundle was generated.
+        // This causes the developer tools to display the original sources at
+        // seemingly unrelated locations.)
+        return path.join(
+          'lit.min.js',
+          makeRelativeToPackagesDir(relativeSourcePath, sourcemapPath)
+        );
+      },
     },
     {
       file: 'index.all',
       output: 'lit.all.min',
       format: 'es',
+      sourcemapPathTransform: (relativeSourcePath, sourcemapPath) => {
+        // See the comment in the core bundle above.
+        return path.join(
+          'lit.all.min.js',
+          makeRelativeToPackagesDir(relativeSourcePath, sourcemapPath)
+        );
+      },
     },
   ],
 });

--- a/rollup-common.js
+++ b/rollup-common.js
@@ -409,13 +409,14 @@ export function litProdConfig({
             ]),
       ],
     },
-    ...bundled.map(({file, output, name, format}) =>
+    ...bundled.map(({file, output, name, format, sourcemapPathTransform}) =>
       litMonoBundleConfig({
         file,
         output,
         name,
         terserOptions,
         format,
+        sourcemapPathTransform,
       })
     ),
   ];
@@ -427,6 +428,7 @@ const litMonoBundleConfig = ({
   name,
   terserOptions,
   format = 'umd',
+  sourcemapPathTransform,
   // eslint-disable-next-line no-undef
 } = options) => ({
   input: `development/${file}.js`,
@@ -435,6 +437,7 @@ const litMonoBundleConfig = ({
     format,
     name,
     sourcemap: !CHECKSIZE,
+    sourcemapPathTransform,
   },
   plugins: [
     nodeResolve(),


### PR DESCRIPTION
By default, the paths in the source map are relative paths from the bundle to the included sources as they were on disk at the time the bundle was generated. This causes the developer tools to display the original sources at seemingly unrelated locations. This PR transforms them so that the original locations appear to be in a single directory with the same name as the bundle with the same structure as the `packages` directory.

For example, rather than the source map for `lit.min.js` saying that the main `lit-html` entrypoint is located at `../lit-html/src/lit-html.ts`:

```
+ lit-html (generated by source map)
| + src
|   + lit-html.ts
+ lit-element (generated by source map)
| + ...
+ dir-with-bundle
  + lit.min.js
```

It will say that it is at `./lit.min.js/lit-html/src/lit.html.ts` instead:
 
 ```

+ dir-with-bundle
   + lit.min.js
   + lit.min.js (generated by source map)
     + lit-html
     | + src
     |   + lit-html.ts
     + lit-element
       + ...
```

 (tl;dr: `path.join(bundleName, relativeFromPackagesDirToSource)`)