### PR TITLE
[@lit-labs/eleventy-plugin-lit] Update readme to clarify using .cjs for eleventy config

### DIFF
--- a/.changeset/dirty-lemons-shop.md
+++ b/.changeset/dirty-lemons-shop.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/eleventy-plugin-lit': patch
+---
+
+Update README to clarify using .cjs extension for eleventy config

--- a/packages/labs/eleventy-plugin-lit/README.md
+++ b/packages/labs/eleventy-plugin-lit/README.md
@@ -105,8 +105,14 @@ while still reading the eleventy config file as CommonJS.
 
 Some options are:
 
-1. Add `{"type": "module"}` to your base `package.json` and make sure the
-   eleventy config file end with the `.cjs` extension.
+1. Add `{"type": "module"}` to your base `package.json`, make sure the
+   eleventy config file ends with the `.cjs` extension, and supply it as
+   a command line argument to `eleventy`.
+
+   ```sh
+   eleventy --config=.eleventy.cjs
+   ```
+
 1. Put all component `.js` files in a subdirectory with a nested `package.json` with
    `{"type": "module"}`.
 


### PR DESCRIPTION
Add to README that when using `.cjs` extension for the eleventy config file, it needs to be specified via command line argument for eleventy to pick up.