### PR TITLE
Separate local and saucelabs tests

### DIFF
--- a/.github/workflows/sauce-ie11.yaml
+++ b/.github/workflows/sauce-ie11.yaml
@@ -43,4 +43,4 @@ jobs:
           SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
           BROWSERS: preset:sauce-ie11
         # Retry once automatically.
-        run: npm run test || npm run test
+        run: npm run test:remote || npm run test:remote

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "nuke": "rm -rf node_modules && npm install && lerna exec 'rm -rf node_modules' && lerna bootstrap && npm run clean",
     "upgrade": "rm -rf node_modules package-lock.json && npm install && lerna exec 'rm -rf node_modules package-lock.json' && lerna bootstrap && npm run clean",
     "test": "lerna run test --ignore lit --ignore tests --ignore @lit-labs/motion --concurrency 1 --stream",
+    "test:remote": "cd tests && npm run test",
     "prepare": "husky install",
     "changeset": "changeset",
     "version": "npm run changeset version && npm run update-version-vars",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint": "eslint \"**/*.{js,ts}\"",
     "nuke": "rm -rf node_modules && npm install && lerna exec 'rm -rf node_modules' && lerna bootstrap && npm run clean",
     "upgrade": "rm -rf node_modules package-lock.json && npm install && lerna exec 'rm -rf node_modules package-lock.json' && lerna bootstrap && npm run clean",
-    "test": "lerna run test --ignore lit --ignore lit-html --ignore lit-element --ignore @lit/reactive-element --ignore @lit-labs/motion --concurrency 1 --stream",
+    "test": "lerna run test --ignore lit --ignore tests --ignore @lit-labs/motion --concurrency 1 --stream",
     "prepare": "husky install",
     "changeset": "changeset",
     "version": "npm run changeset version && npm run update-version-vars",

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "npm run test:dev && npm run test:prod",
     "test:dev": "npx wtr",
-    "test:prod": "MODE=prod npm run test:dev",
+    "test:prod": "TEST_PROD_BUILD=true npm run test:dev",
     "test:watch": "npm run test:dev -- --watch"
   },
   "devDependencies": {

--- a/packages/tests/web-test-runner.config.js
+++ b/packages/tests/web-test-runner.config.js
@@ -163,9 +163,18 @@ const require = createRequire(import.meta.url);
 export default {
   rootDir: '../',
   // Note this file list can be overridden by wtr command-line arguments.
+  // Tests run by lerna should override command-line arguments.
+  // Sauce tests are sent in one go to reduce proxy attempts.
   files: [
     '../lit-html/development/**/*_test.(js|html)',
+    '../labs/observers/development/**/*_test.(js|html)',
+    '../labs/react/development/**/*_test.(js|html)',
+    '../labs/router/development/**/*_test.js',
+    '../labs/scoped-registry-mixin/development/**/*_test.(js|html)',
+    '../labs/ssr/development/**/*_test.(js|html)',
+    '../labs/task/development/**/*_test.(js|html)',
     '../lit-element/development/**/*_test.(js|html)',
+    '../lit-html/development/**/*_test.(js|html)',
     '../reactive-element/development/**/*_test.(js|html)',
   ],
   nodeResolve: true,


### PR DESCRIPTION
- use `tests/` dir to explicitly run tests sent to saucelabs
- add package.json command `tests:remote` to run saucelabs