### PR TITLE
ts-transformers can support reactive getters

### DIFF
--- a/.changeset/thick-hotels-admire.md
+++ b/.changeset/thick-hotels-admire.md
@@ -1,0 +1,5 @@
+---
+'@lit/ts-transformers': patch
+---
+
+Fix reactive prop support for getters

--- a/packages/ts-transformers/src/internal/decorators/property.ts
+++ b/packages/ts-transformers/src/internal/decorators/property.ts
@@ -11,6 +11,30 @@ import type {LitClassContext} from '../lit-class-context.js';
 import type {MemberDecoratorVisitor} from '../visitor.js';
 
 /**
+ * Copies the comments and, optionally, leading blank lines from one node to
+ * another.
+ *
+ * @param fromNode Node from which to copy comments.
+ * @param toNode Node where comments should be copied to.
+ * @param blankLines (Default: false) Whether to preserve leading blank lines.
+ *   Useful for classmembers not moved to the constructor.
+ */
+const copyComments = (
+  fromNode: ts.Node,
+  toNode: ts.Node,
+  blankLines = false
+) => {
+  // Omit blank lines from the PreserveBlankLines transformer, because they
+  // usually look awkward in the constructor.
+  const nonBlankLineSyntheticComments = ts
+    .getSyntheticLeadingComments(fromNode)
+    ?.filter(
+      (comment) => blankLines || comment.text !== BLANK_LINE_PLACEHOLDER_COMMENT
+    );
+  ts.setSyntheticLeadingComments(toNode, nonBlankLineSyntheticComments);
+};
+
+/**
  * Transform:
  *
  *   @property({type: Number})
@@ -40,14 +64,14 @@ export class PropertyVisitor implements MemberDecoratorVisitor {
 
   visit(
     litClassContext: LitClassContext,
-    property: ts.ClassElement,
+    propertyOrGetter: ts.ClassElement,
     decorator: ts.Decorator
   ) {
-    const isGetter = ts.isGetAccessor(property);
-    if (!ts.isPropertyDeclaration(property) && !isGetter) {
+    const isGetter = ts.isGetAccessor(propertyOrGetter);
+    if (!ts.isPropertyDeclaration(propertyOrGetter) && !isGetter) {
       return;
     }
-    if (!ts.isIdentifier(property.name)) {
+    if (!ts.isIdentifier(propertyOrGetter.name)) {
       return;
     }
     if (!ts.isCallExpression(decorator.expression)) {
@@ -58,42 +82,36 @@ export class PropertyVisitor implements MemberDecoratorVisitor {
       return;
     }
     const options = this._augmentOptions(arg0);
-    const name = property.name.text;
+    const name = propertyOrGetter.name.text;
     const factory = this._factory;
 
-    if (isGetter && property.decorators) {
-      // Filter out the current decorator
-      let decorators: ts.Decorator[] | undefined = property.decorators.filter(
-        (dec) => dec !== decorator
-      );
-
-      // If there are no decorators prevent the tslib package from being
-      // imported by unassigning the decorators array.
-      if (decorators.length === 0) {
-        decorators = undefined;
-      }
-
+    if (isGetter) {
       // Decorators is readonly so clone the property.
       const getterWithoutDecorators = factory.createGetAccessorDeclaration(
-        decorators,
-        property.modifiers,
-        property.name,
-        property.parameters,
-        property.type,
-        property.body
+        undefined,
+        propertyOrGetter.modifiers,
+        propertyOrGetter.name,
+        propertyOrGetter.parameters,
+        propertyOrGetter.type,
+        propertyOrGetter.body
       );
 
+      copyComments(propertyOrGetter, getterWithoutDecorators, true);
+
       litClassContext.litFileContext.nodeReplacements.set(
-        property,
+        propertyOrGetter,
         getterWithoutDecorators
       );
-    } else if (!isGetter) {
+    } else {
       // Delete the member property
-      litClassContext.litFileContext.nodeReplacements.set(property, undefined);
+      litClassContext.litFileContext.nodeReplacements.set(
+        propertyOrGetter,
+        undefined
+      );
     }
     litClassContext.reactiveProperties.push({name, options});
 
-    if (!isGetter && property.initializer !== undefined) {
+    if (!isGetter && propertyOrGetter.initializer !== undefined) {
       const initializer = factory.createExpressionStatement(
         factory.createBinaryExpression(
           factory.createPropertyAccessExpression(
@@ -101,19 +119,11 @@ export class PropertyVisitor implements MemberDecoratorVisitor {
             factory.createIdentifier(name)
           ),
           factory.createToken(ts.SyntaxKind.EqualsToken),
-          property.initializer
+          propertyOrGetter.initializer
         )
       );
-      ts.setTextRange(initializer, property);
-      // Omit blank lines from the PreserveBlankLines transformer, because they
-      // usually look awkward in the constructor.
-      const nonBlankLineSyntheticComments = ts
-        .getSyntheticLeadingComments(property)
-        ?.filter((comment) => comment.text !== BLANK_LINE_PLACEHOLDER_COMMENT);
-      ts.setSyntheticLeadingComments(
-        initializer,
-        nonBlankLineSyntheticComments
-      );
+      ts.setTextRange(initializer, propertyOrGetter);
+      copyComments(propertyOrGetter, initializer);
       litClassContext.extraConstructorStatements.push(initializer);
     }
   }

--- a/packages/ts-transformers/src/internal/decorators/property.ts
+++ b/packages/ts-transformers/src/internal/decorators/property.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import ts, {factory} from 'typescript';
+import ts from 'typescript';
 import {BLANK_LINE_PLACEHOLDER_COMMENT} from '../../preserve-blank-lines.js';
 
 import type {LitClassContext} from '../lit-class-context.js';
@@ -59,6 +59,7 @@ export class PropertyVisitor implements MemberDecoratorVisitor {
     }
     const options = this._augmentOptions(arg0);
     const name = property.name.text;
+    const factory = this._factory;
 
     if (isGetter && property.decorators) {
       // Filter out the current decorator
@@ -93,7 +94,6 @@ export class PropertyVisitor implements MemberDecoratorVisitor {
     litClassContext.reactiveProperties.push({name, options});
 
     if (!isGetter && property.initializer !== undefined) {
-      const factory = this._factory;
       const initializer = factory.createExpressionStatement(
         factory.createBinaryExpression(
           factory.createPropertyAccessExpression(

--- a/packages/ts-transformers/src/tests/idiomatic-decorators-test.ts
+++ b/packages/ts-transformers/src/tests/idiomatic-decorators-test.ts
@@ -127,6 +127,11 @@ const tests = (test: uvu.Test<uvu.Context>, options: ts.CompilerOptions) => {
 
       @property({type: Boolean, reflect: true})
       reactiveInitializedBool = false;
+
+      @property({type: Boolean})
+      get reactiveGetter() {
+        return false;
+      }
     }
     `;
 
@@ -141,6 +146,7 @@ const tests = (test: uvu.Test<uvu.Context>, options: ts.CompilerOptions) => {
           reactiveUninitializedObj: {type: Object},
           reactiveInitializedNum: {type: Number, attribute: false},
           reactiveInitializedBool: {type: Boolean, reflect: true},
+          reactiveGetter: {type: Boolean},
         };
 
         constructor() {
@@ -151,11 +157,14 @@ const tests = (test: uvu.Test<uvu.Context>, options: ts.CompilerOptions) => {
           this.reactiveInitializedStr = "foo";
           this.reactiveInitializedNum = 42;
           this.reactiveInitializedBool = false;
-        }
+      }
 
         nonReactiveInitialized = 123;
 
         nonReactiveUninitialized;
+        get reactiveGetter() {
+          return false;
+        }
       }
       `;
     } else {
@@ -174,12 +183,16 @@ const tests = (test: uvu.Test<uvu.Context>, options: ts.CompilerOptions) => {
           this.reactiveInitializedNum = 42;
           this.reactiveInitializedBool = false;
         }
+        get reactiveGetter() {
+          return false;
+        }
       }
       MyElement.properties = {
         reactiveInitializedStr: {},
         reactiveUninitializedObj: {type: Object},
         reactiveInitializedNum: {type: Number, attribute: false},
         reactiveInitializedBool: {type: Boolean, reflect: true},
+        reactiveGetter: {type: Boolean},
       };
       `;
     }
@@ -208,6 +221,11 @@ const tests = (test: uvu.Test<uvu.Context>, options: ts.CompilerOptions) => {
       @property({type: Boolean, reflect: true})
       reactiveInitializedBool = false;
 
+      @property({type: Boolean})
+      get reactiveGetter() {
+        return false;
+      }
+
       constructor() {
         super();
       }
@@ -225,11 +243,15 @@ const tests = (test: uvu.Test<uvu.Context>, options: ts.CompilerOptions) => {
           reactiveUninitializedObj: {type: Object},
           reactiveInitializedNum: {type: Number, attribute: false},
           reactiveInitializedBool: {type: Boolean, reflect: true},
+          reactiveGetter: {type: Boolean},
         };
 
         nonReactiveInitialized = 123;
 
         nonReactiveUninitialized;
+        get reactiveGetter() {
+          return false;
+        }
 
         constructor() {
           super();
@@ -244,6 +266,10 @@ const tests = (test: uvu.Test<uvu.Context>, options: ts.CompilerOptions) => {
       import {LitElement} from 'lit';
 
       class MyElement extends LitElement {
+        get reactiveGetter() {
+          return false;
+        }
+
         constructor() {
           super();
 
@@ -258,6 +284,51 @@ const tests = (test: uvu.Test<uvu.Context>, options: ts.CompilerOptions) => {
         reactiveUninitializedObj: {type: Object},
         reactiveInitializedNum: {type: Number, attribute: false},
         reactiveInitializedBool: {type: Boolean, reflect: true},
+        reactiveGetter: {type: Boolean},
+      };
+      `;
+    }
+    checkTransform(input, expected, options);
+  });
+
+  test('@property (do not create constructor if just getter)', () => {
+    const input = `
+    import {LitElement} from 'lit';
+    import {property} from 'lit/decorators.js';
+
+    class MyElement extends LitElement {
+      @property({type: Boolean})
+      get reactiveGetter() {
+        return false;
+      }
+    }
+    `;
+
+    let expected;
+    if (options.useDefineForClassFields) {
+      expected = `
+      import {LitElement} from 'lit';
+
+      class MyElement extends LitElement {
+        static properties = {
+          reactiveGetter: {type: Boolean},
+        };
+        get reactiveGetter() {
+          return false;
+        }
+      }
+      `;
+    } else {
+      expected = `
+      import {LitElement} from 'lit';
+
+      class MyElement extends LitElement {
+        get reactiveGetter() {
+          return false;
+        }
+      }
+      MyElement.properties = {
+        reactiveGetter: {type: Boolean},
       };
       `;
     }

--- a/packages/ts-transformers/src/tests/idiomatic-decorators-test.ts
+++ b/packages/ts-transformers/src/tests/idiomatic-decorators-test.ts
@@ -128,8 +128,16 @@ const tests = (test: uvu.Test<uvu.Context>, options: ts.CompilerOptions) => {
       @property({type: Boolean, reflect: true})
       reactiveInitializedBool = false;
 
+      /**
+       * Reactive getter description.
+       */
       @property({type: Boolean})
       get reactiveGetter() {
+        return false;
+      }
+
+      @property({type: Boolean})
+      get reactiveGetterNoComment() {
         return false;
       }
     }
