### PR TITLE
[@lit-labs/react] - remove renegade properties

### DIFF
--- a/.changeset/honest-hats-explode.md
+++ b/.changeset/honest-hats-explode.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/react': patch
+---
+
+Skip the \_\_forwardedRef when passing component props to element.

--- a/packages/labs/react/src/create-component.ts
+++ b/packages/labs/react/src/create-component.ts
@@ -14,10 +14,6 @@ const reservedReactProperties = new Set([
   'className',
 ]);
 
-const propertySieve = new Set([
-  "__forwardedRef",
-]);
-
 const listenedEvents: WeakMap<
   Element,
   Map<string, EventListenerObject>
@@ -259,7 +255,7 @@ export const createComponent = <I extends HTMLElement, E extends Events>(
       // iterate again when setting properties.
       this._elementProps = {};
       for (const [k, v] of Object.entries(this.props)) {
-        if (propertySieve.has(k)) continue;
+        if (k === '__forwardedRef') continue;
 
         if (elementClassProps.has(k)) {
           this._elementProps[k] = v;

--- a/packages/labs/react/src/create-component.ts
+++ b/packages/labs/react/src/create-component.ts
@@ -14,6 +14,10 @@ const reservedReactProperties = new Set([
   'className',
 ]);
 
+const propertySieve = new Set([
+  "__forwardedRef",
+]);
+
 const listenedEvents: WeakMap<
   Element,
   Map<string, EventListenerObject>
@@ -255,6 +259,8 @@ export const createComponent = <I extends HTMLElement, E extends Events>(
       // iterate again when setting properties.
       this._elementProps = {};
       for (const [k, v] of Object.entries(this.props)) {
+        if (propertySieve.has(k)) continue;
+
         if (elementClassProps.has(k)) {
           this._elementProps[k] = v;
         } else {

--- a/packages/labs/react/src/test/create-component_test.tsx
+++ b/packages/labs/react/src/test/create-component_test.tsx
@@ -137,6 +137,20 @@ suite('createComponent', () => {
     assert.equal(elementRef2.current, null);
   });
 
+  test('ref does not create new attribute on element', async () => {
+    await renderReactComponent({ref: undefined});
+    const el = container.querySelector(elementName);
+    const outerHTML = el?.outerHTML;
+
+    const elementRef1 = window.React.createRef();
+    await renderReactComponent({ref: elementRef1});
+
+    const elAfterRef = container.querySelector(elementName);
+    const outerHTMLAfterRef = elAfterRef?.outerHTML;
+
+    assert.equal(outerHTML, outerHTMLAfterRef);
+  });
+
   test('can get ref to element via callbacks', async () => {
     const ref1Calls: Array<string | undefined> = [];
     const refCb1 = (e: Element | null) => ref1Calls.push(e?.localName);


### PR DESCRIPTION
Currently our react wrapper will attach the '__forwardedRef' react component property to the referenced element itself.

This PR:
- creates a property sieve (i'm assuming there might be other rogue properties in the future)
- skips over properties in the property sieve, doesn't pass sieve props to element
- add tests to confirm sieve properties aren't added

solves issue:
#2593