### PR TITLE
Fix changeset version

### DIFF
--- a/.changeset/young-cups-develop.md
+++ b/.changeset/young-cups-develop.md
@@ -1,6 +1,6 @@
 ---
-'lit-html': major
-'lit': major
+'lit-html': patch
+'lit': patch
 ---
 
 Clarify that hacking around the template strings array brand error can create security vulnerabilities.


### PR DESCRIPTION
Fixes a small typo in the changeset version committed as part of https://github.com/lit/lit/pull/2646/files. Since the PR updates an error message I've reduced `major` to `patch`.

This PR unblocks the release, which would otherwise bump `lit` to `3.0.0`.

Thank you!