### PR TITLE
[lit-html] svg tag function JSDoc replace 'rare' with 'invalid'

### DIFF
--- a/.changeset/curvy-candles-drum.md
+++ b/.changeset/curvy-candles-drum.md
@@ -1,0 +1,6 @@
+---
+'lit-html': patch
+'lit': patch
+---
+
+Replace 'rare' with 'invalid' in svg tag function JSDocs.

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -341,9 +341,9 @@ export const html = tag(HTML_RESULT);
  * function. The `<svg>` element is an HTML element and should be used within a
  * template tagged with the {@linkcode html} tag function.
  *
- * In LitElement usage, it's rare to return an SVG fragment from the `render()`
- * method, as the SVG fragment will be contained within the element's shadow
- * root and thus cannot be used within an `<svg>` HTML element.
+ * In LitElement usage, it's invalid to return an SVG fragment from the
+ * `render()` method, as the SVG fragment will be contained within the element's
+ * shadow root and thus cannot be used within an `<svg>` HTML element.
  */
 export const svg = tag(SVG_RESULT);
 


### PR DESCRIPTION
Include Justin's feedback on https://github.com/lit/lit/pull/2479.
Link to feedback: https://github.com/lit/lit/pull/2479#discussion_r799829808

Replace 'rare' with 'invalid' and reflow markdown