### PR TITLE
[localize-tools] Keep expressions in attribute values for transform mode

### DIFF
--- a/.changeset/tender-bobcats-greet.md
+++ b/.changeset/tender-bobcats-greet.md
@@ -1,0 +1,5 @@
+---
+'@lit/localize-tools': patch
+---
+
+Fix issue with placing expressions as html attribute values in transform mode

--- a/packages/localize-tools/src/tests/transform.unit.test.ts
+++ b/packages/localize-tools/src/tests/transform.unit.test.ts
@@ -355,20 +355,70 @@ test('msg(string(<b>msg(string)</b>)) translated', () => {
 
 test('html(msg(string)) with msg as attr value', () => {
   checkTransform(
-    'html`Hello <b bar=${msg("world", {id: "bar"})}>${"World"}</b>!`;',
-    'html`Hello <b bar=${"world"}>World</b>!`;'
+    'html`Hello <b bar=${msg("World", {id: "bar"})}>${"World"}</b>!`;',
+    'html`Hello <b bar=${"World"}>World</b>!`;'
   );
 });
 
 test('html(msg(string)) with msg as attr value translated', () => {
   checkTransform(
     'html`Hello <b bar=${msg("world", {id: "bar"})}>${"World"}</b>!`;',
-    'html`Hello <b bar=${`mundo`}>World</b>!`;',
+    'html`Hello <b bar=${`Mundo`}>World</b>!`;',
     {
       messages: [
         {
           name: 'bar',
-          contents: ['mundo'],
+          contents: ['Mundo'],
+        },
+      ],
+    }
+  );
+});
+
+test('html(msg(string)) with multiple msg as attr value', () => {
+  checkTransform(
+    'html`<b foo=${msg("Hello", {id: "foo"})}>${"Hello"}</b>' +
+      '<b bar=${msg("World", {id: "bar"})}>${"World"}</b>!`;',
+    'html`<b foo=${"Hello"}>Hello</b><b bar=${"World"}>World</b>!`;'
+  );
+});
+
+test('html(msg(string)) with multiple msg as attr value translated', () => {
+  checkTransform(
+    'html`<b foo=${msg("Hello", {id: "foo"})}>${"Hello"}</b>' +
+      '<b bar=${msg("World", {id: "bar"})}>${"World"}</b>!`;',
+    'html`<b foo=${`Hola`}>Hello</b><b bar=${`Mundo`}>World</b>!`;',
+    {
+      messages: [
+        {
+          name: 'foo',
+          contents: ['Hola'],
+        },
+        {
+          name: 'bar',
+          contents: ['Mundo'],
+        },
+      ],
+    }
+  );
+});
+
+test('html(msg(string)) with msg as property attr value', () => {
+  checkTransform(
+    'html`Hello <b .bar=${msg("World", {id: "bar"})}>${"World"}</b>!`;',
+    'html`Hello <b .bar=${"World"}>World</b>!`;'
+  );
+});
+
+test('html(msg(string)) with msg as property attr value translated', () => {
+  checkTransform(
+    'html`Hello <b .bar=${msg("World", {id: "bar"})}>${"World"}</b>!`;',
+    'html`Hello <b .bar=${`Mundo`}>World</b>!`;',
+    {
+      messages: [
+        {
+          name: 'bar',
+          contents: ['Mundo'],
         },
       ],
     }

--- a/packages/localize-tools/src/tests/transform.unit.test.ts
+++ b/packages/localize-tools/src/tests/transform.unit.test.ts
@@ -353,6 +353,28 @@ test('msg(string(<b>msg(string)</b>)) translated', () => {
   );
 });
 
+test('html(msg(string)) with msg as attr value', () => {
+  checkTransform(
+    'html`Hello <b bar=${msg("world", {id: "bar"})}>${"World"}</b>!`;',
+    'html`Hello <b bar=${"world"}>World</b>!`;'
+  );
+});
+
+test('html(msg(string)) with msg as attr value translated', () => {
+  checkTransform(
+    'html`Hello <b bar=${msg("world", {id: "bar"})}>${"World"}</b>!`;',
+    'html`Hello <b bar=${`mundo`}>World</b>!`;',
+    {
+      messages: [
+        {
+          name: 'bar',
+          contents: ['mundo'],
+        },
+      ],
+    }
+  );
+});
+
 test('import * as litLocalize', () => {
   checkTransform(
     `

--- a/packages/localize-tools/testdata/build-transform-xliff/goldens/foo.ts
+++ b/packages/localize-tools/testdata/build-transform-xliff/goldens/foo.ts
@@ -83,3 +83,6 @@ msg(html`&lt;Hello<b>&lt;World &amp; Friends&gt;</b>!&gt;`);
 // Expressions as attribute values should stay as expressions
 html`Hello <b foo=${'World'}>World</b>`;
 html`Hello <b foo=${msg('World')}>World</b>`;
+html`<b foo=${msg('Hello')}>Hello</b><b bar=${msg('World')}>World</b>`;
+html`Hello <b .foo=${'World'}>World</b>`;
+html`Hello <b .foo=${msg('World')}>World</b>`;

--- a/packages/localize-tools/testdata/build-transform-xliff/goldens/foo.ts
+++ b/packages/localize-tools/testdata/build-transform-xliff/goldens/foo.ts
@@ -79,3 +79,7 @@ export class MyElement2 extends LitElement {
 
 // Escaped markup characters should remain escaped
 msg(html`&lt;Hello<b>&lt;World &amp; Friends&gt;</b>!&gt;`);
+
+// Expressions as attribute values should stay as expressions
+html`Hello <b foo=${'World'}>World</b>`;
+html`Hello <b foo=${msg('World')}>World</b>`;

--- a/packages/localize-tools/testdata/build-transform-xliff/goldens/tsout/en/foo.js
+++ b/packages/localize-tools/testdata/build-transform-xliff/goldens/tsout/en/foo.js
@@ -54,3 +54,6 @@ export class MyElement2 extends LitElement {
 }
 // Escaped markup characters should remain escaped
 html`&lt;Hello<b>&lt;World &amp; Friends&gt;</b>!&gt;`;
+// Expressions as attribute values should stay as expressions
+html`Hello <b foo=${'World'}>World</b>`;
+html`Hello <b foo=${'World'}>World</b>`;

--- a/packages/localize-tools/testdata/build-transform-xliff/goldens/tsout/en/foo.js
+++ b/packages/localize-tools/testdata/build-transform-xliff/goldens/tsout/en/foo.js
@@ -57,3 +57,6 @@ html`&lt;Hello<b>&lt;World &amp; Friends&gt;</b>!&gt;`;
 // Expressions as attribute values should stay as expressions
 html`Hello <b foo=${'World'}>World</b>`;
 html`Hello <b foo=${'World'}>World</b>`;
+html`<b foo=${'Hello'}>Hello</b><b bar=${'World'}>World</b>`;
+html`Hello <b .foo=${'World'}>World</b>`;
+html`Hello <b .foo=${'World'}>World</b>`;

--- a/packages/localize-tools/testdata/build-transform-xliff/goldens/tsout/es-419/foo.js
+++ b/packages/localize-tools/testdata/build-transform-xliff/goldens/tsout/es-419/foo.js
@@ -54,3 +54,6 @@ export class MyElement2 extends LitElement {
 }
 // Escaped markup characters should remain escaped
 html`&lt;Hola<b>&lt;Mundo &amp; Amigos&gt;</b>!&gt;`;
+// Expressions as attribute values should stay as expressions
+html`Hello <b foo=${'World'}>World</b>`;
+html`Hello <b foo=${`Mundo`}>World</b>`;

--- a/packages/localize-tools/testdata/build-transform-xliff/goldens/tsout/es-419/foo.js
+++ b/packages/localize-tools/testdata/build-transform-xliff/goldens/tsout/es-419/foo.js
@@ -57,3 +57,6 @@ html`&lt;Hola<b>&lt;Mundo &amp; Amigos&gt;</b>!&gt;`;
 // Expressions as attribute values should stay as expressions
 html`Hello <b foo=${'World'}>World</b>`;
 html`Hello <b foo=${`Mundo`}>World</b>`;
+html`<b foo=${'Hello'}>Hello</b><b bar=${`Mundo`}>World</b>`;
+html`Hello <b .foo=${'World'}>World</b>`;
+html`Hello <b .foo=${`Mundo`}>World</b>`;

--- a/packages/localize-tools/testdata/build-transform-xliff/goldens/tsout/zh_CN/foo.js
+++ b/packages/localize-tools/testdata/build-transform-xliff/goldens/tsout/zh_CN/foo.js
@@ -54,3 +54,6 @@ export class MyElement2 extends LitElement {
 }
 // Escaped markup characters should remain escaped
 html`&lt;Hello<b>&lt;World &amp; Friends&gt;</b>!&gt;`;
+// Expressions as attribute values should stay as expressions
+html`Hello <b foo=${'World'}>World</b>`;
+html`Hello <b foo=${'World'}>World</b>`;

--- a/packages/localize-tools/testdata/build-transform-xliff/goldens/tsout/zh_CN/foo.js
+++ b/packages/localize-tools/testdata/build-transform-xliff/goldens/tsout/zh_CN/foo.js
@@ -57,3 +57,6 @@ html`&lt;Hello<b>&lt;World &amp; Friends&gt;</b>!&gt;`;
 // Expressions as attribute values should stay as expressions
 html`Hello <b foo=${'World'}>World</b>`;
 html`Hello <b foo=${'World'}>World</b>`;
+html`<b foo=${'Hello'}>Hello</b><b bar=${'World'}>World</b>`;
+html`Hello <b .foo=${'World'}>World</b>`;
+html`Hello <b .foo=${'World'}>World</b>`;

--- a/packages/localize-tools/testdata/build-transform-xliff/input/foo.ts
+++ b/packages/localize-tools/testdata/build-transform-xliff/input/foo.ts
@@ -79,3 +79,7 @@ export class MyElement2 extends LitElement {
 
 // Escaped markup characters should remain escaped
 msg(html`&lt;Hello<b>&lt;World &amp; Friends&gt;</b>!&gt;`);
+
+// Expressions as attribute values should stay as expressions
+html`Hello <b foo=${"World"}>World</b>`;
+html`Hello <b foo=${msg("World")}>World</b>`;

--- a/packages/localize-tools/testdata/build-transform-xliff/input/foo.ts
+++ b/packages/localize-tools/testdata/build-transform-xliff/input/foo.ts
@@ -83,3 +83,6 @@ msg(html`&lt;Hello<b>&lt;World &amp; Friends&gt;</b>!&gt;`);
 // Expressions as attribute values should stay as expressions
 html`Hello <b foo=${"World"}>World</b>`;
 html`Hello <b foo=${msg("World")}>World</b>`;
+html`<b foo=${msg("Hello")}>Hello</b><b bar=${msg("World")}>World</b>`;
+html`Hello <b .foo=${"World"}>World</b>`;
+html`Hello <b .foo=${msg("World")}>World</b>`;


### PR DESCRIPTION
Fixes #2574

No longer subsume expressions into text if they follow a `=` with the assumption being they are placed as a value of a html attribute, allowing `lit-html` to parse them properly.

This PR also corrects an oversight from #2405 where we were returning the old `template` rather than `newTemplate` if we had a simple string literal after applying translation.
