### PR TITLE
The bundle push step no longer runs in the `lit` repo, so this script needs to be called directly.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -85,13 +85,13 @@ jobs:
         working-directory: dist
         run: |
           # Extract the version of `lit` that was published or the empty string.
-          LIT_VERSION=$(npm run --silent extract-published-lit-version <<EOF
+          LIT_VERSION=$(node ../lit/scripts/extract-published-lit-version.js <<EOF
             ${{ steps.cs.outputs.publishedPackages }}
           EOF
           )
           # Don't create a bundle commit if `lit` wasn't published.
           if [[ -z "$LIT_VERSION" ]]; then
-            exit
+            exit 0
           fi
           # Checkout the empty root commit (with tag `empty`).
           git checkout --detach empty

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "changeset": "changeset",
     "version": "npm run changeset version && npm run update-version-vars",
     "update-version-vars": "node scripts/update-version-variables.js",
-    "extract-published-lit-version": "node scripts/extract-published-lit-version.js",
     "release": "npm run bootstrap && npm run build && npm run changeset publish"
   },
   "devDependencies": {


### PR DESCRIPTION
This also removes the `extract-published-lit-version` from the repo's npm scripts and adds an explicit exit code to the `exit`.