### PR TITLE
[localize-tools] Fix xliff note element ordering

### DIFF
--- a/.changeset/curly-points-flash.md
+++ b/.changeset/curly-points-flash.md
@@ -1,0 +1,5 @@
+---
+'@lit/localize-tools': patch
+---
+
+Reorder xliff `<note>` elements to follow `<target>` elements to be OASIS-compliant

--- a/packages/localize-tools/src/formatters/xliff.ts
+++ b/packages/localize-tools/src/formatters/xliff.ts
@@ -240,14 +240,6 @@ export class XliffFormatter implements Formatter {
       indent(transUnit, 1);
       transUnit.setAttribute('id', name);
 
-      if (desc) {
-        // https://docs.oasis-open.org/xliff/v1.2/os/xliff-core.html#note
-        const note = doc.createElement('note');
-        note.appendChild(doc.createTextNode(desc));
-        transUnit.appendChild(note);
-        indent(transUnit, 1);
-      }
-
       // https://docs.oasis-open.org/xliff/v1.2/os/xliff-core.html#source
       const source = doc.createElement('source');
       for (const child of this.encodeContents(doc, sourceContents)) {
@@ -265,6 +257,15 @@ export class XliffFormatter implements Formatter {
         indent(transUnit, 1);
         transUnit.appendChild(target);
       }
+
+      if (desc) {
+        // https://docs.oasis-open.org/xliff/v1.2/os/xliff-core.html#note
+        const note = doc.createElement('note');
+        note.appendChild(doc.createTextNode(desc));
+        indent(transUnit, 1);
+        transUnit.appendChild(note);
+      }
+
       indent(transUnit);
       indent(body);
     }

--- a/packages/localize-tools/testdata/extract-xliff-fresh-js/goldens/data/xliff/es-419.xlf
+++ b/packages/localize-tools/testdata/extract-xliff-fresh-js/goldens/data/xliff/es-419.xlf
@@ -3,8 +3,8 @@
 <file target-language="es-419" source-language="en" original="lit-localize-inputs" datatype="plaintext">
 <body>
 <trans-unit id="he7b474847636149b">
-  <note>Friendly greeting</note>
   <source>Hello <ph id="0">&lt;b>${name}</ph>!<ph id="1">&lt;/b></ph></source>
+  <note>Friendly greeting</note>
 </trans-unit>
 </body>
 </file>

--- a/packages/localize-tools/testdata/extract-xliff-fresh-js/goldens/data/xliff/zh_CN.xlf
+++ b/packages/localize-tools/testdata/extract-xliff-fresh-js/goldens/data/xliff/zh_CN.xlf
@@ -3,8 +3,8 @@
 <file target-language="zh_CN" source-language="en" original="lit-localize-inputs" datatype="plaintext">
 <body>
 <trans-unit id="he7b474847636149b">
-  <note>Friendly greeting</note>
   <source>Hello <ph id="0">&lt;b>${name}</ph>!<ph id="1">&lt;/b></ph></source>
+  <note>Friendly greeting</note>
 </trans-unit>
 </body>
 </file>

--- a/packages/localize-tools/testdata/extract-xliff-fresh-ph/goldens/data/xliff/es-419.xlf
+++ b/packages/localize-tools/testdata/extract-xliff-fresh-ph/goldens/data/xliff/es-419.xlf
@@ -6,12 +6,12 @@
   <source>&lt;Hello<ph id="0">&lt;b></ph>&lt;World &amp; Friends><ph id="1">&lt;/b></ph>!></source>
 </trans-unit>
 <trans-unit id="he7b474847636149b">
-  <note>Description of Hello $(name)</note>
   <source>Hello <ph id="0">&lt;b>${name}</ph>!<ph id="1">&lt;/b></ph></source>
+  <note>Description of Hello $(name)</note>
 </trans-unit>
 <trans-unit id="s8c0ec8d1fb9e6e32">
-  <note>Description of Hello World</note>
   <source>Hello World!</source>
+  <note>Description of Hello World</note>
 </trans-unit>
 </body>
 </file>

--- a/packages/localize-tools/testdata/extract-xliff-fresh-ph/goldens/data/xliff/zh_CN.xlf
+++ b/packages/localize-tools/testdata/extract-xliff-fresh-ph/goldens/data/xliff/zh_CN.xlf
@@ -6,12 +6,12 @@
   <source>&lt;Hello<ph id="0">&lt;b></ph>&lt;World &amp; Friends><ph id="1">&lt;/b></ph>!></source>
 </trans-unit>
 <trans-unit id="he7b474847636149b">
-  <note>Description of Hello $(name)</note>
   <source>Hello <ph id="0">&lt;b>${name}</ph>!<ph id="1">&lt;/b></ph></source>
+  <note>Description of Hello $(name)</note>
 </trans-unit>
 <trans-unit id="s8c0ec8d1fb9e6e32">
-  <note>Description of Hello World</note>
   <source>Hello World!</source>
+  <note>Description of Hello World</note>
 </trans-unit>
 </body>
 </file>

--- a/packages/localize-tools/testdata/extract-xliff-fresh/goldens/data/xliff/es-419.xlf
+++ b/packages/localize-tools/testdata/extract-xliff-fresh/goldens/data/xliff/es-419.xlf
@@ -6,12 +6,12 @@
   <source>&lt;Hello<x id="0" equiv-text="&lt;b>"/>&lt;World &amp; Friends><x id="1" equiv-text="&lt;/b>"/>!></source>
 </trans-unit>
 <trans-unit id="he7b474847636149b">
-  <note>Description of Hello $(name)</note>
   <source>Hello <x id="0" equiv-text="&lt;b>${name}"/>!<x id="1" equiv-text="&lt;/b>"/></source>
+  <note>Description of Hello $(name)</note>
 </trans-unit>
 <trans-unit id="s8c0ec8d1fb9e6e32">
-  <note>Description of Hello World</note>
   <source>Hello World!</source>
+  <note>Description of Hello World</note>
 </trans-unit>
 </body>
 </file>

--- a/packages/localize-tools/testdata/extract-xliff-fresh/goldens/data/xliff/zh_CN.xlf
+++ b/packages/localize-tools/testdata/extract-xliff-fresh/goldens/data/xliff/zh_CN.xlf
@@ -6,12 +6,12 @@
   <source>&lt;Hello<x id="0" equiv-text="&lt;b>"/>&lt;World &amp; Friends><x id="1" equiv-text="&lt;/b>"/>!></source>
 </trans-unit>
 <trans-unit id="he7b474847636149b">
-  <note>Description of Hello $(name)</note>
   <source>Hello <x id="0" equiv-text="&lt;b>${name}"/>!<x id="1" equiv-text="&lt;/b>"/></source>
+  <note>Description of Hello $(name)</note>
 </trans-unit>
 <trans-unit id="s8c0ec8d1fb9e6e32">
-  <note>Description of Hello World</note>
   <source>Hello World!</source>
+  <note>Description of Hello World</note>
 </trans-unit>
 </body>
 </file>

--- a/packages/localize-tools/testdata/extract-xliff-merge/goldens/xliff/es-419.xlf
+++ b/packages/localize-tools/testdata/extract-xliff-merge/goldens/xliff/es-419.xlf
@@ -3,13 +3,13 @@
 <file target-language="es-419" source-language="en" original="lit-localize-inputs" datatype="plaintext">
 <body>
 <trans-unit id="se86f4e822256d113">
-  <note>Description of not translated</note>
   <source>I am not translated</source>
+  <note>Description of not translated</note>
 </trans-unit>
 <trans-unit id="s677cb50a446c46f4">
-  <note>Description of translated</note>
   <source>I am translated</source>
   <target>Estoy traducido</target>
+  <note>Description of translated</note>
 </trans-unit>
 </body>
 </file>


### PR DESCRIPTION
Fixes #2560 

- Reorder xliff generation so `<note>` elements to follow `<source>` and `<target>` elements.
- Update test goldens to account for reordering