### PR TITLE
Remove outdated starter kit export docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,31 +93,3 @@ npm run benchmarks
 ```
 
 See individual package READMEs for details on developing for a specific package.
-
-### Exporting starter templates
-
-Although we maintain `lit-starter-ts` and `lit-starter-js` in
-the monorepo for ease of integration testing, the source is exported back out to
-individual repos ([ts](https://github.com/PolymerLabs/lit-element-starter-ts),
-[js](https://github.com/PolymerLabs/lit-element-starter-js)) as these are
-[GitHub Template Repositories](https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/creating-a-template-repository)
-with a nice workflow for users to create their own new element repos based on
-the template.
-
-Use the following command to export new commits to the monorepo packages to a
-branch on the template repos (`lit-next` branch shown in example):
-
-```sh
-# Export TS template
-git remote add lit-element-starter-ts git@github.com:lit/lit-element-starter-ts.git
-git subtree push --prefix=packages/lit-starter-ts/ lit-starter-element-ts lit-next
-
-# Export JS template
-git remote add lit-element-starter-js git@github.com:lit/lit-element-starter-js.git
-git subtree push --prefix=packages/lit-starter-js/ lit-starter-element-js lit-next
-```
-
-Notes:
-
-- If your version of git did not come with `git-subtree`, you can add it by cloning the git source at `git@github.com:git/git.git` and symlinking `git/contrib/subtree/git-subtree` into your path (e.g. `/usr/local/bin`)
-- If `git subtree` errors with a segmentation fault, try increasing your stack size prior to running, e.g. `ulimit -s 16384`


### PR DESCRIPTION
This section of the readme is no longer relevant given that this now happens automatically on any push to `main`.

Fixes #2537.