### PR TITLE
[meta] Fix invisible changeset step in release action by changing its id

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,11 @@ jobs:
         run: rm -rf node_modules/@changesets/*/node_modules/prettier
 
       - name: Create Release Pull Request or Publish to npm
-        id: changesets
+        # The id of this step must not be "changesets", or else the step will be invisible
+        # in the list of steps from the GitHub UI when the action runs (though it will still
+        # run, and its output will appear in the raw logs). Unknown why this is the case,
+        # see https://github.com/changesets/action/issues/149 for discussion.
+        id: cs
         uses: changesets/action@v1
         with:
           version: npm run version
@@ -46,7 +50,7 @@ jobs:
 
       - name: Checkout dist repo
         uses: actions/checkout@v2
-        if: steps.changesets.outputs.published
+        if: steps.cs.outputs.published
         with:
           repository: lit/dist
           ref: empty
@@ -54,12 +58,12 @@ jobs:
           token: ${{ secrets.LIT_ROBOT_AUTOMATION_PAT }}
 
       - name: Push bundles to dist repo
-        if: steps.changesets.outputs.published
+        if: steps.cs.outputs.published
         working-directory: dist
         run: |
           # Extract the version of `lit` that was published or the empty string.
           LIT_VERSION=$(npm run --silent extract-published-lit-version <<EOF
-            ${{ steps.changesets.outputs.publishedPackages }}
+            ${{ steps.cs.outputs.publishedPackages }}
           EOF
           )
           # Don't create a bundle commit if `lit` wasn't published.


### PR DESCRIPTION
For some surprising reason, changing the `id` of the changesets step in our release workflow from `"changesets"` to *anything else* (I picked `"cs"`) fixes the problem where the step is invisible from the list of steps in the GitHub UI.

See https://github.com/changesets/action/issues/149

### Before

<img src="https://user-images.githubusercontent.com/48894/152895403-e01b9bd2-862f-4556-b378-73cd23add567.png" width="400">

### After

<img src="https://user-images.githubusercontent.com/48894/152895035-6c7d8203-7ec8-427d-ac21-895267f8e878.png" width="400">

