### PR TITLE
Set `fetch-depth: 0` on all repos when syncing the starter kits.

### DIFF
--- a/.github/workflows/starter-kits.yaml
+++ b/.github/workflows/starter-kits.yaml
@@ -22,6 +22,8 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: lit
+          # Fetch all history, otherwise we can't fetch from this repo.
+          fetch-depth: 0
 
       - name: Checkout lit-element-starter-ts repo
         uses: actions/checkout@v2


### PR DESCRIPTION
The source repo needs to not be shallow for the fetch to succeed without [`--update-shallow`](https://git-scm.com/docs/git-fetch#Documentation/git-fetch.txt---update-shallow) ([`.git/shallow` docs here](https://git-scm.com/docs/shallow)). I think this likely means that #2597 wasn't necessary, but I'm not inclined to revert it since I'm worried it would affect the push.