### PR TITLE
Use lit-robot for changesets commits

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,7 +41,7 @@ jobs:
           publish: npm run release
         env:
           HUSKY: 0
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.LIT_ROBOT_AUTOMATION_PAT }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Checkout dist repo


### PR DESCRIPTION
Update changesets to use the new `lit-robot` account instead of the default github actions account. This should fix CLA problems.

Fixes https://github.com/lit/lit/issues/2452