### PR TITLE
Fix PropertyValues<any> to be compatible with Map<string, string> and subtyping

### DIFF
--- a/.changeset/dull-hotels-brake.md
+++ b/.changeset/dull-hotels-brake.md
@@ -1,0 +1,6 @@
+---
+'@lit/reactive-element': patch
+'lit': patch
+---
+
+Fix breaking change in the PropertyValues type. Make PropertyValues<any> compatible with Map<string, string> and other Map types.

--- a/packages/reactive-element/src/reactive-element.ts
+++ b/packages/reactive-element/src/reactive-element.ts
@@ -218,33 +218,29 @@ type PropertyDeclarationMap = Map<PropertyKey, PropertyDeclaration>;
 
 type AttributeMap = Map<string, PropertyKey>;
 
-// This condition is here so that if the type parameter T is not specified, or
-// is `any`, the type will include `Map<PropertyKey, unknown>`. Since T is not
-// given in the uses of PropertyValues in this file, all uses here fallback to
-// meaning `Map<PropertyKey, unknown>`, but if a developer uses
-// `PropertyValues<this>` (or any other value for T) they will get a
-// strongly-typed Map type.
 /**
- * A Map of property keys to values. If the type parameter T is specified as
- * a non-any, non-unknown type, the Map will be a strongly-typed
- * PropertyValueMap that associates the map keys with their corresponding
- * property type on T.
+ * A Map of property keys to values.
+ *
+ * Takes an optional type parameter T, which when specified as a non-any,
+ * non-unknown type, will make the Map more strongly-typed, associating the map
+ * keys with their corresponding value type on T.
  *
  * Use `PropertyValues<this>` when overriding ReactiveElement.update() and
  * other lifecycle methods in order to get stronger type-checking on keys
  * and values.
  */
+// This type is conditional so that if the parameter T is not specified, or
+// is `any`, the type will include `Map<PropertyKey, unknown>`. Since T is not
+// given in the uses of PropertyValues in this file, all uses here fallback to
+// meaning `Map<PropertyKey, unknown>`, but if a developer uses
+// `PropertyValues<this>` (or any other value for T) they will get a
+// strongly-typed Map type.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type PropertyValues<T = any> = T extends object
   ? PropertyValueMap<T>
   : Map<PropertyKey, unknown>;
 
