### PR TITLE
[ssr] Replace window proxy in global DOM shim

### DIFF
--- a/.changeset/silent-carrots-sneeze.md
+++ b/.changeset/silent-carrots-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/ssr': patch
+---
+
+Replace window proxy with reference to globalThis in global DOM shim

--- a/packages/labs/ssr/src/lib/dom-shim.ts
+++ b/packages/labs/ssr/src/lib/dom-shim.ts
@@ -187,19 +187,10 @@ export const installWindowOnGlobal = (props: {[key: string]: unknown} = {}) => {
   // Avoid installing the DOM shim if one already exists
   if (globalThis.window === undefined) {
     const window = getWindow({props});
-    // Setup window to proxy all globals added to window to the node global
-    window.window = new Proxy(window, {
-      set(
-        _target: {[key: string]: unknown},
-        p: PropertyKey,
-        value: unknown
-      ): boolean {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (window as any)[p] = (globalThis as any)[p] = value;
-        return true;
-      },
-    });
     // Copy initial window globals to node global
     Object.assign(globalThis, window);
+    // Set up global reference to window so all globals added to window are
+    // added to the node global
+    globalThis.window = globalThis as typeof globalThis & Window;
   }
 };


### PR DESCRIPTION
Addresses part of the problem surfaced by #2393.

The proxy was causing unexpected behavior when attempting to assign to `window.global` after the shim is installed. Making `globalThis.window` a reference to `globalThis` should achieve the same thing the proxy was meant to handle.