### PR TITLE
Better types for PropertyValues<T>

### DIFF
--- a/.changeset/friendly-llamas-laugh.md
+++ b/.changeset/friendly-llamas-laugh.md
@@ -1,0 +1,6 @@
+---
+'@lit/reactive-element': patch
+'lit': patch
+---
+
+Update the definition of the PropertyValues type to give better types to `.get(k)`. `.get(k)` is now defined to return the correct type when using `PropertyValues<this>` and a parameter that's a key of the element class.

--- a/packages/reactive-element/src/reactive-element.ts
+++ b/packages/reactive-element/src/reactive-element.ts
@@ -223,9 +223,18 @@ type AttributeMap = Map<string, PropertyKey>;
  * interface corresponding to the declared element properties.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type PropertyValues<T = any> = keyof T extends PropertyKey
-  ? Map<keyof T, unknown>
-  : never;
+export interface PropertyValues<T = any> extends Map<keyof T, unknown> {
+  get<K extends keyof T>(k: K): T[K];
+  forEach(
+    callbackfn: <K extends keyof T>(
+      value: T[K],
+      key: K,
+      map: Map<K, unknown>
+    ) => void,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    thisArg?: any
+  ): void;
+}
 
 export const defaultConverter: ComplexAttributeConverter = {
   toAttribute(value: unknown, type?: unknown): unknown {

--- a/packages/reactive-element/src/reactive-element.ts
+++ b/packages/reactive-element/src/reactive-element.ts
@@ -223,13 +223,14 @@ type AttributeMap = Map<string, PropertyKey>;
  * interface corresponding to the declared element properties.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export interface PropertyValues<T = any> extends Map<keyof T, unknown> {
+export interface PropertyValues<T = any> extends Map<keyof T, T[keyof T]> {
   get<K extends keyof T>(k: K): T[K];
+  set<K extends keyof T>(key: K, value: T[K]): this;
   forEach(
     callbackfn: <K extends keyof T>(
       value: T[K],
       key: K,
-      map: Map<K, unknown>
+      map: Map<K, T[keyof T]>
     ) => void,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     thisArg?: any

--- a/packages/reactive-element/src/reactive-element.ts
+++ b/packages/reactive-element/src/reactive-element.ts
@@ -232,8 +232,7 @@ export interface PropertyValues<T = any> extends Map<keyof T, T[keyof T]> {
       key: K,
       map: Map<K, T[keyof T]>
     ) => void,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    thisArg?: any
+    thisArg?: unknown
   ): void;
 }
 

--- a/packages/reactive-element/src/test/reactive-element_test.ts
+++ b/packages/reactive-element/src/test/reactive-element_test.ts
@@ -3084,19 +3084,32 @@ suite('ReactiveElement', () => {
         override update(changedProperties: PropertyValues<this>) {
           // @ts-expect-error 'bar' is not a keyof this
           changedProperties.get('bar');
+          // @ts-expect-error 'bar' is not a keyof this
+          changedProperties.set('bar', 1);
+          // @ts-expect-error 'bar' is not a keyof this
+          changedProperties.has('bar');
+          // @ts-expect-error 'bar' is not a keyof this
+          changedProperties.delete('bar');
+          // @ts-expect-error number is not assignable to string
+          const w: string = changedProperties.get('foo');
+          // @ts-expect-error string is not assignable to number
+          changedProperties.set('foo', 'hi');
 
           // This should type-check without a cast:
           const x: number = changedProperties.get('foo');
+          changedProperties.set('foo', 2);
 
           // This should type-check without a cast:
           const propNames: Array<keyof this> = ['foo'];
           const y = changedProperties.get(propNames[0]);
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          changedProperties.set(propNames[0], 1 as any);
 
           changedProperties.forEach((v, k) => {
             if (k === 'foo') {
-              // This assignment ideally _shouldn't_ fail. tsc should se that
-              // k === 'foo' implies v is typeof this['foo'] (because v is
-              // this[typeof k]).
+              // This assignment ideally _shouldn't_ fail. tsc should see that
+              // `k === 'foo'` implies `v is typeof this['foo']` (because v is
+              // `this[typeof k]`).
               // @ts-expect-error tsc should be better
               const z: number = v;
               return z;
@@ -3107,6 +3120,7 @@ suite('ReactiveElement', () => {
               return z;
             }
           });
+
           // Suppress no-unused-vars warnings on x and y
           return {x, y};
         }


### PR DESCRIPTION
Fixes #2481 

This is technically a breaking change in that:

```ts
class E extends LitElement {
  declare foo: number;
  update(changedProperties: PropertyValues<this>) {
    changedProperties.get('bar'); // Error
  }
}
```

This should be an ok breaking change as it catches a legitimate problem. The thing to look out for here is whether this causes unexpected breaks. I don't quite understand what the conditional type was doing here, but since one branch was `never`, removing that should't cause any new errors.