### PR TITLE
`working-directory` only works for steps with `run`. Use `with.cwd` instead for `changesets/action`.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,6 +45,8 @@ jobs:
         id: cs
         uses: changesets/action@v1
         with:
+          # The `working-directory` option is only available for steps that use
+          # `run`. This `cwd` option is the same, but specific to this action.
           cwd: lit
           version: npm run version
           publish: npm run release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,7 +38,6 @@ jobs:
         run: rm -rf node_modules/@changesets/*/node_modules/prettier
 
       - name: Create Release Pull Request or Publish to npm
-        working-directory: lit
         # The id of this step must not be "changesets", or else the step will be invisible
         # in the list of steps from the GitHub UI when the action runs (though it will still
         # run, and its output will appear in the raw logs). Unknown why this is the case,
@@ -46,6 +45,7 @@ jobs:
         id: cs
         uses: changesets/action@v1
         with:
+          cwd: lit
           version: npm run version
           publish: npm run release
         env:


### PR DESCRIPTION
Apparently, `working-directory` is only applicable to jobs that use `run` and not those that specify an action with `uses`. Fortunately, changesets/action supports [a `cwd` input](https://github.com/changesets/action#inputs) for the same purpose.

Here's where `working-directory` is mentioned in the docs:
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_iddefaultsrun