### PR TITLE
[starter-kits] Add a link to the starter templates so users will know where they should file issues.

### DIFF
--- a/.changeset/shy-grapes-stare.md
+++ b/.changeset/shy-grapes-stare.md
@@ -1,0 +1,6 @@
+---
+'@lit/lit-starter-js': patch
+'@lit/lit-starter-ts': patch
+---
+
+Update the README to indicate that issues and PRs should be filed on the main Lit repo.

--- a/packages/lit-starter-js/README.md
+++ b/packages/lit-starter-js/README.md
@@ -2,6 +2,10 @@
 
 This project includes a sample component using LitElement with JavaScript.
 
+This template is generated from the `lit-starter-js` package in [the main Lit
+repo](https://github.com/lit/lit). Issues and PRs for this template should be
+filed in that repo.
+
 ## Setup
 
 Install dependencies:

--- a/packages/lit-starter-ts/README.md
+++ b/packages/lit-starter-ts/README.md
@@ -2,6 +2,10 @@
 
 This project includes a sample component using LitElement with TypeScript.
 
+This template is generated from the `lit-starter-ts` package in [the main Lit
+repo](https://github.com/lit/lit). Issues and PRs for this template should be
+filed in that repo.
+
 ## Setup
 
 Install dependencies:


### PR DESCRIPTION
I'm going to transfer all of the issues in the starter kit repos to this one and then disable issues. These links should help people find the original repo so they know where to file issues if they need to.

Part of #2536.