### PR TITLE
[@tests] only run remote tests in sauce actions

### DIFF
--- a/.github/workflows/sauce-ie11.yaml
+++ b/.github/workflows/sauce-ie11.yaml
@@ -43,4 +43,6 @@ jobs:
           SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
           BROWSERS: preset:sauce-ie11
         # Retry once automatically.
-        run: npm run test || npm run test
+        run: |
+          cd packages/tests
+          npm run test || npm run test

--- a/.github/workflows/sauce-ie11.yaml
+++ b/.github/workflows/sauce-ie11.yaml
@@ -12,7 +12,9 @@ jobs:
     continue-on-error: true
 
     runs-on: ubuntu-latest
-
+    env:
+      BROWSERS: preset:sauce-ie11
+  
     steps:
       - uses: actions/checkout@v2
 
@@ -41,8 +43,16 @@ jobs:
         env:
           SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
           SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
-          BROWSERS: preset:sauce-ie11
         # Retry once automatically.
         run: |
           cd packages/tests
           npm run test || npm run test
+
+      - name: Test SSR
+        env:
+          SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
+          SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
+        # Retry once automatically.
+        run: |
+          cd packages/labs/ssr
+          npm run test:integration || npm run test:integration

--- a/.github/workflows/sauce.yaml
+++ b/.github/workflows/sauce.yaml
@@ -12,6 +12,8 @@ jobs:
     continue-on-error: true
 
     runs-on: ubuntu-latest
+    env:
+      BROWSERS: preset:sauce
 
     steps:
       - uses: actions/checkout@v2
@@ -41,7 +43,14 @@ jobs:
         env:
           SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
           SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
-          BROWSERS: preset:sauce
         run: |
           cd packages/tests
           npm run test
+
+      - name: Test SSR
+        env:
+          SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
+          SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
+        run: |
+          cd packages/labs/ssr
+          npm run test:integration

--- a/.github/workflows/sauce.yaml
+++ b/.github/workflows/sauce.yaml
@@ -42,4 +42,6 @@ jobs:
           SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
           SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
           BROWSERS: preset:sauce
-        run: npm run test
+        run: |
+          cd packages/tests
+          npm run test


### PR DESCRIPTION
Currently, tests are run in our sauce related github actions that do not involve sauce. Removing them greatly cuts down on our total github action usage.

This change points the `sauce` and `sauce-ie11` github actions to the `tests` package to run tests. Reason being, some tests like localize are not run as saucelabs tests. Others don't test in a browser.

As we gather more tests for saucelabs, they can be included in `web-test-runner.config.js`. If they're more involved or require a more complex setup, they can be added in a more itemized way for future jobs

For instance, SSR is a little involved. So we could add it to saucelabs tests with:

```
   - name: Test SSR
      run: |
        cd packages/labs/ssr
        npm run test:integration
```



