### PR TITLE
[@labs/react] type event callbacks

### DIFF
--- a/.changeset/light-jobs-retire.md
+++ b/.changeset/light-jobs-retire.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/react': patch
+---
+
+Event callbacks can be typed by casting with EventHandler

--- a/packages/labs/react/README.md
+++ b/packages/labs/react/README.md
@@ -57,14 +57,14 @@ React component.
 
 #### Typescript
 
-Event callback types can be refined by type casting with `EventHandler`. The
+Event callback types can be refined by type casting with `EventName`. The
 type cast helps `createComponent` correlate typed callbacks to property names in
 the event property map.
 
-Uncasted EventHandlers will fallback to `(e: Event) => void`.
+Non-casted event names will fallback to an event type of `Event`.
 
 ```ts
-import type {EventHandler} from '@lit-labs/react';
+import type {EventName} from '@lit-labs/react';
 
 import * as React from 'react';
 import {createComponent} from '@lit-labs/react';
@@ -75,7 +75,7 @@ export const MyElementComponent = createComponent(
   'my-element',
   MyElement,
   {
-    onClick: 'pointerdown' as EventHandler<PointerEvent>,
+    onClick: 'pointerdown' as EventName<PointerEvent>,
     onChange: 'input',
   }
 );
@@ -96,9 +96,9 @@ Event callbacks will match their type cast. In the example below, a
 ```
 
 NOTE: This type casting is not associated to any component property. Be
-careful to use the corresponding type dispatched or bubbling from the
-webcomponent. Incorrect type casts might result in events with missing
-properties.
+careful to use the corresponding type dispatched or bubbled from the
+webcomponent. Incorrect types might result in additional properties, missing
+properties, or properties of the wrong type.
 
 ## `useController`
 

--- a/packages/labs/react/README.md
+++ b/packages/labs/react/README.md
@@ -57,9 +57,9 @@ React component.
 
 #### Typescript
 
-EventHandlers can be typecasted using the `EventHandler` type included in
+Event callbacks can be typecasted using the `EventHandler` type included in
 this package. The cast helps `createComponent` correlate callback types to
-property names from an event prop name map.
+property names from an event property map.
 
 Uncasted EventHandlers will fallback to `(e: Event) => void`.
 
@@ -75,7 +75,7 @@ export const MyElementComponent = createComponent(
   'my-element',
   MyElement,
   {
-    onClick: 'pointerdown' as EventHandler<PointerEvent>
+    onClick: 'pointerdown' as EventHandler<PointerEvent>,
     onChange: 'input',
   }
 );
@@ -86,11 +86,15 @@ EventHandlers in a component's props will match their typecast. A
 
 ```tsx
 <MyElementComponent
-  onClick={(e: PointerEvent) => { console.log('DOM PointerEvent called!')}}
-  onChange={(e: Event) => { console.log(e)}}
+  onClick={(e: PointerEvent) => {
+    console.log('DOM PointerEvent called!');
+  }}
+  onChange={(e: Event) => {
+    console.log(e);
+  }}
 />
 ```
- 
+
 NOTE: This type cast is not associated to any actual component property. Be
 careful to use the corresponding type dispatched from the webcomponent.
 Incorrect type casts might result in events without expected properties.

--- a/packages/labs/react/README.md
+++ b/packages/labs/react/README.md
@@ -57,8 +57,9 @@ React component.
 
 #### Typescript
 
-Event callbacks can be typed using the included `EventHandler` type. By using a
-typecast, `createComponent` correlates callback types to property names from an event property map.
+Event callback types can be refined by type casting with `EventHandler`. The
+type cast helps `createComponent` correlate typed callbacks to property names in
+the event property map.
 
 Uncasted EventHandlers will fallback to `(e: Event) => void`.
 
