### PR TITLE
Remove saucelabs tests

### DIFF
--- a/.github/workflows/sauce-ie11.yaml
+++ b/.github/workflows/sauce-ie11.yaml
@@ -22,25 +22,25 @@ jobs:
           cache: 'npm'
           cache-dependency-path: '**/package-lock.json'
 
-      - name: Install playwright deps
-        run: npx playwright install-deps
+      # - name: Install playwright deps
+      #   run: npx playwright install-deps
 
-      - name: NPM install
-        run: npm ci
+      # - name: NPM install
+      #   run: npm ci
 
-      - name: Lerna bootstrap
-        run: npm run bootstrap
+      # - name: Lerna bootstrap
+      #   run: npm run bootstrap
 
-      - name: Lint
-        run: npm run lint
+      # - name: Lint
+      #   run: npm run lint
 
-      - name: Build
-        run: npm run build
+      # - name: Build
+      #   run: npm run build
 
-      - name: Test
-        env:
-          SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
-          SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
-          BROWSERS: preset:sauce-ie11
-        # Retry once automatically.
-        run: npm run test || npm run test
+      # - name: Test
+      #   env:
+      #     SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
+      #     SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
+      #     BROWSERS: preset:sauce-ie11
+      #   # Retry once automatically.
+      #   run: npm run test || npm run test

--- a/.github/workflows/sauce.yaml
+++ b/.github/workflows/sauce.yaml
@@ -22,24 +22,24 @@ jobs:
           cache: 'npm'
           cache-dependency-path: '**/package-lock.json'
 
-      - name: Install playwright deps
-        run: npx playwright install-deps
+      # - name: Install playwright deps
+      #   run: npx playwright install-deps
 
-      - name: NPM install
-        run: npm ci
+      # - name: NPM install
+      #   run: npm ci
 
-      - name: Lerna bootstrap
-        run: npm run bootstrap
+      # - name: Lerna bootstrap
+      #   run: npm run bootstrap
 
-      - name: Lint
-        run: npm run lint
+      # - name: Lint
+      #   run: npm run lint
 
-      - name: Build
-        run: npm run build
+      # - name: Build
+      #   run: npm run build
 
-      - name: Test
-        env:
-          SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
-          SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
-          BROWSERS: preset:sauce
-        run: npm run test
+      # - name: Test
+      #   env:
+      #     SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
+      #     SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
+      #     BROWSERS: preset:sauce
+      #   run: npm run test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,3 +67,33 @@ jobs:
           BROWSERS: preset:local
           CONCURRENT_BROWSERS: 3
         run: npm run test
+
+  tests-local-windows:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
+          cache: 'npm'
+          cache-dependency-path: '**/package-lock.json'
+
+      - name: Install playwright deps
+        run: npx playwright install-deps
+
+      - name: NPM install
+        run: npm ci
+
+      - name: Lerna bootstrap
+        run: npm run bootstrap
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        env:
+          BROWSERS: preset:local
+          CONCURRENT_BROWSERS: 3
+        run: npm run test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
       - run: npm ci
       - run: npm run lint
 
-  tests-local:
+  tests-local-ubuntu:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,10 @@ name: Tests
 
 on: [push, pull_request]
 
+env:
+  BROWSERS: preset:sauce
+  CONCURRENT_BROWSERS: 3
+
 jobs:
   changeset:
     runs-on: ubuntu-latest
@@ -38,7 +42,7 @@ jobs:
       - run: npm ci
       - run: npm run lint
 
-  tests-local-ubuntu:
+  tests-ubuntu:
     runs-on: ubuntu-latest
 
     steps:
@@ -63,12 +67,9 @@ jobs:
         run: npm run build
 
       - name: Test
-        env:
-          BROWSERS: preset:local
-          CONCURRENT_BROWSERS: 3
         run: npm run test
 
-  tests-local-windows:
+  tests-windows:
     runs-on: windows-latest
 
     steps:
@@ -93,7 +94,31 @@ jobs:
         run: npm run build
 
       - name: Test
-        env:
-          BROWSERS: preset:local
-          CONCURRENT_BROWSERS: 3
+        run: npm run test
+
+  tests-macos:
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
+          cache: 'npm'
+          cache-dependency-path: '**/package-lock.json'
+
+      - name: Install playwright deps
+        run: npx playwright install-deps
+
+      - name: NPM install
+        run: npm ci
+
+      - name: Lerna bootstrap
+        run: npm run bootstrap
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
         run: npm run test

--- a/packages/tests/web-test-runner.config.js
+++ b/packages/tests/web-test-runner.config.js
@@ -47,7 +47,14 @@ const browserPresets = {
     'sauce:macOS 10.15/Safari@latest',
     // 'sauce:Windows 10/MicrosoftEdge@18', // needs globalThis polyfill
   ],
