### PR TITLE
[meta] Switch NPM publish token from justinfagnani to lit-robot

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,7 +65,7 @@ jobs:
         env:
           HUSKY: 0
           GITHUB_TOKEN: ${{ secrets.LIT_ROBOT_AUTOMATION_PAT }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.LIT_ROBOT_NPM_PUBLISH_ACCESS_TOKEN }}
 
       - name: Checkout dist repo
         uses: actions/checkout@v2


### PR DESCRIPTION
Until now we have been using an NPM access token from https://www.npmjs.com/~justinfagnani. After this change we will use an access token for https://www.npmjs.com/~lit-robot instead.

Fixes https://github.com/lit/lit/issues/2504