### PR TITLE
Forging TSAs is a security bug

### DIFF
--- a/.changeset/young-cups-develop.md
+++ b/.changeset/young-cups-develop.md
@@ -1,0 +1,6 @@
+---
+'lit-html': major
+'lit': major
+---
+
+Clarify that hacking around the template strings array brand error can create security vulnerabilities.

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -893,11 +893,20 @@ const getTemplateHtml = (
   if (!Array.isArray(strings) || !strings.hasOwnProperty('raw')) {
     let message = 'invalid template strings array';
     if (DEV_MODE) {
-      message =
-        `Internal Error: expected template strings to be an array ` +
-        `with a 'raw' field. Please file a bug at ` +
-        `https://github.com/lit/lit/issues/new?template=bug_report.md ` +
-        `and include information about your build tooling, if any.`;
+      message = `
+          Internal Error: expected template strings to be an array
+          with a 'raw' field. Faking a template strings array by
+          calling html or svg like an ordinary function is effectively
+          the same as calling unsafeHtml and can lead to major security
+          issues, e.g. opening your code up to XSS attacks.
+
+          If you're using the html or svg tagged template functions normally
+          and and still seeing this error, please file a bug at
+          https://github.com/lit/lit/issues/new?template=bug_report.md
+          and include information about your build tooling, if any.
+        `
+        .trim()
+        .replace(/\n */g, '\n');
     }
     throw new Error(message);
   }


### PR DESCRIPTION
Expands on the error message for a missing 'raw' property on a TemplateResult's strings to call out that this is part of Lit's security system.