### PR TITLE
Remove the polyfill support module and decorators from the 'all' bundle.

### DIFF
--- a/packages/lit/src/index.all.ts
+++ b/packages/lit/src/index.all.ts
@@ -4,12 +4,9 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import './polyfill-support.js';
-
 export * from './index.js';
 
 export * from './async-directive.js';
-export * from './decorators.js';
 export * from './directive-helpers.js';
 export * from './directive.js';
 export * from './directives/async-append.js';


### PR DESCRIPTION
The polyfill support module is only useful in contexts where this ES2019 bundle won't work and the decorators are very unergonomic without TypeScript and have JS equivalents.