-  'sauce-ie11': ['sauce:Windows 7/Internet Explorer@11'],
+  windows: [
+    // 'sauce:Windows 10/Firefox@78', // Current ESR. See: https://wiki.mozilla.org/Release_Management/Calendar
+    // 'sauce:Windows 10/Chrome@latest-3',
+    // 'sauce:macOS 10.15/Safari@latest',
+    'sauce:Windows 10/MicrosoftEdge@18', // needs globalThis polyfill
+    'sauce:Windows 7/Internet Explorer@11',
+  ],
+  // 'sauce-ie11': ['sauce:Windows 7/Internet Explorer@11'],
 };
 
 let sauceLauncher;

--- a/packages/tests/web-test-runner.config.js
+++ b/packages/tests/web-test-runner.config.js
@@ -57,25 +57,21 @@ const browserPresets = {
   // 'sauce-ie11': ['sauce:Windows 7/Internet Explorer@11'],
 };
 
-let sauceLauncher;
+// let sauceLauncher;
 
-function makeSauceLauncherOnce() {
-  if (!sauceLauncher) {
-    const user = (process.env.SAUCE_USERNAME || '').trim();
-    const key = (process.env.SAUCE_ACCESS_KEY || '').trim();
-    if (!user || !key) {
-      throw new Error(
-        'To test on Sauce, set the SAUCE_USERNAME' +
-          ' and SAUCE_ACCESS_KEY environment variables.'
-      );
-    }
-    sauceLauncher = createSauceLabsLauncher({
-      user,
-      key,
-    });
-  }
-  return sauceLauncher;
-}
+// const user = (process.env.SAUCE_USERNAME || '').trim();
+// const key = (process.env.SAUCE_ACCESS_KEY || '').trim();
+// if (!user || !key) {
+//   console.warn(
+//     'To test on Sauce, set the SAUCE_USERNAME' +
+//       ' and SAUCE_ACCESS_KEY environment variables.'
+//   );
+// } else {
+//   sauceLauncher = createSauceLabsLauncher({
+//     user,
+//     key,
+//   });
+// }
 
 /**
  * Recognized formats:
@@ -110,41 +106,41 @@ function parseBrowser(browser) {
     return entries.map(parseBrowser).flat();
   }
 
-  if (browser.startsWith('sauce:')) {
-    // Note this is the syntax used by WCT. Might as well use the same one.
-    const match = browser.match(/^sauce:(.+)\/(.+)@(.+)$/);
-    if (!match) {
-      throw new Error(`
+//   if (browser.startsWith('sauce:')) {
+//     // Note this is the syntax used by WCT. Might as well use the same one.
+//     const match = browser.match(/^sauce:(.+)\/(.+)@(.+)$/);
+//     if (!match) {
+//       throw new Error(`
 
-Invalid Sauce browser string.
-Expected format "sauce:os/browser@version".
-Provided string was "${browser}".
+// Invalid Sauce browser string.
+// Expected format "sauce:os/browser@version".
+// Provided string was "${browser}".
 
-Valid examples:
+// Valid examples:
 
-  sauce:macOS 10.15/safari@13
-  sauce:Windows 10/MicrosoftEdge@18
-  sauce:Windows 7/internet explorer@11
-  sauce:Linux/chrome@latest-3
-  sauce:Linux/firefox@78
+//   sauce:macOS 10.15/safari@13
+//   sauce:Windows 10/MicrosoftEdge@18
+//   sauce:Windows 7/internet explorer@11
+//   sauce:Linux/chrome@latest-3
+//   sauce:Linux/firefox@78
 
-See https://wiki.saucelabs.com/display/DOCS/Platform+Configurator for all options.`);
-    }
-    const [, platformName, browserName, browserVersion] = match;
-    return [
-      makeSauceLauncherOnce()({
-        browserName,
-        browserVersion,
-        platformName,
-        'sauce:options': {
-          name: `lit tests [${mode}]`,
-          build: `${process.env.GITHUB_REF ?? 'local'} build ${
-            process.env.GITHUB_RUN_NUMBER ?? ''
-          }`,
-        },
-      }),
-    ];
-  }
+// See https://wiki.saucelabs.com/display/DOCS/Platform+Configurator for all options.`);
+//     }
+//     const [, platformName, browserName, browserVersion] = match;
+//     return [
+//       makeSauceLauncherOnce()({
+//         browserName,
+//         browserVersion,
+//         platformName,
+//         'sauce:options': {
+//           name: `lit tests [${mode}]`,
+//           build: `${process.env.GITHUB_REF ?? 'local'} build ${
+//             process.env.GITHUB_RUN_NUMBER ?? ''
+//           }`,
+//         },
+//       }),
+//     ];
+//   }
 
   const config = {
     product: browser,


### PR DESCRIPTION
- experimenting with removing sauce labs for our tests
- github actions have matured into full featured CI/CD
- AFAICT we currently create a new saucelabs proxy per package, we are rate-limited after a certain number of saucelab proxies are created

Solution:
- we are testing per browser per os
- move over to custom github actions
- then refine WTR and other testing capabilities to improve testing speed