### PR TITLE
[lit-html] Fix `ref` bug when auto-bound class method used as as callback

### DIFF
--- a/.changeset/short-cooks-deliver.md
+++ b/.changeset/short-cooks-deliver.md
@@ -1,5 +1,6 @@
 ---
 'lit-html': patch
+'lit': patch
 ---
 
 Fixs `ref` bug when auto-bound class method used as as callback could incorrectly receive `undefined`.

--- a/.changeset/short-cooks-deliver.md
+++ b/.changeset/short-cooks-deliver.md
@@ -1,0 +1,5 @@
+---
+'lit-html': patch
+---
+
+Fixs `ref` bug when auto-bound class method used as as callback could incorrectly receive `undefined`.

--- a/.changeset/short-cooks-deliver.md
+++ b/.changeset/short-cooks-deliver.md
@@ -3,4 +3,4 @@
 'lit': patch
 ---
 
-Fixs `ref` bug when auto-bound class method used as as callback could incorrectly receive `undefined`.
+Fixes `ref` bug when auto-bound class method used as a callback could incorrectly receive `undefined`.

--- a/packages/lit-html/src/directives/ref.ts
+++ b/packages/lit-html/src/directives/ref.ts
@@ -30,16 +30,20 @@ interface RefInternal {
 
 // When callbacks are used for refs, this map tracks the last value the callback
 // was called with, for ensuring a directive doesn't clear the ref if the ref
-// has already been rendered to a new spot
-const lastElementForCallback: WeakMap<Function, Element | undefined> =
-  new WeakMap();
+// has already been rendered to a new spot. It is double-keyed on both the
+// callback and the context (options.host), since we auto-bind class methods to
+// options.host.
+const lastElementForCallback: WeakMap<
+  Function,
+  WeakMap<object, Element | undefined>
+> = new WeakMap();
 
 export type RefOrCallback = Ref | ((el: Element | undefined) => void);
 
 class RefDirective extends AsyncDirective {
   private _element?: Element;
   private _ref?: RefOrCallback;
-  private _context: unknown;
+  private _context: object | undefined;
 
   render(_ref: RefOrCallback) {
     return nothing;
@@ -69,11 +73,20 @@ class RefDirective extends AsyncDirective {
       // way regardless of whether a ref might be moving up in the tree (in
       // which case it would otherwise be called with the new value before the
       // previous one unsets it) and down in the tree (where it would be unset
-      // before being set)
-      if (lastElementForCallback.get(this._ref) !== undefined) {
+      // before being set). Note that element lookup is keyed by
+      // both the callback and the context, since we allow passing unbound
+      // functions that are called on options.host, and we want to treat
+      // these as unique "instances" of a function.
+      let lastElementForContext = lastElementForCallback.get(this._ref);
+      if (lastElementForContext === undefined) {
+        lastElementForContext = new WeakMap();
+        lastElementForCallback.set(this._ref, lastElementForContext);
+      }
+      const context = this._context ?? globalThis;
+      if (lastElementForContext.get(context) !== undefined) {
         this._ref.call(this._context, undefined);
       }
-      lastElementForCallback.set(this._ref, element);
+      lastElementForContext.set(context, element);
       // Call the ref with the new element value
       if (element !== undefined) {
         this._ref.call(this._context, element);
@@ -85,7 +98,7 @@ class RefDirective extends AsyncDirective {
 
   private get _lastElementForRef() {
     return typeof this._ref === 'function'
-      ? lastElementForCallback.get(this._ref)
+      ? lastElementForCallback.get(this._ref)?.get(this._context ?? globalThis)
       : this._ref?.value;
   }
 

--- a/packages/lit-html/src/test/directives/ref_test.ts
+++ b/packages/lit-html/src/test/directives/ref_test.ts
@@ -140,41 +140,76 @@ suite('ref', () => {
   });
 
   test('calls callback bound to options.host', () => {
-    let queriedEl: Element | null;
-    const host = {
-      calls: [] as Array<string | undefined>,
+    class Host {
+      bool = false;
+      calls: Array<string | undefined> = [];
+      root = document.createElement('div');
       elCallback(e: Element | undefined) {
         this.calls.push(e?.tagName);
-      },
+      }
+      render() {
+        return render(
+          this.bool
+            ? html`<div ${ref(this.elCallback)}></div>`
+            : html`<span ${ref(this.elCallback)}></span>`,
+          this.root,
+          {host: this}
+        );
+      }
+    }
+
+    const testRef = (
+      host: Host,
+      initialCalls: Array<string | undefined> = []
+    ) => {
+      let queriedEl: Element | null;
+      host.bool = true;
+      host.render();
+      queriedEl = host.root.firstElementChild;
+      assert.equal(queriedEl?.tagName, 'DIV');
+      assert.deepEqual(host.calls, [...initialCalls, 'DIV']);
+
+      host.bool = true;
+      host.render();
+      queriedEl = host.root.firstElementChild;
+      assert.equal(queriedEl?.tagName, 'DIV');
+      assert.deepEqual(host.calls, [...initialCalls, 'DIV']);
+
+      host.bool = false;
+      host.render();
+      queriedEl = host.root.firstElementChild;
+      assert.equal(queriedEl?.tagName, 'SPAN');
+      assert.deepEqual(host.calls, [...initialCalls, 'DIV', undefined, 'SPAN']);
+
+      host.bool = true;
+      host.render();
+      queriedEl = host.root.firstElementChild;
+      assert.equal(queriedEl?.tagName, 'DIV');
+      assert.deepEqual(host.calls, [
+        ...initialCalls,
+        'DIV',
+        undefined,
+        'SPAN',
+        undefined,
+        'DIV',
+      ]);
     };
-    const go = (x: boolean) =>
-      render(
-        x
-          ? html`<div ${ref(host.elCallback)}></div>`
-          : html`<span ${ref(host.elCallback)}></span>`,
-        container,
-        {host}
-      );
 
-    go(true);
-    queriedEl = container.firstElementChild;
-    assert.equal(queriedEl?.tagName, 'DIV');
-    assert.deepEqual(host.calls, ['DIV']);
+    // Test first instance
+    const host1 = new Host();
+    testRef(host1);
 
-    go(true);
-    queriedEl = container.firstElementChild;
-    assert.equal(queriedEl?.tagName, 'DIV');
-    assert.deepEqual(host.calls, ['DIV']);
+    // Test second instance
+    const host2 = new Host();
+    testRef(host2);
 
-    go(false);
-    queriedEl = container.firstElementChild;
-    assert.equal(queriedEl?.tagName, 'SPAN');
-    assert.deepEqual(host.calls, ['DIV', undefined, 'SPAN']);
-
-    go(true);
-    queriedEl = container.firstElementChild;
-    assert.equal(queriedEl?.tagName, 'DIV');
-    assert.deepEqual(host.calls, ['DIV', undefined, 'SPAN', undefined, 'DIV']);
+    // Test on first instance again
+    // (reset boolean to render SPAN, so we see an initial change
+    // back to DIV)
+    host1.bool = false;
+    host1.render();
+    // Add in an undefined call for the initial switch from SPAN back to DIV
+    testRef(host1, [...host1.calls, undefined]);
   });
 
   test('two refs', () => {


### PR DESCRIPTION
The `WeakMap` used to store the last element called to a given callback is keyed on the callback function. Since unbound LitElement class methods passed as callbacks will all have the same references between class instances, this will result in incorrect tracking of the last element per unique callback, given that callbacks called on different context's should be considered unique.

The change here uses nested WeakMaps to effectively double-key the lookup on both function _and_ context.

Fixes #2677.