### PR TITLE
[meta] Fix changeset action failing on release PR

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
       - run: git checkout main
       - run: git checkout ${{ github.sha }}
       - run: npm ci
-      # Enforce that all PR's that change packages need changesets. Changes
+      # Enforce that all PRs that change packages need changesets. Changes
       # without changesets result in this job failing.
       - run: npm run changeset status -- --since=main
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,9 @@ on: [push, pull_request]
 jobs:
   changeset:
     runs-on: ubuntu-latest
+    # When lit-robot creates a release PR, skip this check as it will always
+    # fail.
+    if: ${{ github.actor != 'lit-robot' }}
 
     steps:
       - uses: actions/checkout@v2
@@ -21,6 +24,8 @@ jobs:
       - run: git checkout main
       - run: git checkout ${{ github.sha }}
       - run: npm ci
+      # Enforce that all PR's that change packages need changesets. Changes
+      # without changesets result in this job failing.
       - run: npm run changeset status -- --since=main
 
   lint:


### PR DESCRIPTION
Fixes https://github.com/lit/lit/issues/2544

### Context

This check was added in https://github.com/lit/lit/pull/2061 and ensures that changes to packages require a changeset file. See docs on the command: https://github.com/changesets/changesets/blob/main/packages/cli/README.md#status

However in the case of an automated release PR, we create a situation which fails this check. This is because the release PR deletes all changeset files, and also modifies packages by bumping version numbers and updating the CHANGELOG.md files (reference PR: https://github.com/lit/lit/pull/2565/files).

Thus this check will (and does) always fail in a release PR.

### Fix

Skip this check if `lit-robot` authored the PR.

### Alternative considered

We could create an empty changeset file as part of the automated release PR. I opted for this route as I think it makes sense for the automated release PR to not have a changeset file, but can be convinced otherwise.