@@ -147,6 +155,7 @@ const tests = (test: uvu.Test<uvu.Context>, options: ts.CompilerOptions) => {
           reactiveInitializedNum: {type: Number, attribute: false},
           reactiveInitializedBool: {type: Boolean, reflect: true},
           reactiveGetter: {type: Boolean},
+          reactiveGetterNoComment: {type: Boolean},
         };
 
         constructor() {
@@ -162,7 +171,15 @@ const tests = (test: uvu.Test<uvu.Context>, options: ts.CompilerOptions) => {
         nonReactiveInitialized = 123;
 
         nonReactiveUninitialized;
+
+        /**
+         * Reactive getter description.
+         */
         get reactiveGetter() {
+          return false;
+        }
+
+        get reactiveGetterNoComment() {
           return false;
         }
       }
@@ -183,7 +200,15 @@ const tests = (test: uvu.Test<uvu.Context>, options: ts.CompilerOptions) => {
           this.reactiveInitializedNum = 42;
           this.reactiveInitializedBool = false;
         }
+
+        /**
+         * Reactive getter description.
+         */
         get reactiveGetter() {
+          return false;
+        }
+
+        get reactiveGetterNoComment() {
           return false;
         }
       }
@@ -193,6 +218,7 @@ const tests = (test: uvu.Test<uvu.Context>, options: ts.CompilerOptions) => {
         reactiveInitializedNum: {type: Number, attribute: false},
         reactiveInitializedBool: {type: Boolean, reflect: true},
         reactiveGetter: {type: Boolean},
+        reactiveGetterNoComment: {type: Boolean},
       };
       `;
     }
@@ -221,8 +247,16 @@ const tests = (test: uvu.Test<uvu.Context>, options: ts.CompilerOptions) => {
       @property({type: Boolean, reflect: true})
       reactiveInitializedBool = false;
 
+      /**
+       * Reactive getter description.
+       */
       @property({type: Boolean})
       get reactiveGetter() {
+        return false;
+      }
+
+      @property({type: Boolean})
+      get reactiveGetterNoComment() {
         return false;
       }
 
@@ -244,12 +278,21 @@ const tests = (test: uvu.Test<uvu.Context>, options: ts.CompilerOptions) => {
           reactiveInitializedNum: {type: Number, attribute: false},
           reactiveInitializedBool: {type: Boolean, reflect: true},
           reactiveGetter: {type: Boolean},
+          reactiveGetterNoComment: {type: Boolean},
         };
 
         nonReactiveInitialized = 123;
 
         nonReactiveUninitialized;
+
+        /**
+         * Reactive getter description.
+         */
         get reactiveGetter() {
+          return false;
+        }
+
+        get reactiveGetterNoComment() {
           return false;
         }
 
@@ -266,7 +309,14 @@ const tests = (test: uvu.Test<uvu.Context>, options: ts.CompilerOptions) => {
       import {LitElement} from 'lit';
 
       class MyElement extends LitElement {
+        /**
+         * Reactive getter description.
+         */
         get reactiveGetter() {
+          return false;
+        }
+
+        get reactiveGetterNoComment() {
           return false;
         }
 
@@ -285,6 +335,7 @@ const tests = (test: uvu.Test<uvu.Context>, options: ts.CompilerOptions) => {
         reactiveInitializedNum: {type: Number, attribute: false},
         reactiveInitializedBool: {type: Boolean, reflect: true},
         reactiveGetter: {type: Boolean},
+        reactiveGetterNoComment: {type: Boolean},
       };
       `;
     }


### PR DESCRIPTION
Adds support for

```ts
import {LitElement} from 'lit';
import {property} from 'lit/decorators.js';

class MyElement extends LitElement {
  @property({type: Boolean})
  get reactiveGetter() {
    return false;
  }
}
```

transforming into:

```ts
import {LitElement} from 'lit';

class MyElement extends LitElement {
  static properties = {
    reactiveGetter: {type: Boolean},
  };
  get reactiveGetter() {
    return false;
  }
}
```