### PR TITLE
Test are located in ./src/test/ and externsion is .ts

### DIFF
--- a/packages/lit-starter-ts/web-test-runner.config.js
+++ b/packages/lit-starter-ts/web-test-runner.config.js
@@ -91,7 +91,7 @@ try {
 // https://modern-web.dev/docs/test-runner/cli-and-configuration/
 export default {
   rootDir: '.',
-  files: ['./test/**/*_test.js'],
+  files: ['./src/**/*_test.ts'],
   nodeResolve: {exportConditions: mode === 'dev' ? ['development'] : []},
   preserveSymlinks: true,
   browsers: commandLineBrowsers ?? Object.values(browsers),

--- a/packages/lit-starter-ts/web-test-runner.config.js
+++ b/packages/lit-starter-ts/web-test-runner.config.js
@@ -91,7 +91,7 @@ try {
 // https://modern-web.dev/docs/test-runner/cli-and-configuration/
 export default {
   rootDir: '.',
-  files: ['./src/**/*_test.ts'],
+  files: ['./src/test/**/*_test.ts'],
   nodeResolve: {exportConditions: mode === 'dev' ? ['development'] : []},
   preserveSymlinks: true,
   browsers: commandLineBrowsers ?? Object.values(browsers),


### PR DESCRIPTION
Hi, I noted this small bug on the lit-starter-ts,

- Tests are located in src/test directory
- Tests have extension .ts

Here is a small PR for fix this 

Thanks