### PR TITLE
Fetch all history for the starter kit repos during checkout in the sync workflow.

### DIFF
--- a/.github/workflows/starter-kits.yaml
+++ b/.github/workflows/starter-kits.yaml
@@ -30,6 +30,7 @@ jobs:
           ref: release-automation-test-main
           path: lit-element-starter-ts
           token: ${{ secrets.LIT_ROBOT_AUTOMATION_PAT }}
+          depth: 0
 
       - name: Push changes to lit-element-starter-ts repo
         working-directory: lit-element-starter-ts
@@ -58,6 +59,7 @@ jobs:
           ref: release-automation-test-main
           path: lit-element-starter-js
           token: ${{ secrets.LIT_ROBOT_AUTOMATION_PAT }}
+          depth: 0
 
       - name: Push changes to lit-element-starter-js repo
         working-directory: lit-element-starter-js

--- a/.github/workflows/starter-kits.yaml
+++ b/.github/workflows/starter-kits.yaml
@@ -31,7 +31,7 @@ jobs:
           path: lit-element-starter-ts
           token: ${{ secrets.LIT_ROBOT_AUTOMATION_PAT }}
           # Fetch all history, otherwise we can't push to this repo.
-          depth: 0
+          fetch-depth: 0
 
       - name: Push changes to lit-element-starter-ts repo
         working-directory: lit-element-starter-ts
@@ -66,7 +66,7 @@ jobs:
           path: lit-element-starter-js
           token: ${{ secrets.LIT_ROBOT_AUTOMATION_PAT }}
           # Fetch all history, otherwise we can't push to this repo.
-          depth: 0
+          fetch-depth: 0
 
       - name: Push changes to lit-element-starter-js repo
         working-directory: lit-element-starter-js

--- a/.github/workflows/starter-kits.yaml
+++ b/.github/workflows/starter-kits.yaml
@@ -30,6 +30,7 @@ jobs:
           ref: release-automation-test-main
           path: lit-element-starter-ts
           token: ${{ secrets.LIT_ROBOT_AUTOMATION_PAT }}
+          # Fetch all history, otherwise we can't push to this repo.
           depth: 0
 
       - name: Push changes to lit-element-starter-ts repo
@@ -64,6 +65,7 @@ jobs:
           ref: release-automation-test-main
           path: lit-element-starter-js
           token: ${{ secrets.LIT_ROBOT_AUTOMATION_PAT }}
+          # Fetch all history, otherwise we can't push to this repo.
           depth: 0
 
       - name: Push changes to lit-element-starter-js repo

--- a/.github/workflows/starter-kits.yaml
+++ b/.github/workflows/starter-kits.yaml
@@ -37,20 +37,25 @@ jobs:
         run: |
           # Add the local Lit repo as a remote and fetch the currently checked
           # out commit.
+          echo "Fetching from local Lit repo..."
           git remote add lit ../lit
           git fetch --no-tags lit HEAD:lit-head
           IMPORT_REF=$(git rev-parse lit-head)
           # Read the contents of the TS starter kit directory from the imported
           # commit into the index root, ignoring any conflicts (`--reset`) and
           # updating the work tree too (`-u`).
+          echo "Staging changes..."
           git read-tree --reset -u "$IMPORT_REF":packages/lit-starter-ts
           # If there are no changes, skip the rest of this step.
           if git diff --cached --quiet --exit-code; then
+            echo "There are no changes."
             exit 0
           fi
           # Commit and push.
+          echo "Pushing changes..."
           git commit -m "Import upstream changes (${IMPORT_REF})"
           git push origin release-automation-test-main
+          echo "Done."
 
       - name: Checkout lit-element-starter-js repo
         uses: actions/checkout@v2
@@ -66,17 +71,22 @@ jobs:
         run: |
           # Add the local Lit repo as a remote and fetch the currently checked
           # out commit.
+          echo "Fetching from local Lit repo..."
           git remote add lit ../lit
           git fetch --no-tags lit HEAD:lit-head
           IMPORT_REF=$(git rev-parse lit-head)
           # Read the contents of the JS starter kit directory from the imported
           # commit into the index root, ignoring any conflicts (`--reset`) and
           # updating the work tree too (`-u`).
+          echo "Staging changes..."
           git read-tree --reset -u "$IMPORT_REF":packages/lit-starter-js
           # If there are no changes, skip the rest of this step.
           if git diff --cached --quiet --exit-code; then
+            echo "There are no changes."
             exit 0
           fi
           # Commit and push.
+          echo "Pushing changes..."
           git commit -m "Import upstream changes (${IMPORT_REF})"
           git push origin release-automation-test-main
+          echo "Done."


### PR DESCRIPTION
The starter kit repos were not pushed after merging #2496 because the checked out repos are shallow: https://github.com/lit/lit/runs/5415481001?check_suite_focus=true#step:5:28