@@ -81,7 +82,7 @@ export const MyElementComponent = createComponent(
 ```
 
 Event callbacks will match their type cast. In the example below, a
-`PointerEvent` is expected in the `onClick` callback in the example below.
+`PointerEvent` is expected in the `onClick` callback.
 
 ```tsx
 <MyElementComponent
@@ -95,8 +96,9 @@ Event callbacks will match their type cast. In the example below, a
 ```
 
 NOTE: This type casting is not associated to any component property. Be
-careful to use the corresponding type dispatched from the webcomponent.
-Incorrect type casts might result in events with missing properties.
+careful to use the corresponding type dispatched or bubbling from the
+webcomponent. Incorrect type casts might result in events with missing
+properties.
 
 ## `useController`
 

--- a/packages/labs/react/README.md
+++ b/packages/labs/react/README.md
@@ -55,6 +55,46 @@ React component.
 />
 ```
 
+#### Typescript
+
+EventHandlers can be typecasted using the `EventHandler` type included in
+this package. The cast helps `createComponent` correlate callback types to
+property names from an event prop name map.
+
+Uncasted EventHandlers will fallback to `(e: Event) => void`.
+
+```ts
+import type { EventHandler } from '@lit-labs/react';
+
+import * as React from 'react';
+import {createComponent} from '@lit-labs/react';
+import {MyElement} from './my-element.js';
+
+export const MyElementComponent = createComponent(
+  React,
+  'my-element',
+  MyElement,
+  {
+    onClick: 'pointerdown' as EventHandler<PointerEvent>
+    onChange: 'input',
+  }
+);
+```
+
+EventHandlers in a component's props will match their typecast. A
+`PointerEvent` is expected in the `onClick` callback in the example below.
+
+```tsx
+<MyElementComponent
+  onClick={(e: PointerEvent) => { console.log('DOM PointerEvent called!')}}
+  onChange={(e: Event) => { console.log(e)}}
+/>
+```
+ 
+NOTE: This type cast is not associated to any actual component property. Be
+careful to use the corresponding type dispatched from the webcomponent.
+Incorrect type casts might result in events without expected properties.
+
 ## `useController`
 
 Reactive Controllers allow developers to hook a component's lifecycle to bundle

--- a/packages/labs/react/README.md
+++ b/packages/labs/react/README.md
@@ -64,7 +64,7 @@ property names from an event property map.
 Uncasted EventHandlers will fallback to `(e: Event) => void`.
 
 ```ts
-import type { EventHandler } from '@lit-labs/react';
+import type {EventHandler} from '@lit-labs/react';
 
 import * as React from 'react';
 import {createComponent} from '@lit-labs/react';

--- a/packages/labs/react/README.md
+++ b/packages/labs/react/README.md
@@ -57,9 +57,8 @@ React component.
 
 #### Typescript
 
-Event callbacks can be typecasted using the `EventHandler` type included in
-this package. The cast helps `createComponent` correlate callback types to
-property names from an event property map.
+Event callbacks can be typed using the included `EventHandler` type. By using a
+typecast, `createComponent` correlates callback types to property names from an event property map.
 
 Uncasted EventHandlers will fallback to `(e: Event) => void`.
 
@@ -81,7 +80,7 @@ export const MyElementComponent = createComponent(
 );
 ```
 
-EventHandlers in a component's props will match their typecast. A
+Event callbacks will match their type cast. In the example below, a
 `PointerEvent` is expected in the `onClick` callback in the example below.
 
 ```tsx
@@ -95,9 +94,9 @@ EventHandlers in a component's props will match their typecast. A
 />
 ```
 
-NOTE: This type cast is not associated to any actual component property. Be
+NOTE: This type casting is not associated to any component property. Be
 careful to use the corresponding type dispatched from the webcomponent.
-Incorrect type casts might result in events without expected properties.
+Incorrect type casts might result in events with missing properties.
 
 ## `useController`
 

--- a/packages/labs/react/src/create-component.ts
+++ b/packages/labs/react/src/create-component.ts
@@ -90,23 +90,23 @@ type StringValued<T> = {
 
 type Constructor<T> = {new (): T};
 
-type EventString<T = unknown> = string & {
+type EventString<T extends Event = Event> = string & {
   __event_type: T;
 };
 
 /***
  * Typecast that curries an Event type through an EventString. The React
- * equivelant to an event listeners is an `EventHandler`. The goal of the type
- * name is to hint that corresponding EventHandler callback in their props will
+ * equivelant to an event listeners is an `EventName`. The goal of the type
+ * name is to hint that corresponding EventName callback in their props will
  * be of a certain type.
  */
-export type EventHandler<T = unknown> = T extends Event
+export type EventName<T> = T extends Event
   ? EventString<T>
   : never;
 
-type EventHandlerRecord = Record<string, EventString | string>;
+type Events = Record<string, EventString | string>;
 
-type EventHandlerMap<R extends EventHandlerRecord> = {
+type EventProps<R extends Events> = {
   [K in keyof R]: R[K] extends EventString
     ? (e: R[K]['__event_type']) => void
     : (e: Event) => void;
@@ -135,7 +135,7 @@ type EventHandlerMap<R extends EventHandlerRecord> = {
  */
 export const createComponent = <
   I extends HTMLElement,
-  E extends EventHandlerRecord
+  E extends Events
 >(
   React: typeof ReactModule,
   tagName: string,
@@ -153,7 +153,7 @@ export const createComponent = <
   type UserProps = React.PropsWithChildren<
     React.PropsWithRef<
       Partial<Omit<I, 'children'>> &
-        Partial<EventHandlerMap<E>> &
+        Partial<EventProps<E>> &
         Omit<React.HTMLAttributes<HTMLElement>, keyof E>
     >
   >;

--- a/packages/labs/react/src/create-component.ts
+++ b/packages/labs/react/src/create-component.ts
@@ -38,7 +38,7 @@ const addOrUpdateEventListener = (
   if (listener !== undefined) {
     // If necessary, add listener and track handler
     if (handler === undefined) {
-      events.set(event, (handler = { handleEvent: listener }));
+      events.set(event, (handler = {handleEvent: listener}));
       node.addEventListener(event, handler);
       // Otherwise just update the listener with new value
     } else {
@@ -80,7 +80,7 @@ const setRef = (ref: React.Ref<unknown>, value: Element | null) => {
   if (typeof ref === 'function') {
     (ref as (e: Element | null) => void)(value);
   } else {
-    (ref as { current: Element | null }).current = value;
+    (ref as {current: Element | null}).current = value;
   }
 };
 
@@ -88,18 +88,22 @@ type StringValued<T> = {
   [P in keyof T]: string;
 };
 
-type Constructor<T> = { new(): T };
+type Constructor<T> = {new (): T};
 
 type EventHandlerString<T = unknown> = string & {
   __event_handler: T;
-}
+};
 
-export type EventHandler<T = unknown> = T extends Event ? EventHandlerString<T> : never;
+export type EventHandler<T = unknown> = T extends Event
+  ? EventHandlerString<T>
+  : never;
 
 type EventHandlerRecord = Record<string, EventHandlerString | string>;
 
 type EventHandlerMap<R extends EventHandlerRecord> = {
-  [K in keyof R]: R[K] extends EventHandlerString ? (e: R[K]["__event_handler"]) => void : (e: Event) => void;
+  [K in keyof R]: R[K] extends EventHandlerString
+    ? (e: R[K]['__event_handler']) => void
+    : (e: Event) => void;
 };
 
 /**
@@ -123,7 +127,10 @@ type EventHandlerMap<R extends EventHandlerRecord> = {
  * messages. Default value is inferred from the name of custom element class
  * registered via `customElements.define`.
  */
-export const createComponent = <I extends HTMLElement, E extends EventHandlerRecord>(
+export const createComponent = <
+  I extends HTMLElement,
+  E extends EventHandlerRecord
+>(
   React: typeof ReactModule,
   tagName: string,
   elementClass: Constructor<I>,
@@ -140,8 +147,8 @@ export const createComponent = <I extends HTMLElement, E extends EventHandlerRec
   type UserProps = React.PropsWithChildren<
     React.PropsWithRef<
       Partial<Omit<I, 'children'>> &
-      Partial<EventHandlerMap<E>> &
-      Omit<React.HTMLAttributes<HTMLElement>, keyof E>
+        Partial<EventHandlerMap<E>> &
+        Omit<React.HTMLAttributes<HTMLElement>, keyof E>
     >
   >;
 
@@ -166,8 +173,8 @@ export const createComponent = <I extends HTMLElement, E extends EventHandlerRec
         // rare.
         console.warn(
           `${tagName} contains property ${p} which is a React ` +
-          `reserved property. It will be used by React and not set on ` +
-          `the element.`
+            `reserved property. It will be used by React and not set on ` +
+            `the element.`
         );
       } else {
         elementClassProps.add(p);
@@ -177,7 +184,7 @@ export const createComponent = <I extends HTMLElement, E extends EventHandlerRec
 
   class ReactComponent extends Component<ComponentProps> {
     private _element: I | null = null;
-    private _elementProps!: { [index: string]: unknown };
+    private _elementProps!: {[index: string]: unknown};
     private _userRef?: React.Ref<unknown>;
     private _ref?: React.RefCallback<I>;
 
@@ -246,7 +253,7 @@ export const createComponent = <I extends HTMLElement, E extends EventHandlerRec
       // attributes to React. This allows attributes to use framework rules
       // for setting attributes and render correctly under SSR.
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const props: any = { ref: this._ref };
+      const props: any = {ref: this._ref};
       // Note, save element props while iterating to avoid the need to
       // iterate again when setting properties.
       this._elementProps = {};
@@ -267,7 +274,7 @@ export const createComponent = <I extends HTMLElement, E extends EventHandlerRec
     (props?: UserProps, ref?: React.Ref<unknown>) =>
       createElement(
         ReactComponent,
-        { ...props, __forwardedRef: ref } as ComponentProps,
+        {...props, __forwardedRef: ref} as ComponentProps,
         props?.children
       )
   );

--- a/packages/labs/react/src/create-component.ts
+++ b/packages/labs/react/src/create-component.ts
@@ -90,19 +90,25 @@ type StringValued<T> = {
 
 type Constructor<T> = {new (): T};
 
-type EventHandlerString<T = unknown> = string & {
-  __event_handler: T;
+type EventString<T = unknown> = string & {
+  __event_type: T;
 };
 
+/***
+ * Typecast that curries an Event type through an EventString. The React
+ * equivelant to an event listeners is an `EventHandler`. The goal of the type
+ * name is to hint that corresponding EventHandler callback in their props will
+ * be of a certain type.
+ */
 export type EventHandler<T = unknown> = T extends Event
-  ? EventHandlerString<T>
+  ? EventString<T>
   : never;
 
-type EventHandlerRecord = Record<string, EventHandlerString | string>;
+type EventHandlerRecord = Record<string, EventString | string>;
 
 type EventHandlerMap<R extends EventHandlerRecord> = {
-  [K in keyof R]: R[K] extends EventHandlerString
-    ? (e: R[K]['__event_handler']) => void
+  [K in keyof R]: R[K] extends EventString
+    ? (e: R[K]['__event_type']) => void
     : (e: Event) => void;
 };
 

--- a/packages/labs/react/src/create-component.ts
+++ b/packages/labs/react/src/create-component.ts
@@ -90,22 +90,18 @@ type StringValued<T> = {
 
 type Constructor<T> = {new (): T};
 
-type EventString<T extends Event = Event> = string & {
+/***
+ * Typecast that curries an Event type through a string. The goal of the type
+ * cast is to match a prop name to a typed event callback.
+ */
+export type EventName<T extends Event = Event> = string & {
   __event_type: T;
 };
 
-/***
- * Typecast that curries an Event type through an EventString. The React
- * equivelant to an event listeners is an `EventName`. The goal of the type
- * name is to hint that corresponding EventName callback in their props will
- * be of a certain type.
- */
-export type EventName<T> = T extends Event ? EventString<T> : never;
-
-type Events = Record<string, EventString | string>;
+type Events = Record<string, EventName | string>;
 
 type EventProps<R extends Events> = {
-  [K in keyof R]: R[K] extends EventString
+  [K in keyof R]: R[K] extends EventName
     ? (e: R[K]['__event_type']) => void
     : (e: Event) => void;
 };

--- a/packages/labs/react/src/create-component.ts
+++ b/packages/labs/react/src/create-component.ts
@@ -100,9 +100,7 @@ type EventString<T extends Event = Event> = string & {
  * name is to hint that corresponding EventName callback in their props will
  * be of a certain type.
  */
-export type EventName<T> = T extends Event
-  ? EventString<T>
-  : never;
+export type EventName<T> = T extends Event ? EventString<T> : never;
 
 type Events = Record<string, EventString | string>;
 
@@ -133,10 +131,7 @@ type EventProps<R extends Events> = {
  * messages. Default value is inferred from the name of custom element class
  * registered via `customElements.define`.
  */
-export const createComponent = <
-  I extends HTMLElement,
-  E extends Events
->(
+export const createComponent = <I extends HTMLElement, E extends Events>(
   React: typeof ReactModule,
   tagName: string,
   elementClass: Constructor<I>,

--- a/packages/labs/react/src/create-component.ts
+++ b/packages/labs/react/src/create-component.ts
@@ -38,7 +38,7 @@ const addOrUpdateEventListener = (
   if (listener !== undefined) {
     // If necessary, add listener and track handler
     if (handler === undefined) {
-      events.set(event, (handler = {handleEvent: listener}));
+      events.set(event, (handler = { handleEvent: listener }));
       node.addEventListener(event, handler);
       // Otherwise just update the listener with new value
     } else {
@@ -80,19 +80,27 @@ const setRef = (ref: React.Ref<unknown>, value: Element | null) => {
   if (typeof ref === 'function') {
     (ref as (e: Element | null) => void)(value);
   } else {
-    (ref as {current: Element | null}).current = value;
+    (ref as { current: Element | null }).current = value;
   }
-};
-
-type EventsAsListeners<R> = {
-  [K in keyof R]: R[K] extends Event ? (e: R[K]) => void : (e: Event) => void;
 };
 
 type StringValued<T> = {
   [P in keyof T]: string;
 };
 
-type Constructor<T> = {new (): T};
+type Constructor<T> = { new(): T };
+
+type EventHandlerString<T = unknown> = string & {
+  __event_handler: T;
+}
+
+export type EventHandler<T = unknown> = T extends Event ? EventHandlerString<T> : never;
+
+type EventHandlerRecord = Record<string, EventHandlerString | string>;
+
+type EventHandlerMap<R extends EventHandlerRecord> = {
+  [K in keyof R]: R[K] extends EventHandlerString ? (e: R[K]["__event_handler"]) => void : (e: Event) => void;
+};
 
 /**
  * Creates a React component for a custom element. Properties are distinguished
@@ -115,11 +123,11 @@ type Constructor<T> = {new (): T};
  * messages. Default value is inferred from the name of custom element class
  * registered via `customElements.define`.
  */
-export const createComponent = <I extends HTMLElement, E>(
+export const createComponent = <I extends HTMLElement, E extends EventHandlerRecord>(
   React: typeof ReactModule,
   tagName: string,
   elementClass: Constructor<I>,
-  events?: Record<keyof E, string>,
+  events?: E,
   displayName?: string
 ) => {
   const Component = React.Component;
@@ -132,8 +140,8 @@ export const createComponent = <I extends HTMLElement, E>(
   type UserProps = React.PropsWithChildren<
     React.PropsWithRef<
       Partial<Omit<I, 'children'>> &
-        Partial<EventsAsListeners<E>> &
-        Omit<React.HTMLAttributes<HTMLElement>, keyof E>
+      Partial<EventHandlerMap<E>> &
+      Omit<React.HTMLAttributes<HTMLElement>, keyof E>
     >
   >;
 
@@ -158,8 +166,8 @@ export const createComponent = <I extends HTMLElement, E>(
         // rare.
         console.warn(
           `${tagName} contains property ${p} which is a React ` +
-            `reserved property. It will be used by React and not set on ` +
-            `the element.`
+          `reserved property. It will be used by React and not set on ` +
+          `the element.`
         );
       } else {
         elementClassProps.add(p);
@@ -169,7 +177,7 @@ export const createComponent = <I extends HTMLElement, E>(
 
   class ReactComponent extends Component<ComponentProps> {
     private _element: I | null = null;
-    private _elementProps!: {[index: string]: unknown};
+    private _elementProps!: { [index: string]: unknown };
     private _userRef?: React.Ref<unknown>;
     private _ref?: React.RefCallback<I>;
 
@@ -238,7 +246,7 @@ export const createComponent = <I extends HTMLElement, E>(
       // attributes to React. This allows attributes to use framework rules
       // for setting attributes and render correctly under SSR.
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const props: any = {ref: this._ref};
+      const props: any = { ref: this._ref };
       // Note, save element props while iterating to avoid the need to
       // iterate again when setting properties.
       this._elementProps = {};
@@ -259,7 +267,7 @@ export const createComponent = <I extends HTMLElement, E>(
     (props?: UserProps, ref?: React.Ref<unknown>) =>
       createElement(
         ReactComponent,
-        {...props, __forwardedRef: ref} as ComponentProps,
+        { ...props, __forwardedRef: ref } as ComponentProps,
         props?.children
       )
   );

--- a/packages/labs/react/src/create-component.ts
+++ b/packages/labs/react/src/create-component.ts
@@ -84,8 +84,8 @@ const setRef = (ref: React.Ref<unknown>, value: Element | null) => {
   }
 };
 
-type Events<S> = {
-  [P in keyof S]?: (e: Event) => unknown;
+type EventsAsListeners<R> = {
+  [K in keyof R]: R[K] extends Event ? (e: R[K]) => void : (e: Event) => void;
 };
 
 type StringValued<T> = {
@@ -119,7 +119,7 @@ export const createComponent = <I extends HTMLElement, E>(
   React: typeof ReactModule,
   tagName: string,
   elementClass: Constructor<I>,
-  events?: StringValued<E>,
+  events?: Record<keyof E, string>,
   displayName?: string
 ) => {
   const Component = React.Component;
@@ -132,8 +132,8 @@ export const createComponent = <I extends HTMLElement, E>(
   type UserProps = React.PropsWithChildren<
     React.PropsWithRef<
       Partial<Omit<I, 'children'>> &
-        Events<E> &
-        React.HTMLAttributes<HTMLElement>
+        Partial<EventsAsListeners<E>> &
+        Omit<React.HTMLAttributes<HTMLElement>, keyof E>
     >
   >;
 

--- a/packages/labs/react/src/test/create-component_test.tsx
+++ b/packages/labs/react/src/test/create-component_test.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import type {EventHandler} from "../create-component.js";
+import type {EventName} from "../create-component.js";
 
 import {ReactiveElement} from '@lit/reactive-element';
 import {property} from '@lit/reactive-element/decorators/property.js';
@@ -69,7 +69,7 @@ suite('createComponent', () => {
   });
 
   const basicElementEvents = {
-    onFoo: 'foo' as EventHandler<MouseEvent>,
+    onFoo: 'foo' as EventName<MouseEvent>,
     onBar: 'bar',
   };
 

--- a/packages/labs/react/src/test/create-component_test.tsx
+++ b/packages/labs/react/src/test/create-component_test.tsx
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+import type {EventHandler} from "../create-component.js";
+
 import {ReactiveElement} from '@lit/reactive-element';
 import {property} from '@lit/reactive-element/decorators/property.js';
 import {customElement} from '@lit/reactive-element/decorators/custom-element.js';
@@ -66,17 +68,12 @@ suite('createComponent', () => {
     }
   });
 
-  interface BasicElementEvents {
-    onFoo: KeyboardEvent;
-    onBar: CustomEvent<string>;
-  }
-
   const basicElementEvents = {
-    onFoo: 'foo',
+    onFoo: 'foo' as EventHandler<MouseEvent>,
     onBar: 'bar',
   };
 
-  const BasicElementComponent = createComponent<BasicElement, BasicElementEvents>(
+  const BasicElementComponent = createComponent(
     window.React,
     elementName,
     BasicElement,
@@ -246,13 +243,13 @@ suite('createComponent', () => {
     let fooEvent: Event | undefined,
       fooEvent2: Event | undefined,
       barEvent: Event | undefined;
-    const onFoo = (e: KeyboardEvent) => {
+    const onFoo = (e: MouseEvent) => {
       fooEvent = e;
     };
     const onFoo2 = (e: Event) => {
       fooEvent2 = e;
     };
-    const onBar = (e: CustomEvent<string>) => {
+    const onBar = (e: Event) => {
       barEvent = e;
     };
     await renderReactComponent({

--- a/packages/labs/react/src/test/create-component_test.tsx
+++ b/packages/labs/react/src/test/create-component_test.tsx
@@ -66,12 +66,17 @@ suite('createComponent', () => {
     }
   });
 
+  interface BasicElementEvents {
+    onFoo: KeyboardEvent;
+    onBar: CustomEvent<string>;
+  }
+
   const basicElementEvents = {
     onFoo: 'foo',
     onBar: 'bar',
   };
 
-  const BasicElementComponent = createComponent(
+  const BasicElementComponent = createComponent<BasicElement, BasicElementEvents>(
     window.React,
     elementName,
     BasicElement,
@@ -241,13 +246,13 @@ suite('createComponent', () => {
     let fooEvent: Event | undefined,
       fooEvent2: Event | undefined,
       barEvent: Event | undefined;
-    const onFoo = (e: Event) => {
+    const onFoo = (e: KeyboardEvent) => {
       fooEvent = e;
     };
     const onFoo2 = (e: Event) => {
       fooEvent2 = e;
     };
-    const onBar = (e: Event) => {
+    const onBar = (e: CustomEvent<string>) => {
       barEvent = e;
     };
     await renderReactComponent({


### PR DESCRIPTION
This PR is a retcon of PR #2445 

- users explicitly define event types in event callbacks
- default event type expected from a PropName map is `(e: Event) => void`
- user can declare a event map interface like `{propName: EventType, ...}`
- will be expressed as `{prop: (e: EventType) => void, ...}` in the React Component Props
- user prop type is used despite existing or expected React Type
- example: `{'onChange': Event}` will eclipse `React.FormEvent<HTMLInputElement>` with a DOM `Event` 

This should allow clients to explicitly define event types in react event callbacks like the example below:
```Typescript
  interface MyElementEvents {
    onClick: MouseEvent;  
    onKeyDown: KeyboardEvent;
  }

  const myElementPropNames = {
    onClick: 'click', // (e: MouseEvent) => void
    onKeyDown: 'keydown',  // (e: KeyboardEvent) => void
  }; 
  
  const myComponent = createComponent<MyComponent, MyElementEvents>(
    myElementPropNames,
    ...,
  )
```

Without generics, the typing defaults to `Event`:
```Typescript
  const myElementPropNames = {
    onClick: 'click', // (e: Event) => void
    onKeyDown: 'keydown',  // (e: Event) => void
  }; 
  
  const myComponent = createComponent(
    myElementPropNames,
    ...,
  )  
```

Undefined, 'missing', or types that don't extend from `Event` also default to `Event` in the EventMap:
```Typescript
  interface MyElementEvents {
    onClick: MouseEvent; 
    onNotAnEventType: any; 
  }

  const myElementPropNames = {
    onClick: 'click', // (e: MouseEvent) => void
    onKeyDown: 'keydown',  // defaults to (e: Event) => void
    onNotAnEventType: 'not-event-type',  // defaults to (e: Event) => void
  }; 
  
  const myComponent = createComponent<MyComponent, MyElementEvents>(
    myElementPropNames,
    ...,
  )
```