### PR TITLE
Extract the starter kit push steps into a reusable workflow.

### DIFF
--- a/.github/workflows/starter-kits.yaml
+++ b/.github/workflows/starter-kits.yaml
@@ -23,60 +23,22 @@ jobs:
         with:
           path: lit
 
-      - name: Checkout lit-element-starter-ts repo
-        uses: actions/checkout@v2
+      - name: Sync lit-element-starter-ts repo
+        uses: ./.github/workflows/sync-package.yaml
         with:
-          repository: lit/lit-element-starter-ts
-          ref: release-automation-test-main
-          path: lit-element-starter-ts
-          token: ${{ secrets.LIT_ROBOT_AUTOMATION_PAT }}
+          source-repo-path: lit
+          source-package-path: packages/lit-starter-ts
+          destination-checkout-path: lit-element-starter-ts
+          destination-repo: lit/lit-element-starter-ts
+          destination-branch: release-automation-test-main
+          destination-token: ${{ secrets.LIT_ROBOT_AUTOMATION_PAT }}
 
-      - name: Push changes to lit-element-starter-ts repo
-        working-directory: lit-element-starter-ts
-        run: |
-          # Add the local Lit repo as a remote and fetch the currently checked
-          # out commit.
-          git remote add lit ../lit
-          git fetch --no-tags lit HEAD:lit-head
-          IMPORT_REF=$(git rev-parse lit-head)
-          # Read the contents of the TS starter kit directory from the imported
-          # commit into the index root, ignoring any conflicts (`--reset`) and
-          # updating the work tree too (`-u`).
-          git read-tree --reset -u "$IMPORT_REF":packages/lit-starter-ts
-          # If there are no changes, skip the rest of this step.
-          if git diff --quiet --exit-code; then
-            exit 0
-          fi
-          # Stage the changes, commit, and push.
-          git add .
-          git commit -m "Import upstream changes (${IMPORT_REF})"
-          git push origin release-automation-test-main
-
-      - name: Checkout lit-element-starter-js repo
-        uses: actions/checkout@v2
+      - name: Sync lit-element-starter-js repo
+        uses: ./.github/workflows/sync-package.yaml
         with:
-          repository: lit/lit-element-starter-js
-          ref: release-automation-test-main
-          path: lit-element-starter-js
-          token: ${{ secrets.LIT_ROBOT_AUTOMATION_PAT }}
-
-      - name: Push changes to lit-element-starter-js repo
-        working-directory: lit-element-starter-js
-        run: |
-          # Add the local Lit repo as a remote and fetch the currently checked
-          # out commit.
-          git remote add lit ../lit
-          git fetch --no-tags lit HEAD:lit-head
-          IMPORT_REF=$(git rev-parse lit-head)
-          # Read the contents of the JS starter kit directory from the imported
-          # commit into the index root, ignoring any conflicts (`--reset`) and
-          # updating the work tree too (`-u`).
-          git read-tree --reset -u "$IMPORT_REF":packages/lit-starter-js
-          # If there are no changes, skip the rest of this step.
-          if git diff --quiet --exit-code; then
-            exit 0
-          fi
-          # Stage the changes, commit, and push.
-          git add .
-          git commit -m "Import upstream changes (${IMPORT_REF})"
-          git push origin release-automation-test-main
+          source-repo-path: lit
+          source-package-path: packages/lit-starter-js
+          destination-checkout-path: lit-element-starter-js
+          destination-repo: lit/lit-element-starter-js
+          destination-branch: release-automation-test-main
+          destination-token: ${{ secrets.LIT_ROBOT_AUTOMATION_PAT }}

--- a/.github/workflows/sync-package.yaml
+++ b/.github/workflows/sync-package.yaml
@@ -1,0 +1,74 @@
+name: Sync Package
+
+on:
+  workflow_call:
+    inputs:
+      source-repo-path:
+        required: true
+        type: string
+        description: >-
+          The path to the source repo, relative to $GITHUB_WORKSPACE. The source
+          repo should already exist and have the desired ref to sync from
+          checked out.
+      source-package-path:
+        required: true
+        type: string
+        description: >-
+          The path to the source directory to sync from, relative to the source
+          repo root.
+      destination-repo:
+        required: true
+        type: string
+        description: >-
+          The name of the destination repo.
+      destination-checkout-path:
+        required: true
+        type: string
+        description: >-
+          The path where the destination repo should be checked out, relative to
+          $GITHUB_WORKSPACE.
+      destination-branch:
+        required: true
+        type: string
+        description: >-
+          The branch in the destination repo that changes should be pushed to.
+    secrets:
+      destination-token:
+        required: true
+        type: string
+        description: >-
+          The access token used to checkout and push to the destination repo.
+
+jobs:
+  sync-package:
+    name: Sync ${{ inputs.destination-repo }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout ${{ inputs.destination-repo }}
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ inputs.destination-repo }}
+          ref: ${{ inputs.destination-branch }}
+          path: ${{ inputs.destination-checkout-path }}
+          token: ${{ secrets.destination-token }}
+
+      - name: Push to ${{ inputs.destination-repo }}
+        working-directory: ${{ inputs.destination-checkout-path }}
+        run: |
+          # Add the local Lit repo as a remote and fetch the currently checked
+          # out commit.
+          git remote add source-repo "${GITHUB_WORKSPACE}/${{ inputs.source-repo-path }}"
+          git fetch --no-tags source-repo HEAD
+          IMPORT_REF=$(git rev-parse FETCH_HEAD)
+          # Read the contents of the TS starter kit directory from the imported
+          # commit into the index root, ignoring any conflicts (`--reset`) and
+          # updating the work tree too (`-u`).
+          git read-tree --reset -u "${IMPORT_REF}:${{ inputs.source-package-path }}"
+          # If there are no changes, skip the rest of this step.
+          if git diff --quiet --exit-code; then
+            exit 0
+          fi
+          # Stage the changes, commit, and push.
+          git add .
+          git commit -m "Sync upstream changes (${IMPORT_REF})"
+          git push origin ${{ inputs.destination-branch }}

--- a/.github/workflows/sync-package.yaml
+++ b/.github/workflows/sync-package.yaml
@@ -57,18 +57,25 @@ jobs:
         run: |
           # Add the local Lit repo as a remote and fetch the currently checked
           # out commit.
+          echo "Fetching from ${{ inputs.source-repo-path }} ..."
           git remote add source-repo "${GITHUB_WORKSPACE}/${{ inputs.source-repo-path }}"
           git fetch --no-tags source-repo HEAD
           IMPORT_REF=$(git rev-parse FETCH_HEAD)
+          echo "Fetched ref: ${IMPORT_REF}"
           # Read the contents of the TS starter kit directory from the imported
           # commit into the index root, ignoring any conflicts (`--reset`) and
           # updating the work tree too (`-u`).
+          echo "Reading source directory ${{ inputs.source-package-path }} into ${{ inputs.destination-repo }} ..."
           git read-tree --reset -u "${IMPORT_REF}:${{ inputs.source-package-path }}"
           # If there are no changes, skip the rest of this step.
           if git diff --quiet --exit-code; then
+            echo "There are no changes."
             exit 0
           fi
           # Stage the changes, commit, and push.
+          echo "Committing changes..."
           git add .
           git commit -m "Sync upstream changes (${IMPORT_REF})"
+          echo "Pushing to ${{ inputs.destination-branch }} ..."
           git push origin ${{ inputs.destination-branch }}
+          echo "Done."


### PR DESCRIPTION
Other than a few paths and names, the scripts for exporting the starter kits are the same. This PR converts them to a single reusable workflow that's called from the main starter-kit-syncing workflow.