-/**
- * Map of changed properties with old values. Takes an optional generic
- * interface corresponding to the declared element properties.
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export interface PropertyValueMap<T = any> extends Map<PropertyKey, unknown> {
+interface PropertyValueMap<T> extends Map<PropertyKey, unknown> {
   get<K extends keyof T>(k: K): T[K];
   set<K extends keyof T>(key: K, value: T[K]): this;
   has<K extends keyof T>(k: K): boolean;

--- a/packages/reactive-element/src/reactive-element.ts
+++ b/packages/reactive-element/src/reactive-element.ts
@@ -244,17 +244,11 @@ export type PropertyValues<T = any> = T extends object
  * interface corresponding to the declared element properties.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export interface PropertyValueMap<T = any> extends Map<keyof T, unknown> {
+export interface PropertyValueMap<T = any> extends Map<PropertyKey, unknown> {
   get<K extends keyof T>(k: K): T[K];
   set<K extends keyof T>(key: K, value: T[K]): this;
-  forEach(
-    callbackfn: <K extends keyof T>(
-      value: T[K],
-      key: K,
-      map: Map<K, T[keyof T]>
-    ) => void,
-    thisArg?: unknown
-  ): void;
+  has<K extends keyof T>(k: K): boolean;
+  delete<K extends keyof T>(k: K): boolean;
 }
 
 export const defaultConverter: ComplexAttributeConverter = {

--- a/packages/reactive-element/src/reactive-element.ts
+++ b/packages/reactive-element/src/reactive-element.ts
@@ -218,12 +218,33 @@ type PropertyDeclarationMap = Map<PropertyKey, PropertyDeclaration>;
 
 type AttributeMap = Map<string, PropertyKey>;
 
+// This condition is here so that if the type parameter T is not specified, or
+// is `any`, the type will include `Map<PropertyKey, unknown>`. Since T is not
+// given in the uses of PropertyValues in this file, all uses here fallback to
+// meaning `Map<PropertyKey, unknown>`, but if a developer uses
+// `PropertyValues<this>` (or any other value for T) they will get a
+// strongly-typed Map type.
+/**
+ * A Map of property keys to values. If the type parameter T is specified as
+ * a non-any, non-unknown type, the Map will be a strongly-typed
+ * PropertyValueMap that associates the map keys with their corresponding
+ * property type on T.
+ *
+ * Use `PropertyValues<this>` when overriding ReactiveElement.update() and
+ * other lifecycle methods in order to get stronger type-checking on keys
+ * and values.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type PropertyValues<T = any> = T extends object
+  ? PropertyValueMap<T>
+  : Map<PropertyKey, unknown>;
+
 /**
  * Map of changed properties with old values. Takes an optional generic
  * interface corresponding to the declared element properties.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export interface PropertyValues<T = any> extends Map<keyof T, T[keyof T]> {
+export interface PropertyValueMap<T = any> extends Map<keyof T, unknown> {
   get<K extends keyof T>(k: K): T[K];
   set<K extends keyof T>(key: K, value: T[K]): this;
   forEach(

--- a/packages/reactive-element/src/test/reactive-element_test.ts
+++ b/packages/reactive-element/src/test/reactive-element_test.ts
@@ -3159,14 +3159,18 @@ suite('ReactiveElement', () => {
       foo!: number;
       override update(changedProperties: PropertyValues<A>) {
         const n: number = changedProperties.get('foo');
-        console.log(n);
+        if (n) {
+          //Suppress no-unused-vars warnings
+        }
       }
     }
     class B extends A {
       bar!: string;
       override update(changedProperties: PropertyValues<B>) {
         const s: string = changedProperties.get('bar');
-        console.log(s);
+        if (s) {
+          //Suppress no-unused-vars warnings
+        }
       }
     }
     if (A || B) {

--- a/packages/reactive-element/src/test/reactive-element_test.ts
+++ b/packages/reactive-element/src/test/reactive-element_test.ts
@@ -3100,7 +3100,7 @@ suite('ReactiveElement', () => {
           changedProperties.set('foo', 2);
 
           // This should type-check without a cast:
-          const propNames: Array<keyof this> = ['foo'];
+          const propNames: Array<keyof E> = ['foo'];
           const y = changedProperties.get(propNames[0]);
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           changedProperties.set(propNames[0], 1 as any);
@@ -3129,5 +3129,26 @@ suite('ReactiveElement', () => {
         // Suppress no-unused-vars warning on E
       }
     });
+  });
+
+  test('Maps can be used for changedProperties', () => {
+    // This test only checks compile-type behavior. There are no runtime
+    // checks.
+    class A extends ReactiveElement {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      override update(_changedProperties: Map<string, any>) {}
+    }
+    class B extends ReactiveElement {
+      override update(_changedProperties: Map<string, unknown>) {}
+    }
+    class C extends ReactiveElement {
+      override update(_changedProperties: Map<string | number, unknown>) {}
+    }
+    class D extends ReactiveElement {
+      override update(_changedProperties: Map<string, string>) {}
+    }
+    if (A || B || C || D) {
+      // Suppress no-unused-vars warnings
+    }
   });
 });

--- a/packages/reactive-element/src/test/reactive-element_test.ts
+++ b/packages/reactive-element/src/test/reactive-element_test.ts
@@ -3151,4 +3151,26 @@ suite('ReactiveElement', () => {
       // Suppress no-unused-vars warnings
     }
   });
+
+  test('PropertyValues<T> works with subtyping', () => {
+    // This test only checks compile-type behavior. There are no runtime
+    // checks.
+    class A extends ReactiveElement {
+      foo!: number;
+      override update(changedProperties: PropertyValues<A>) {
+        const n: number = changedProperties.get('foo');
+        console.log(n);
+      }
+    }
+    class B extends A {
+      bar!: string;
+      override update(changedProperties: PropertyValues<B>) {
+        const s: string = changedProperties.get('bar');
+        console.log(s);
+      }
+    }
+    if (A || B) {
+      // Suppress no-unused-vars warnings
+    }
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/lit/lit/issues/2513

This still preserves the new behavior of strongly-typed Maps when the type parameter is specified, so there still could be some breaks for cases where people use `PropertyValues<this>` but then access keys that are not in the type. These _should_ be invalid uses that we want to catch, but we need to be on the lookout for unexpected breaks or ones that aren't easily fixable.