### PR TITLE
Put each bundle into separate folders.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -69,10 +69,12 @@ jobs:
           # Checkout the empty root commit (with tag `empty`).
           git checkout --detach empty
           # Copy in all of the bundles.
-          cp ../packages/lit/lit.all.min.js .
-          cp ../packages/lit/lit.all.min.js.map .
-          cp ../packages/lit/lit.min.js .
-          cp ../packages/lit/lit.min.js.map .
+          mkdir all
+          cp ../packages/lit/lit.all.min.js all
+          cp ../packages/lit/lit.all.min.js.map all
+          mkdir core
+          cp ../packages/lit/lit.min.js core
+          cp ../packages/lit/lit.min.js.map core
           # Stage the bundles, create the commit, tag it, and push.
           git add .
           git config user.name "Lit Robot"


### PR DESCRIPTION
This way we don't have to worry about name conflicts if we end up wanting to make the static, unbundled builds we were thinking about later.