### PR TITLE
[@lit-labs/ssr] Implement HTMLElement.shadowRoot

### DIFF
--- a/.changeset/light-candles-yell.md
+++ b/.changeset/light-candles-yell.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/ssr': minor
+---
+
+Adds HTMLElement.shadowRoot property to dom-shim.

--- a/packages/labs/ssr/src/lib/dom-shim.ts
+++ b/packages/labs/ssr/src/lib/dom-shim.ts
@@ -46,6 +46,10 @@ export const getWindow = ({
         value,
       }));
     }
+    #shadowRoot: null | ShadowRoot = null;
+    get shadowRoot() {
+      return this.#shadowRoot;
+    }
     abstract attributeChangedCallback?(
       name: string,
       old: string | null,
@@ -60,8 +64,12 @@ export const getWindow = ({
     hasAttribute(name: string) {
       return attributesForElement(this).has(name);
     }
-    attachShadow() {
-      return {host: this};
+    attachShadow(init?: ShadowRootInit) {
+      const shadowRoot = {host: this};
+      if (init && init.mode === 'open') {
+        this.#shadowRoot = shadowRoot;
+      }
+      return shadowRoot;
     }
     getAttribute(name: string) {
       const value = attributesForElement(this).get(name);

--- a/packages/labs/ssr/src/lib/dom-shim.ts
+++ b/packages/labs/ssr/src/lib/dom-shim.ts
@@ -64,7 +64,7 @@ export const getWindow = ({
     hasAttribute(name: string) {
       return attributesForElement(this).has(name);
     }
-    attachShadow(init?: ShadowRootInit) {
+    attachShadow(init: ShadowRootInit) {
       const shadowRoot = {host: this};
       if (init && init.mode === 'open') {
         this._shadowRoot = shadowRoot;

--- a/packages/labs/ssr/src/lib/dom-shim.ts
+++ b/packages/labs/ssr/src/lib/dom-shim.ts
@@ -46,9 +46,9 @@ export const getWindow = ({
         value,
       }));
     }
-    #shadowRoot: null | ShadowRoot = null;
+    private _shadowRoot: null | ShadowRoot = null;
     get shadowRoot() {
-      return this.#shadowRoot;
+      return this._shadowRoot;
     }
     abstract attributeChangedCallback?(
       name: string,
@@ -67,7 +67,7 @@ export const getWindow = ({
     attachShadow(init?: ShadowRootInit) {
       const shadowRoot = {host: this};
       if (init && init.mode === 'open') {
-        this.#shadowRoot = shadowRoot;
+        this._shadowRoot = shadowRoot;
       }
       return shadowRoot;
     }

--- a/packages/labs/ssr/src/test/all-tests.ts
+++ b/packages/labs/ssr/src/test/all-tests.ts
@@ -4,5 +4,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+import './lib/dom-shim_test.js';
 import './lib/render-lit_test.js';
 import './lib/module-loader_test.js';

--- a/packages/labs/ssr/src/test/lib/dom-shim_test.ts
+++ b/packages/labs/ssr/src/test/lib/dom-shim_test.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/labs/ssr/src/test/lib/dom-shim_test.ts
+++ b/packages/labs/ssr/src/test/lib/dom-shim_test.ts
@@ -21,6 +21,7 @@ test('elements defined with an open shadow root should expose it\'s shadow root 
   const element = new OpenShadowRoot();
   const shadow = element.attachShadow({mode: 'open'});
   assert.is(shadow, element.shadowRoot);
+  assert.is(shadow.host, element);
 });
 test('elements defined with a closed shadow root should expose a null value from the "shadowRoot" property', () => {
   class ClosedShadowRoot extends HTMLElement {}

--- a/packages/labs/ssr/src/test/lib/dom-shim_test.ts
+++ b/packages/labs/ssr/src/test/lib/dom-shim_test.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {getWindow} from '../../lib/dom-shim.js';
+import {test} from 'uvu';
+import * as assert from 'uvu/assert';
+
+const window = getWindow({}) as unknown as Window;
+const {HTMLElement} = window.window;
+
+test('elements without an attached shadow root should expose a null value from the "shadowRoot" property', () => {
+  class UnattachedShadowRoot extends HTMLElement {}
+  const element = new UnattachedShadowRoot();
+  assert.is(element.shadowRoot, null);
+});
+test('elements defined with an open shadow root should expose it\'s shadow root from the "shadowRoot" property', () => {
+  class OpenShadowRoot extends HTMLElement {}
+  const element = new OpenShadowRoot();
+  const shadow = element.attachShadow({mode: 'open'});
+  assert.is(shadow, element.shadowRoot);
+});
+test('elements defined with a closed shadow root should expose a null value from the "shadowRoot" property', () => {
+  class ClosedShadowRoot extends HTMLElement {}
+  const element = new ClosedShadowRoot();
+  element.attachShadow({mode: 'closed'});
+  assert.is(element.shadowRoot, null);
+});
+
+test.run();


### PR DESCRIPTION
This PR implements a public readonly property, `shadowRoot`, on the `HTMLElement` class defined in the dom-shim. This property will evaluate to the object created and returned by `attachShadow()` when `attachShadow()` is invoked with an open shadow root mode (`host.attachShadow({mode: "open"}`). Otherwise, `shadowRoot` will evaluate to `null`. This behavior is intended to match the DOM behavior defined [here](https://dom.spec.whatwg.org/#dom-element-attachshadow).

Let me know if changes are need; I'm happy to make any updates. I've also added one question inline that should probably get attention before merging. Thanks in advance!

Fixes #2652 