### PR TITLE
[reactive-element] Add types to query, query-async, and queryAll jsdoc code examples

### DIFF
--- a/.changeset/rude-jokes-fetch.md
+++ b/.changeset/rude-jokes-fetch.md
@@ -1,0 +1,6 @@
+---
+'@lit/reactive-element': patch
+'lit': patch
+---
+
+Add explicit types to the jsdoc code samples for `query`, `queryAll`, and `queryAsync`.

--- a/packages/reactive-element/src/decorators/query-all.ts
+++ b/packages/reactive-element/src/decorators/query-all.ts
@@ -26,7 +26,7 @@ import {decorateProperty} from './base.js';
  * ```ts
  * class MyElement {
  *   @queryAll('div')
- *   divs;
+ *   divs: NodeListOf<HTMLDivElement>;
  *
  *   render() {
  *     return html`

--- a/packages/reactive-element/src/decorators/query-async.ts
+++ b/packages/reactive-element/src/decorators/query-async.ts
@@ -34,7 +34,7 @@ import {decorateProperty} from './base.js';
  * ```ts
  * class MyElement {
  *   @queryAsync('#first')
- *   first;
+ *   first: Promise<HTMLDivElement>;
  *
  *   render() {
  *     return html`

--- a/packages/reactive-element/src/decorators/query.ts
+++ b/packages/reactive-element/src/decorators/query.ts
@@ -27,7 +27,7 @@ import {decorateProperty} from './base.js';
  * ```ts
  * class MyElement {
  *   @query('#first')
- *   first;
+ *   first: HTMLDivElement;
  *
  *   render() {
  *     return html`


### PR DESCRIPTION
Add explicit types to the code samples showing example usage of `query`, `queryAll`, and `queryAsync`.