### PR TITLE
[lit-html] Add svg tagged template literal documentation

### DIFF
--- a/.changeset/silly-donuts-sit.md
+++ b/.changeset/silly-donuts-sit.md
@@ -3,4 +3,4 @@
 'lit': patch
 ---
 
-Expand JSDocs for the `svg` tagged template literal (TTL). The new documentation makes it more clear that the `svg` TTL should only be used for SVG fragments, and not for the svg html element.
+Expand JSDocs for the `svg` tagged template literal (TTL). The new documentation makes it more clear that the `svg` tag function should only be used for SVG fragments, and not for the `<svg>` HTML element.

--- a/.changeset/silly-donuts-sit.md
+++ b/.changeset/silly-donuts-sit.md
@@ -1,0 +1,6 @@
+---
+'lit-html': patch
+'lit': patch
+---
+
+Expand JSDocs for the `svg` tagged template literal (TTL). The new documentation makes it more clear that the `svg` TTL should only be used for SVG fragments, and not for the svg html element.

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -340,9 +340,9 @@ export const html = tag(HTML_RESULT);
  * common error is wrapping `<svg>` with the svg TTL. The `<svg>` element is an
  * html element and should be used within a {@linkcode html} TTL.
  *
- * In LitElement usage, it's rare to return an svg fragment from the `render()`
- * method, as the svg fragment will be contained within the element's shadow
- * root and thus cannot be used within an `<svg>` html tag.
+ * In LitElement usage, it's rare to return an SVG fragment from the `render()`
+ * method, as the SVG fragment will be contained within the element's shadow
+ * root and thus cannot be used within an `<svg>` HTML element.
  */
 export const svg = tag(SVG_RESULT);
 

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -323,8 +323,26 @@ const tag =
 export const html = tag(HTML_RESULT);
 
 /**
- * Interprets a template literal as an SVG template that can efficiently
+ * Interprets a template literal as an SVG fragment that can efficiently
  * render to and update a container.
+ *
+ * ```ts
+ * const rect = svg`<rect width="10" height="10"></rect>`;
+ *
+ * const myImage = html`
+ *   <svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg">
+ *     ${rect}
+ *   </svg>`;
+ * ```
+ *
+ * The `svg` tagged template literal (TTL) should only be used for SVG
+ * fragments, or elements that would be contained within an `<svg>` html tag. A
+ * common error is wrapping `<svg>` with the svg TTL. The `<svg>` element is an
+ * html element and should be used within a {@linkcode html} TTL.
+ *
+ * In LitElement usage, it's rare to return an svg fragment from the `render()`
+ * method, as the svg fragment will be contained within the element's shadow
+ * root and thus cannot be used within an `<svg>` html tag.
  */
 export const svg = tag(SVG_RESULT);
 

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -336,7 +336,7 @@ export const html = tag(HTML_RESULT);
  * ```
  *
  * The `svg` tagged template literal (TTL) should only be used for SVG
- * fragments, or elements that would be contained within an `<svg>` html tag. A
+ * fragments, or elements that would be contained **inside** an `<svg>` HTML element. A
  * common error is wrapping `<svg>` with the svg TTL. The `<svg>` element is an
  * HTML element and should be used within a template tagged with the {@linkcode html} tag function.
  *

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -335,10 +335,11 @@ export const html = tag(HTML_RESULT);
  *   </svg>`;
  * ```
  *
- * The `svg` tagged template literal (TTL) should only be used for SVG
- * fragments, or elements that would be contained **inside** an `<svg>` HTML element. A
- * common error is placing an `<svg>` *element* in a template tagged with the `svg` *tag function*. The `<svg>` element is an
- * HTML element and should be used within a template tagged with the {@linkcode html} tag function.
+ * The `svg` *tag function* should only be used for SVG fragments, or elements
+ * that would be contained **inside** an `<svg>` HTML element. A common error is
+ * placing an `<svg>` *element* in a template tagged with the `svg` tag
+ * function. The `<svg>` element is an HTML element and should be used within a
+ * template tagged with the {@linkcode html} tag function.
  *
  * In LitElement usage, it's rare to return an SVG fragment from the `render()`
  * method, as the SVG fragment will be contained within the element's shadow

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -338,7 +338,7 @@ export const html = tag(HTML_RESULT);
  * The `svg` tagged template literal (TTL) should only be used for SVG
  * fragments, or elements that would be contained within an `<svg>` html tag. A
  * common error is wrapping `<svg>` with the svg TTL. The `<svg>` element is an
- * html element and should be used within a {@linkcode html} TTL.
+ * HTML element and should be used within a template tagged with the {@linkcode html} tag function.
  *
  * In LitElement usage, it's rare to return an SVG fragment from the `render()`
  * method, as the SVG fragment will be contained within the element's shadow

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -337,7 +337,7 @@ export const html = tag(HTML_RESULT);
  *
  * The `svg` tagged template literal (TTL) should only be used for SVG
  * fragments, or elements that would be contained **inside** an `<svg>` HTML element. A
- * common error is wrapping `<svg>` with the svg TTL. The `<svg>` element is an
+ * common error is placing an `<svg>` *element* in a template tagged with the `svg` *tag function*. The `<svg>` element is an
  * HTML element and should be used within a template tagged with the {@linkcode html} tag function.
  *
  * In LitElement usage, it's rare to return an SVG fragment from the `render()`


### PR DESCRIPTION
Addresses issue: https://github.com/lit/lit.dev/issues/652
Also addresses generated docs for `svg`: https://github.com/lit/lit/issues/1883#issuecomment-1018777254

This is a documentation only change to guide correct usage of the svg tagged template literal. Currently it's easy to reach for this whenever anything svg related comes up.

Instead of going into the implementation details for how the `svg` TTL copies the fragment into an `<svg>` element and then copies that fragment over, I've instead focussed on correct usage and provided an example that shows both an svg fragment and complete svg element.

Test of the code example: [Lit Playground](https://lit.dev/playground/#project=W3sibmFtZSI6InNpbXBsZS1ncmVldGluZy50cyIsImNvbnRlbnQiOiJpbXBvcnQge2h0bWwsIGNzcywgTGl0RWxlbWVudCwgc3ZnfSBmcm9tICdsaXQnO1xuaW1wb3J0IHtjdXN0b21FbGVtZW50LCBwcm9wZXJ0eX0gZnJvbSAnbGl0L2RlY29yYXRvcnMuanMnO1xuXG5AY3VzdG9tRWxlbWVudCgnc2ltcGxlLWdyZWV0aW5nJylcbmV4cG9ydCBjbGFzcyBTaW1wbGVHcmVldGluZyBleHRlbmRzIExpdEVsZW1lbnQge1xuICBzdGF0aWMgc3R5bGVzID0gY3NzYHAgeyBjb2xvcjogYmx1ZSB9YDtcblxuICBAcHJvcGVydHkoKVxuICBuYW1lID0gJ1NvbWVib2R5JztcblxuICByZW5kZXIoKSB7XG4gICAgY29uc3QgcmVjdCA9IHN2Z2A8cmVjdCB3aWR0aD1cIjEwXCIgaGVpZ2h0PVwiMTBcIj48L3JlY3Q-YDtcbiBcbiAgICBjb25zdCBteUltYWdlID0gaHRtbGBcbiAgICAgIDxzdmcgdmlld0JveD1cIjAgMCAxMCAxMFwiIHhtbG5zPVwiaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmdcIj5cbiAgICAgICAgJHtyZWN0fVxuICAgICAgPC9zdmc-YDtcbiAgICByZXR1cm4gbXlJbWFnZTtcbiAgfVxufVxuIn0seyJuYW1lIjoiaW5kZXguaHRtbCIsImNvbnRlbnQiOiI8IURPQ1RZUEUgaHRtbD5cbjxoZWFkPlxuICA8c2NyaXB0IHR5cGU9XCJtb2R1bGVcIiBzcmM9XCIuL3NpbXBsZS1ncmVldGluZy5qc1wiPjwvc2NyaXB0PlxuPC9oZWFkPlxuPGJvZHk-XG4gIDxzaW1wbGUtZ3JlZXRpbmcgbmFtZT1cIldvcmxkXCI-PC9zaW1wbGUtZ3JlZXRpbmc-XG48L2JvZHk-XG4ifSx7Im5hbWUiOiJwYWNrYWdlLmpzb24iLCJjb250ZW50Ijoie1xuICBcImRlcGVuZGVuY2llc1wiOiB7XG4gICAgXCJsaXRcIjogXCJeMi4wLjBcIixcbiAgICBcIkBsaXQvcmVhY3RpdmUtZWxlbWVudFwiOiBcIl4xLjAuMFwiLFxuICAgIFwibGl0LWVsZW1lbnRcIjogXCJeMy4wLjBcIixcbiAgICBcImxpdC1odG1sXCI6IFwiXjIuMC4wXCJcbiAgfVxufSIsImhpZGRlbiI6dHJ1ZX1d)

### Risks

No codebase risk, docs only change. Main risk is adding incorrect documentation.

