### PR TITLE
[@lit/reactive-element] Fix a lint warning in the tests.

### DIFF
--- a/packages/reactive-element/src/test/reactive-element_test.ts
+++ b/packages/reactive-element/src/test/reactive-element_test.ts
@@ -3091,6 +3091,7 @@ suite('ReactiveElement', () => {
           // @ts-expect-error 'bar' is not a keyof this
           changedProperties.delete('bar');
           // @ts-expect-error number is not assignable to string
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
           const w: string = changedProperties.get('foo');
           // @ts-expect-error string is not assignable to number
           changedProperties.set('foo', 'hi');


### PR DESCRIPTION
This unused variable is intentional because the assignment's type error is used to check the type of the expression, but the lint warning appears at the end of every PR's diff because it isn't handled.