### PR TITLE
[labs/context] Removes use of WeakRef

### DIFF
--- a/.changeset/thin-ducks-camp.md
+++ b/.changeset/thin-ducks-camp.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/context': patch
+---
+
+Removed use of WeakRef in ContextRoot

--- a/packages/labs/context/src/lib/context-root.ts
+++ b/packages/labs/context/src/lib/context-root.ts
@@ -76,6 +76,10 @@ export class ContextRoot {
   private onContextRequest = (
     ev: ContextRequestEvent<ContextKey<unknown, unknown>>
   ) => {
+    // events that are not subscribing should not be captured
+    if (!ev.subscribe) {
+      return;
+    }
     // store a weakref to this element under the context key
     const request: PendingContextRequest = {
       element: ev.target as HTMLElement,

--- a/packages/labs/context/src/test/late-provider_test.ts
+++ b/packages/labs/context/src/test/late-provider_test.ts
@@ -20,6 +20,10 @@ class ContextConsumerElement extends LitElement {
   @property({type: Number})
   public value = 0;
 
+  @contextProvided({context: simpleContext})
+  @property({type: Number})
+  public onceValue = 0;
+
   protected render(): TemplateResult {
     return html`Value <span id="value">${this.value}</span>`;
   }
@@ -77,6 +81,7 @@ suite('late context provider', () => {
   test(`handles late upgrade properly`, async () => {
     // initially consumer has initial value
     assert.strictEqual(consumer.value, 0);
+    assert.strictEqual(consumer.onceValue, 0);
     // do upgrade
     customElements.define('late-context-provider', LateContextProviderElement);
     // await update of provider component
@@ -85,9 +90,13 @@ suite('late context provider', () => {
     await consumer.updateComplete;
     // should now have provided context
     assert.strictEqual(consumer.value, 1000);
+    // but only to the subscribed value
+    assert.strictEqual(consumer.onceValue, 0);
     // confirm subscription is established
     provider.value = 500;
     await consumer.updateComplete;
     assert.strictEqual(consumer.value, 500);
+    // and once was not updated
+    assert.strictEqual(consumer.onceValue, 0);
   });
 });


### PR DESCRIPTION
@justinfagnani realised this was using WeakRef unnecessarily.

The `ContextRoot` should only handle those requests which are intended to be subscribers to updates. Otherwise the semantics are somewhat lost of a one-time context request. By making ContextRoot only work for those context requests which intend to subscribe to future updates, we can remove WeakRef usage as the connected components will clean themselves up through disconnection. This also broadens browser support!