### PR TITLE
[labs/router] Skip tests on ie11

### DIFF
--- a/packages/labs/router/src/test/router_test.ts
+++ b/packages/labs/router/src/test/router_test.ts
@@ -7,7 +7,12 @@
 import {assert} from '@esm-bundle/chai';
 import type {Test1, Child1, Child2} from './router_test_code.js';
 
-suite('Router', () => {
+const canTest =
+  window.ShadowRoot &&
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  !(window as any).ShadyDOM?.inUse;
+
+(canTest ? suite : suite.skip)('Router', () => {
   let container: HTMLIFrameElement;
 
   setup(async () => {


### PR DESCRIPTION
Fixes https://github.com/lit/lit/issues/2468

### Context

There are currently 3 red router tests on ie11 breaking our sauce-ie11 tests.

### Fix

Fixed by skipping labs/router tests on ie11. I don't know if we run the ie11 router tests with shadydom polyfill.

This change is a test only change and should result in an sauce-ie11 green run.