### PR TITLE
[meta] Upgrade release workflow to Node 16

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,10 +19,10 @@ jobs:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
 
-      - name: Setup Node.js 14.x
+      - name: Setup Node.js 16
         uses: actions/setup-node@v2
         with:
-          node-version: 14.x
+          node-version: 16
 
       - name: Install Dependencies
         run: npm ci


### PR DESCRIPTION
Starting to look into https://github.com/changesets/action/issues/149. One thing I noticed is that release is running on Node 14, whereas our other actions run on 16.