### PR TITLE
The `published` output of the changesets action is the string 'false'.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/checkout@v2
         # GitHub Actions outputs are strings and the string 'false' converts to
         # `true` because it isn't the empty string.
-        if: steps.changesets.outputs.published && steps.changesets.outputs.published != 'false'
+        if: steps.changesets.outputs.published == 'true'
         with:
           repository: lit/dist
           ref: empty
@@ -58,7 +58,7 @@ jobs:
       - name: Push bundles to dist repo
         # GitHub Actions outputs are strings and the string 'false' converts to
         # `true` because it isn't the empty string.
-        if: steps.changesets.outputs.published && steps.changesets.outputs.published != 'false'
+        if: steps.changesets.outputs.published == 'true'
         working-directory: dist
         run: |
           # Extract the version of `lit` that was published or the empty string.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Checkout dist repo
         uses: actions/checkout@v2
-        if: steps.changesets.outputs.published
+        if: steps.changesets.outputs.published && steps.changesets.outputs.published != 'false'
         with:
           repository: lit/dist
           ref: empty
@@ -54,7 +54,7 @@ jobs:
           token: ${{ secrets.LIT_ROBOT_AUTOMATION_PAT }}
 
       - name: Push bundles to dist repo
-        if: steps.changesets.outputs.published
+        if: steps.changesets.outputs.published && steps.changesets.outputs.published != 'false'
         working-directory: dist
         run: |
           # Extract the version of `lit` that was published or the empty string.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,6 +46,8 @@ jobs:
 
       - name: Checkout dist repo
         uses: actions/checkout@v2
+        # GitHub Actions outputs are strings and the string 'false' converts to
+        # `true` because it isn't the empty string.
         if: steps.changesets.outputs.published && steps.changesets.outputs.published != 'false'
         with:
           repository: lit/dist
@@ -54,6 +56,8 @@ jobs:
           token: ${{ secrets.LIT_ROBOT_AUTOMATION_PAT }}
 
       - name: Push bundles to dist repo
+        # GitHub Actions outputs are strings and the string 'false' converts to
+        # `true` because it isn't the empty string.
         if: steps.changesets.outputs.published && steps.changesets.outputs.published != 'false'
         working-directory: dist
         run: |


### PR DESCRIPTION
I assumed this output was a boolean, but it seems like it's actually a string, which caused these steps to run more often than necessary.

https://github.com/lit/lit/runs/5097992845?check_suite_focus=true#step:8:21

Fixes #2514.