### PR TITLE
Fix a bug in the bundle release script. Rename bundles properly.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -44,8 +44,8 @@ packages/lit/experimental-hydrate.*
 packages/lit/index.*
 packages/lit/static-html.*
 
-packages/lit/lit.all.min.*
-packages/lit/lit.min.*
+packages/lit/lit-all.min.*
+packages/lit/lit-core.min.*
 packages/lit/polyfill-support.*
 
 packages/lit-element/decorators/

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,11 +70,11 @@ jobs:
           git checkout --detach empty
           # Copy in all of the bundles.
           mkdir all
-          cp ../packages/lit/lit.all.min.js all/lit-all.min.js
-          cp ../packages/lit/lit.all.min.js.map all/lit-all.min.js
+          cp ../packages/lit/lit-all.min.js all
+          cp ../packages/lit/lit-all.min.js.map all
           mkdir core
-          cp ../packages/lit/lit.min.js core/lit-core.min.js
-          cp ../packages/lit/lit.min.js.map core/lit-core.min.js
+          cp ../packages/lit/lit-core.min.js core
+          cp ../packages/lit/lit-core.min.js.map core
           # Stage the bundles, create the commit, tag it, and push.
           git add .
           git config user.name "Lit Robot"

--- a/.prettierignore
+++ b/.prettierignore
@@ -44,8 +44,8 @@ packages/lit/experimental-hydrate.*
 packages/lit/index.*
 packages/lit/static-html.*
 
-packages/lit/lit.all.min.*
-packages/lit/lit.min.*
+packages/lit/lit-all.min.*
+packages/lit/lit-core.min.*
 packages/lit/polyfill-support.*
 
 packages/lit-element/decorators/

--- a/packages/lit/.gitignore
+++ b/packages/lit/.gitignore
@@ -14,6 +14,6 @@
 /index.*
 /static-html.*
 
-/lit.all.min.*
-/lit.min.*
+/lit-all.min.*
+/lit-core.min.*
 /polyfill-support.*

--- a/packages/lit/rollup.config.js
+++ b/packages/lit/rollup.config.js
@@ -77,7 +77,7 @@ export default litProdConfig({
     },
     {
       file: 'index',
-      output: 'lit.min',
+      output: 'lit-core.min',
       format: 'es',
       sourcemapPathTransform: (relativeSourcePath, sourcemapPath) => {
         // Convert the paths of the sources to appear as descendants of a
@@ -87,19 +87,19 @@ export default litProdConfig({
         // This causes the developer tools to display the original sources at
         // seemingly unrelated locations.)
         return path.join(
-          'lit.min.js',
+          'lit-core.min.js',
           makeRelativeToPackagesDir(relativeSourcePath, sourcemapPath)
         );
       },
     },
     {
       file: 'index.all',
-      output: 'lit.all.min',
+      output: 'lit-all.min',
       format: 'es',
       sourcemapPathTransform: (relativeSourcePath, sourcemapPath) => {
         // See the comment in the core bundle above.
         return path.join(
-          'lit.all.min.js',
+          'lit-all.min.js',
           makeRelativeToPackagesDir(relativeSourcePath, sourcemapPath)
         );
       },


### PR DESCRIPTION
When I copied the `cp ...` lines used to import the bundles, I didn't add the `.map` suffix to the lines that copy the source maps, so they overwrote the bundles. This PR copies both using their original names but also causes them to be emitted initially with the final names, which fixes another bug where the simple renaming would have broken the association with the source map.