### PR TITLE
[@tests] remove playwright install for remote tests

### DIFF
--- a/.github/workflows/sauce-ie11.yaml
+++ b/.github/workflows/sauce-ie11.yaml
@@ -28,9 +28,6 @@ jobs:
       - name: Lerna bootstrap
         run: npm run bootstrap
 
-      - name: Lint
-        run: npm run lint
-
       - name: Build
         run: npm run build
 

--- a/.github/workflows/sauce-ie11.yaml
+++ b/.github/workflows/sauce-ie11.yaml
@@ -22,9 +22,6 @@ jobs:
           cache: 'npm'
           cache-dependency-path: '**/package-lock.json'
 
-      - name: Install playwright deps
-        run: npx playwright install-deps
-
       - name: NPM install
         run: npm ci
 

--- a/.github/workflows/sauce.yaml
+++ b/.github/workflows/sauce.yaml
@@ -28,9 +28,6 @@ jobs:
       - name: Lerna bootstrap
         run: npm run bootstrap
 
-      - name: Lint
-        run: npm run lint
-
       - name: Build
         run: npm run build
 

--- a/.github/workflows/sauce.yaml
+++ b/.github/workflows/sauce.yaml
@@ -22,9 +22,6 @@ jobs:
           cache: 'npm'
           cache-dependency-path: '**/package-lock.json'
 
-      - name: Install playwright deps
-        run: npx playwright install-deps
-
       - name: NPM install
         run: npm ci
 


### PR DESCRIPTION
Playwright is not used for saucelabs testing and does not need to be installed in the saucelabs github action.

This PR removes both the `playwright` job and the `lint` job. Neither are necessary for saucelabs runs