### PR TITLE
Add step to remove old version of prettier during release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,6 +27,12 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
+      # Changeset uses prettier@1 which creates unstable formatting issues
+      # Deleting this forces fallback to our version of prettier
+      # https://github.com/changesets/changesets/issues/616
+      - name: Remove old version of prettier from changesets
+        run: rm -rf node_modules/@changesets/write/node_modules/prettier
+
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@master


### PR DESCRIPTION
Add step in release workflow to remove old version of prettier to fallback to our version.
The old version of prettier handles formatting of nested javascript differently.