### PR TITLE
Push starter kit changes to the individual repos' `main` branches.

### DIFF
--- a/.github/workflows/starter-kits.yaml
+++ b/.github/workflows/starter-kits.yaml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: lit/lit-element-starter-ts
-          ref: release-automation-test-main
+          ref: main
           path: lit-element-starter-ts
           token: ${{ secrets.LIT_ROBOT_AUTOMATION_PAT }}
           # Fetch all history, otherwise we can't push to this repo.
@@ -57,14 +57,14 @@ jobs:
           # Commit and push.
           echo "Pushing changes..."
           git commit -m "Import upstream changes (${IMPORT_REF})"
-          git push origin release-automation-test-main
+          git push origin main
           echo "Done."
 
       - name: Checkout lit-element-starter-js repo
         uses: actions/checkout@v2
         with:
           repository: lit/lit-element-starter-js
-          ref: release-automation-test-main
+          ref: main
           path: lit-element-starter-js
           token: ${{ secrets.LIT_ROBOT_AUTOMATION_PAT }}
           # Fetch all history, otherwise we can't push to this repo.
@@ -92,5 +92,5 @@ jobs:
           # Commit and push.
           echo "Pushing changes..."
           git commit -m "Import upstream changes (${IMPORT_REF})"
-          git push origin release-automation-test-main
+          git push origin main
           echo "Done."


### PR DESCRIPTION
Changes to the starter kits are currently being pushed to the `release-automation-test-main` branch of each repo. This PR starts pushing changes to `main` instead.

Here are the current diffs with the `release-automation-test-main` branch in each repo:
- https://github.com/lit/lit-element-starter-ts/compare/release-automation-test-main
- https://github.com/lit/lit-element-starter-js/compare/release-automation-test-main

Here's the run where the first successful push happened (which commits in the diffs above):
- https://github.com/lit/lit/runs/5416539896?check_suite_focus=true

Here's a later run with no changes, where nothing was pushed:
- https://github.com/lit/lit/runs/5416801484?check_suite_focus=true

Closes #2248.