### PR TITLE
remove build steps that don't affect saucelabs

### DIFF
--- a/.github/workflows/sauce-ie11.yaml
+++ b/.github/workflows/sauce-ie11.yaml
@@ -22,17 +22,11 @@ jobs:
           cache: 'npm'
           cache-dependency-path: '**/package-lock.json'
 
-      - name: Install playwright deps
-        run: npx playwright install-deps
-
       - name: NPM install
         run: npm ci
 
       - name: Lerna bootstrap
         run: npm run bootstrap
-
-      - name: Lint
-        run: npm run lint
 
       - name: Build
         run: npm run build

--- a/.github/workflows/sauce.yaml
+++ b/.github/workflows/sauce.yaml
@@ -22,17 +22,11 @@ jobs:
           cache: 'npm'
           cache-dependency-path: '**/package-lock.json'
 
-      - name: Install playwright deps
-        run: npx playwright install-deps
-
       - name: NPM install
         run: npm ci
 
       - name: Lerna bootstrap
         run: npm run bootstrap
-
-      - name: Lint
-        run: npm run lint
 
       - name: Build
         run: npm run build


### PR DESCRIPTION
Remove build steps that don't affect saucelabs tests.

There are no lint-ing requirements or playwright dependencies used in a saucelabs test.