### PR TITLE
Fix links to the starter kit repos in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,10 @@ lit-html 1.x source is available on the [`lit-html-1.x`](https://github.com/lit/
   - [`@lit-labs/motion`](./packages/labs/motion) - Lit directives for making things move
   - [`@lit-labs/scoped-registry-mixin`](./packages/labs/scoped-registry-mixin) - A mixin for LitElement that integrates with the speculative Scoped CustomElementRegistry polyfill.
 - Starter kits (not published to npm)
-  - [`lit-starter-ts`](./packages/lit-starter-ts) ([template repo](https://github.com/lit/lit/tree/main/packages/lit-starter-ts)) - A starter repo for building reusable components using Lit in TypeScript.
-  - [`lit-starter-js`](./packages/lit-starter-js) ([template repo](https://github.com/lit/lit/tree/main/packages/lit-starter-js)) - A starter repo for building reusable components using Lit in Javascript.
+  - [`lit-starter-ts`](./packages/lit-starter-ts) ([template
+    repo](https://github.com/lit/lit-element-starter-ts)) - A starter repo for building reusable components using Lit in TypeScript.
+  - [`lit-starter-js`](./packages/lit-starter-js) ([template
+    repo](https://github.com/lit/lit-element-starter-js)) - A starter repo for building reusable components using Lit in Javascript.
 - Internal packages (not published to npm)
   - [`tests`](./packages/tests) - Test infrastructure for the monorepo.
   - [`benchmarks`](./packages/benchmarks) - Benchmarks for testing various libraries in the monorepo.


### PR DESCRIPTION
These links are currently pointing to the folder within this repo, which are already referenced by a link right before each. This PR updates them to point to the separate template repos.