### PR TITLE
[@lit-labs/eleventy-plugin-lit] Remove unnecessary marker comments

### DIFF
--- a/packages/labs/eleventy-plugin-lit/demo/_js/package.json
+++ b/packages/labs/eleventy-plugin-lit/demo/_js/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/packages/labs/eleventy-plugin-lit/src/index.ts
+++ b/packages/labs/eleventy-plugin-lit/src/index.ts
@@ -13,7 +13,8 @@
 // So instead we use TypeScript's ESM output mode, but explicitly write
 // require() calls for the CommonJS modules we import.
 //
-// See https://github.com/microsoft/TypeScript/issues/43329 for more details.
+// See https://github.com/microsoft/TypeScript/issues/43329 and
+// https://github.com/microsoft/TypeScript#22321 for more details.
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const path = require('path') as typeof import('path');

--- a/packages/labs/eleventy-plugin-lit/src/index.ts
+++ b/packages/labs/eleventy-plugin-lit/src/index.ts
@@ -31,35 +31,35 @@ module.exports = {
     eleventyConfig.addTransform(
       'render-lit',
       async (content: string, outputPath: string) => {
-        if (outputPath.endsWith('.html')) {
-          const render = (
-            await import('@lit-labs/ssr/lib/render-with-global-dom-shim.js')
-          ).render;
-          const html = (await import('lit')).html;
-          const unsafeHTML = (await import('lit/directives/unsafe-html.js'))
-            .unsafeHTML;
-          // TODO(aomarks) This doesn't work in Eleventy --watch mode, because
-          // the ES module cache never gets cleared. Switch to isolated VM
-          // modules so that we can control this.
-          await Promise.all(
-            (options.componentModules ?? []).map(
-              (module) => import(path.resolve(process.cwd(), module))
-            )
-          );
-          let head, body, tail;
-          const page = content.match(/(.*)(<body.*<\/body>)(.*)/);
-          if (page) {
-            [head, body, tail] = page;
-          } else {
-            head = `<html><head></head>`;
-            body = `<body>${content}</body>`;
-            tail = `</html>`;
-          }
-          return (
-            head + iterableToString(render(html`${unsafeHTML(body)}`)) + tail
-          );
+        if (!outputPath.endsWith('.html')) {
+          return content;
         }
-        return content;
+        const render = (
+          await import('@lit-labs/ssr/lib/render-with-global-dom-shim.js')
+        ).render;
+        const html = (await import('lit')).html;
+        const unsafeHTML = (await import('lit/directives/unsafe-html.js'))
+          .unsafeHTML;
+        // TODO(aomarks) This doesn't work in Eleventy --watch mode, because
+        // the ES module cache never gets cleared. Switch to isolated VM
+        // modules so that we can control this.
+        await Promise.all(
+          (options.componentModules ?? []).map(
+            (module) => import(path.resolve(process.cwd(), module))
+          )
+        );
+        let head, body, tail;
+        const page = content.match(/(.*)(<body.*<\/body>)(.*)/);
+        if (page) {
+          [head, body, tail] = page;
+        } else {
+          head = `<html><head></head>`;
+          body = `<body>${content}</body>`;
+          tail = `</html>`;
+        }
+        return (
+          head + iterableToString(render(html`${unsafeHTML(body)}`)) + tail
+        );
       }
     );
   },

--- a/packages/labs/eleventy-plugin-lit/src/index.ts
+++ b/packages/labs/eleventy-plugin-lit/src/index.ts
@@ -4,8 +4,19 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+// Note this file must be CommonJS for compatibility with Eleventy, but we can't
+// rely on TypeScript's CommonJS output mode, because that will also convert
+// dynamic import() calls to require() calls. That would be bad, because we need
+// to import ES modules from @lit-labs/ssr, which requires preserved import()
+// calls.
+//
+// So instead we use TypeScript's ESM output mode, but explicitly write
+// require() calls for the CommonJS modules we import.
+//
+// See https://github.com/microsoft/TypeScript/issues/43329 for more details.
+
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const path = require('path');
+const path = require('path') as typeof import('path');
 
 type LitPluginOptions = {
   componentModules?: string[];


### PR DESCRIPTION
Trims Lit SSR `<!--lit-part-->` and `<?>` marker comments before and after the top-level synthetic template that is rendered for each Eleventy HTML file. I believe these serve no purpose, since the top-level template that we synthetically render could never be hydrated.

This also avoids the problem of marker comments appearing before `<!doctype>` declarations, which I think may have been why we had some special handling around trying to detect or synthesize `<body>` tags previously. So I was able to remove this part of the code as well.

Also includes some miscellaneous minor cleanup.

Part of https://github.com/lit/lit/issues/2352