### PR TITLE
[bundles] Update `staticSvg` case to match `staticHtml`.

### DIFF
--- a/packages/lit/src/index.all.ts
+++ b/packages/lit/src/index.all.ts
@@ -33,7 +33,7 @@ export * from './directives/when.js';
 export {
   html as staticHtml,
   literal,
-  svg as staticSVG,
+  svg as staticSvg,
   unsafeStatic,
   withStatic,
 } from './static-html.js';


### PR DESCRIPTION
This makes the case consistent between these two items renamed on re-export and matches the convention used in `static.ts`:

https://github.com/lit/lit/blob/cdc9ee3117fe015b036c6592970e250d724f85a1/packages/lit-html/src/static.ts#L10