### PR TITLE
[@lit-labs/eleventy-plugin-lit] Temporary fix for ModuleLoader concurrency issue

### DIFF
--- a/.changeset/few-books-exist.md
+++ b/.changeset/few-books-exist.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/eleventy-plugin-lit': patch
+---
+
+Fix issue related to "request for <module> is not yet fulfilled" errors when loading multiple component modules.

--- a/packages/labs/eleventy-plugin-lit/package-lock.json
+++ b/packages/labs/eleventy-plugin-lit/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@lit-labs/eleventy-plugin-lit",
-	"version": "0.0.0",
+	"version": "0.1.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@lit-labs/eleventy-plugin-lit",
-			"version": "0.0.0",
+			"version": "0.1.0",
 			"license": "BSD-3-Clause",
 			"devDependencies": {
 				"@11ty/eleventy": "^1.0.0",
@@ -15,6 +15,9 @@
 				"rimraf": "^3.0.2",
 				"typescript": "^4.1.3",
 				"uvu": "^0.5.3"
+			},
+			"engines": {
+				"node": ">=12.16.0"
 			}
 		},
 		"node_modules/@11ty/dependency-tree": {

--- a/packages/labs/eleventy-plugin-lit/src/index.ts
+++ b/packages/labs/eleventy-plugin-lit/src/index.ts
@@ -82,11 +82,11 @@ ${reset}`
       const {ModuleLoader} = await import('@lit-labs/ssr/lib/module-loader.js');
       const window = getWindow({includeJSBuiltIns: true});
       const loader = new ModuleLoader({global: window});
-      await Promise.all(
-        resolvedComponentModules.map((module) =>
-          loader.importModule(module, renderModulePath)
-        )
-      );
+      // TODO(aomarks) Replace with concurrent Promise.all version once
+      // https://github.com/lit/lit/issues/2549 has been addressed.
+      for (const module of resolvedComponentModules) {
+        await loader.importModule(module, renderModulePath);
+      }
       contextifiedRender = (
         await loader.importModule(
           '@lit-labs/ssr/lib/render-lit-html.js',

--- a/packages/labs/ssr/package-lock.json
+++ b/packages/labs/ssr/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@lit-labs/ssr",
-	"version": "2.0.1",
+	"version": "2.0.3",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@lit-labs/ssr",
-			"version": "2.0.1",
+			"version": "2.0.3",
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"@types/node": "^16.0.0",


### PR DESCRIPTION
There is some underlying issue in our ModuleLoader class whereby
loading multiple modules concurrently can cause errors like:

```
"request for '@lit/reactive-element' is not yet fulfilled
```

There is likely some kind of race condition there, but I haven't
yet identified it. Tracking at https://github.com/lit/lit/issues/2549.

To address this problem for the Eleventy plugin in the short term,
this temporarily makes module loading serial instead of concurrent.