### PR TITLE
Don't clone nodes as part of the debug event logger

### DIFF
--- a/.changeset/weak-feet-invent.md
+++ b/.changeset/weak-feet-invent.md
@@ -1,0 +1,6 @@
+---
+'lit-html': patch
+'@lit/reactive-element': patch
+---
+
+Make the event debug logger lazier, doing even less work (with no side effects) even in dev mode unless the page has opted in.

--- a/lit-next.code-workspace
+++ b/lit-next.code-workspace
@@ -1,62 +1,62 @@
 {
-	"folders": [
-		{
-			"name": "lit",
-			"path": "packages/lit"
-		},
-		{
-			"name": "lit-html",
-			"path": "packages/lit-html"
-		},
-		{
-			"name": "lit-element",
-			"path": "packages/lit-element"
-		},
-		{
-			"name": "reactive-element",
-			"path": "packages/reactive-element"
-		},
-		{
-			"name": "ssr",
-			"path": "packages/labs/ssr"
-		},
-		{
-			"name": "lit-starter-ts",
-			"path": "packages/lit-starter-ts"
-		},
-		{
-			"name": "lit-starter-js",
-			"path": "packages/lit-starter-js"
-		},
-		{
-			"name": "localize",
-			"path": "packages/localize"
-		},
-		{
-			"name": "labs",
-			"path": "packages/labs"
-		},
-		{
-			"name": "tests",
-			"path": "packages/tests"
-		},
-		{
-			"name": "benchmarks",
-			"path": "packages/benchmarks"
-		},
-		{
-			"name": "lit",
-			"path": "."
-		}
-	],
-	"settings": {
-		"typescript.tsdk": "node_modules/typescript/lib",
-		"debug.javascript.warnOnLongPrediction": false
-	},
-	"extensions": {
-		"recommendations": [
-			"dbaeumer.vscode-eslint",
-			"esbenp.prettier-vscode"
-		]
-	}
+  "folders": [
+    {
+      "name": "lit",
+      "path": "packages/lit"
+    },
+    {
+      "name": "lit-html",
+      "path": "packages/lit-html"
+    },
+    {
+      "name": "lit-element",
+      "path": "packages/lit-element"
+    },
+    {
+      "name": "reactive-element",
+      "path": "packages/reactive-element"
+    },
+    {
+      "name": "ssr",
+      "path": "packages/labs/ssr"
+    },
+    {
+      "name": "lit-starter-ts",
+      "path": "packages/lit-starter-ts"
+    },
+    {
+      "name": "lit-starter-js",
+      "path": "packages/lit-starter-js"
+    },
+    {
+      "name": "localize",
+      "path": "packages/localize"
+    },
+    {
+      "name": "labs",
+      "path": "packages/labs"
+    },
+    {
+      "name": "tests",
+      "path": "packages/tests"
+    },
+    {
+      "name": "benchmarks",
+      "path": "packages/benchmarks"
+    },
+    {
+      "name": "lit",
+      "path": "."
+    }
+  ],
+  "settings": {
+    "typescript.tsdk": "node_modules/typescript/lib",
+    "debug.javascript.warnOnLongPrediction": false,
+    // Regardless of the user's usual formatter, files
+    // in the Lit repo must be formatted using prettier.
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "extensions": {
+    "recommendations": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode"]
+  }
 }

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -189,16 +189,19 @@ interface DebugLoggingWindow {
  * Compiled out of prod mode builds.
  */
 const debugLogEvent = DEV_MODE
-  ? (event: LitUnstable.DebugLog.Entry) => {
+  ? () => {
       const shouldEmit = (window as unknown as DebugLoggingWindow)
         .emitLitDebugLogEvents;
       if (shouldEmit) {
+        return undefined;
+      }
+      return (event: LitUnstable.DebugLog.Entry) => {
         window.dispatchEvent(
           new CustomEvent<LitUnstable.DebugLog.Entry>('lit-debug', {
             detail: event,
           })
         );
-      }
+      };
     }
   : undefined;
 // Used for connecting beginRender and endRender events when there are nested
@@ -641,7 +644,7 @@ export const render = (
   // This property needs to remain unminified.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let part: ChildPart = (partOwnerNode as any)['_$litPart$'];
-  debugLogEvent?.({
+  debugLogEvent?.()?.({
     kind: 'begin render',
     id: renderId,
     value,
@@ -675,7 +678,7 @@ export const render = (
     );
   }
   part._$setValue(value);
-  debugLogEvent?.({
+  debugLogEvent?.()?.({
     kind: 'end render',
     id: renderId,
     value,
@@ -1064,7 +1067,7 @@ class Template {
       }
       nodeIndex++;
     }
-    debugLogEvent?.({
+    debugLogEvent?.()?.({
       kind: 'template prep',
       template: this,
       clonableTemplate: this.el,
@@ -1222,7 +1225,7 @@ class TemplateInstance implements Disconnectable {
     let i = 0;
     for (const part of this._parts) {
       if (part !== undefined) {
-        debugLogEvent?.({
+        debugLogEvent?.()?.({
           kind: 'set part',
           part,
           value: values[i],
@@ -1416,7 +1419,7 @@ class ChildPart implements Disconnectable {
       // fallback content.
       if (value === nothing || value == null || value === '') {
         if (this._$committedValue !== nothing) {
-          debugLogEvent?.({
+          debugLogEvent?.()?.({
             kind: 'commit nothing to child',
             start: this._$startNode,
             end: this._$endNode,
@@ -1476,7 +1479,7 @@ class ChildPart implements Disconnectable {
           throw new Error(message);
         }
       }
-      debugLogEvent?.({
+      debugLogEvent?.()?.({
         kind: 'commit node',
         start: this._$startNode,
         parent: this._$parent,
@@ -1502,7 +1505,7 @@ class ChildPart implements Disconnectable {
         }
         value = this._textSanitizer(value);
       }
-      debugLogEvent?.({
+      debugLogEvent?.()?.({
         kind: 'commit text',
         node,
         value,
@@ -1521,7 +1524,7 @@ class ChildPart implements Disconnectable {
           this._textSanitizer = createSanitizer(textNode, 'data', 'property');
         }
         value = this._textSanitizer(value);
-        debugLogEvent?.({
+        debugLogEvent?.()?.({
           kind: 'commit text',
           node: textNode,
           value,
@@ -1530,7 +1533,7 @@ class ChildPart implements Disconnectable {
         textNode.data = value as string;
       } else {
         this._commitNode(d.createTextNode(value as string));
-        debugLogEvent?.({
+        debugLogEvent?.()?.({
           kind: 'commit text',
           node: wrap(this._$startNode).nextSibling as Text,
           value,
@@ -1558,7 +1561,7 @@ class ChildPart implements Disconnectable {
           type);
 
     if ((this._$committedValue as TemplateInstance)?._$template === template) {
-      debugLogEvent?.({
+      debugLogEvent?.()?.({
         kind: 'template updating',
         template,
         instance: this._$committedValue as TemplateInstance,
@@ -1570,7 +1573,7 @@ class ChildPart implements Disconnectable {
     } else {
       const instance = new TemplateInstance(template as Template, this);
       const fragment = instance._clone(this.options);
-      debugLogEvent?.({
+      debugLogEvent?.()?.({
         kind: 'template instantiated',
         template,
         instance,
@@ -1580,7 +1583,7 @@ class ChildPart implements Disconnectable {
         values,
       });
       instance._update(values);
-      debugLogEvent?.({
+      debugLogEvent?.()?.({
         kind: 'template instantiated and updated',
         template,
         instance,
@@ -1870,7 +1873,7 @@ class AttributePart implements Disconnectable {
         }
         value = this._sanitizer(value ?? '');
       }
-      debugLogEvent?.({
+      debugLogEvent?.()?.({
         kind: 'commit attribute',
         element: this.element,
         name: this.name,
@@ -1901,7 +1904,7 @@ class PropertyPart extends AttributePart {
       }
       value = this._sanitizer(value);
     }
-    debugLogEvent?.({
+    debugLogEvent?.()?.({
       kind: 'commit property',
       element: this.element,
       name: this.name,
@@ -1927,7 +1930,7 @@ class BooleanAttributePart extends AttributePart {
 
   /** @internal */
   override _commitValue(value: unknown) {
-    debugLogEvent?.({
+    debugLogEvent?.()?.({
       kind: 'commit boolean attribute',
       element: this.element,
       name: this.name,
@@ -2012,7 +2015,7 @@ class EventPart extends AttributePart {
       newListener !== nothing &&
       (oldListener === nothing || shouldRemoveListener);
 
-    debugLogEvent?.({
+    debugLogEvent?.()?.({
       kind: 'commit event listener',
       element: this.element,
       name: this.name,
@@ -2084,7 +2087,7 @@ class ElementPart implements Disconnectable {
   }
 
   _$setValue(value: unknown): void {
-    debugLogEvent?.({
+    debugLogEvent?.()?.({
       kind: 'commit to element binding',
       element: this.element,
       value,

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -192,7 +192,7 @@ const debugLogEvent = DEV_MODE
   ? () => {
       const shouldEmit = (window as unknown as DebugLoggingWindow)
         .emitLitDebugLogEvents;
-      if (shouldEmit) {
+      if (!shouldEmit) {
         return undefined;
       }
       return (event: LitUnstable.DebugLog.Entry) => {

--- a/packages/reactive-element/src/reactive-element.ts
+++ b/packages/reactive-element/src/reactive-element.ts
@@ -138,16 +138,19 @@ interface DebugLoggingWindow {
  * Compiled out of prod mode builds.
  */
 const debugLogEvent = DEV_MODE
-  ? (event: ReactiveUnstable.DebugLog.Entry) => {
+  ? () => {
       const shouldEmit = (window as unknown as DebugLoggingWindow)
         .emitLitDebugLogEvents;
-      if (shouldEmit) {
+      if (!shouldEmit) {
+        return undefined;
+      }
+      return (event: ReactiveUnstable.DebugLog.Entry) => {
         window.dispatchEvent(
           new CustomEvent<ReactiveUnstable.DebugLog.Entry>('lit-debug', {
             detail: event,
           })
         );
-      }
+      };
     }
   : undefined;
 
@@ -1258,7 +1261,7 @@ export abstract class ReactiveElement
     if (!this.isUpdatePending) {
       return;
     }
-    debugLogEvent?.({kind: 'update'});
+    debugLogEvent?.()?.({kind: 'update'});
     // create renderRoot before first update.
     if (!this.hasUpdated) {
       // Produce warning if any class properties are shadowed by class fields

--- a/packages/reactive-element/src/reactive-element.ts
+++ b/packages/reactive-element/src/reactive-element.ts
@@ -138,19 +138,17 @@ interface DebugLoggingWindow {
  * Compiled out of prod mode builds.
  */
 const debugLogEvent = DEV_MODE
-  ? () => {
+  ? (event: ReactiveUnstable.DebugLog.Entry) => {
       const shouldEmit = (window as unknown as DebugLoggingWindow)
         .emitLitDebugLogEvents;
       if (!shouldEmit) {
-        return undefined;
+        return;
       }
-      return (event: ReactiveUnstable.DebugLog.Entry) => {
-        window.dispatchEvent(
-          new CustomEvent<ReactiveUnstable.DebugLog.Entry>('lit-debug', {
-            detail: event,
-          })
-        );
-      };
+      window.dispatchEvent(
+        new CustomEvent<ReactiveUnstable.DebugLog.Entry>('lit-debug', {
+          detail: event,
+        })
+      );
     }
   : undefined;
 
@@ -1261,7 +1259,7 @@ export abstract class ReactiveElement
     if (!this.isUpdatePending) {
       return;
     }
-    debugLogEvent?.()?.({kind: 'update'});
+    debugLogEvent?.({kind: 'update'});
     // create renderRoot before first update.
     if (!this.hasUpdated) {
       // Produce warning if any class properties are shadowed by class fields


### PR DESCRIPTION
Integrations that need to clone nodes can do so themselves

Fixes #2632