### PR TITLE
[meta] Use changesets/action@v1 instead of master

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@master
+        uses: changesets/action@v1
         with:
           version: npm run version
           publish: npm run release


### PR DESCRIPTION
As suggested in https://github.com/changesets/action/issues/149#issuecomment-1032005802