### PR TITLE
[analyzer] Initial support for finding LitElement declarations

### DIFF
--- a/.changeset/dull-panthers-burn.md
+++ b/.changeset/dull-panthers-burn.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/analyzer': patch
+---
+
+Initial support for finding LitElement declarations

--- a/packages/labs/analyzer/src/lib/analyzer.ts
+++ b/packages/labs/analyzer/src/lib/analyzer.ts
@@ -78,18 +78,19 @@ export class Analyzer {
 
     for (const statement of sourceFile.statements) {
       if (ts.isClassDeclaration(statement)) {
+        const name = statement.name?.text;
         if (this.isLitElement(statement)) {
           module.declarations.push(
             new LitElementDeclaration({
               tagname: getTagName(statement),
-              name: statement.name?.getText(),
+              name,
               node: statement,
             })
           );
         } else {
           module.declarations.push(
             new ClassDeclaration({
-              name: statement.name?.getText(),
+              name,
               node: statement,
             })
           );
@@ -109,7 +110,7 @@ export class Analyzer {
     return (
       this._isLitElementModule(node.getSourceFile()) &&
       ts.isClassDeclaration(node) &&
-      node.name?.getText() === 'LitElement'
+      node.name?.text === 'LitElement'
     );
   };
 
@@ -139,8 +140,7 @@ const getTagName = (declaration: ts.ClassDeclaration) => {
     isCustomElementDecorator
   );
   if (
-    customElementDecorator !== undefined &&
-    customElementDecorator.expression.arguments.length === 1 &&
+    customElementDecorator?.expression.arguments.length === 1 &&
     ts.isStringLiteral(customElementDecorator.expression.arguments[0])
   ) {
     tagname = customElementDecorator.expression.arguments[0].text;
@@ -153,7 +153,7 @@ const isCustomElementDecorator = (
 ): decorator is CustomElementDecorator =>
   ts.isCallExpression(decorator.expression) &&
   ts.isIdentifier(decorator.expression.expression) &&
-  decorator.expression.expression.getText() === 'customElement';
+  decorator.expression.expression.text === 'customElement';
 
 /**
  * A narrower type for ts.Decorator that represents the shape of an analyzable

--- a/packages/labs/analyzer/src/lib/model.ts
+++ b/packages/labs/analyzer/src/lib/model.ts
@@ -47,3 +47,27 @@ export class ClassDeclaration {
     this.node = init.node;
   }
 }
+
+interface LitElementDeclarationInit extends ClassDeclarationInit {
+  tagname: string | undefined;
+}
+
+export class LitElementDeclaration extends ClassDeclaration {
+  readonly isLitElement = true;
+
+  /**
+   * The element's tag name, if one is associated with this class declaration,
+   * such as with a `@customElement()` decorator or `customElements.define()`
+   * call int he same module.
+   *
+   * This is undefined if the element has no associated custom element
+   * registration in the same module. This class might be intended for use as a
+   * base class or with scoped custom element registries.
+   */
+  readonly tagname: string | undefined;
+
+  constructor(init: LitElementDeclarationInit) {
+    super(init);
+    this.tagname = init.tagname;
+  }
+}

--- a/packages/labs/analyzer/src/test/analyzer_test.ts
+++ b/packages/labs/analyzer/src/test/analyzer_test.ts
@@ -13,6 +13,7 @@ import {fileURLToPath} from 'url';
 
 import {Analyzer} from '../lib/analyzer.js';
 import {AbsolutePath} from '../lib/paths.js';
+import {LitElementDeclaration} from '../lib/model.js';
 
 const test = suite<{analyzer: Analyzer; packagePath: AbsolutePath}>(
   'Basic Analyzer tests'
@@ -27,7 +28,7 @@ test.before((ctx) => {
 
 test('Reads project files', ({analyzer, packagePath}) => {
   const rootFileNames = analyzer.program.getRootFileNames();
-  assert.equal(rootFileNames.length, 3);
+  assert.equal(rootFileNames.length, 4);
 
   const elementAPath = path.resolve(packagePath, 'src/element-a.ts');
   const sourceFile = analyzer.program.getSourceFile(elementAPath);
@@ -60,14 +61,28 @@ test('isLitElement returns false for non-LitElement', ({
   assert.equal(analyzer.isLitElement(notLitDeclaration), false);
 });
 
-test('analyzePackage() finds class declarations', ({analyzer}) => {
+test('Analyzer finds class declarations', ({analyzer}) => {
   const result = analyzer.analyzePackage();
-  assert.equal(result.modules.length, 3);
+  const elementAModule = result.modules.find(
+    (m) => m.path === 'src/class-a.ts'
+  );
+  assert.equal(elementAModule?.declarations.length, 1);
+  assert.equal(elementAModule?.declarations[0].name, 'ClassA');
+});
+
+test('Analyzer finds LitElement declarations', ({analyzer}) => {
+  const result = analyzer.analyzePackage();
   const elementAModule = result.modules.find(
     (m) => m.path === 'src/element-a.ts'
   );
   assert.equal(elementAModule?.declarations.length, 1);
-  assert.equal(elementAModule?.declarations[0].name, 'ElementA');
+  const decl = elementAModule!.declarations[0];
+  assert.equal(decl.name, 'ElementA');
+  assert.instance(decl, LitElementDeclaration);
+  assert.equal((decl as LitElementDeclaration).isLitElement, true);
+
+  // TODO (justinfagnani): test for customElements.define()
+  assert.equal((decl as LitElementDeclaration).tagname, 'element-a');
 });
 
 test.run();

--- a/packages/labs/analyzer/src/test/analyzer_test.ts
+++ b/packages/labs/analyzer/src/test/analyzer_test.ts
@@ -28,7 +28,7 @@ test.before((ctx) => {
 
 test('Reads project files', ({analyzer, packagePath}) => {
   const rootFileNames = analyzer.program.getRootFileNames();
-  assert.equal(rootFileNames.length, 4);
+  assert.equal(rootFileNames.length, 5);
 
   const elementAPath = path.resolve(packagePath, 'src/element-a.ts');
   const sourceFile = analyzer.program.getSourceFile(elementAPath);
@@ -70,19 +70,32 @@ test('Analyzer finds class declarations', ({analyzer}) => {
   assert.equal(elementAModule?.declarations[0].name, 'ClassA');
 });
 
-test('Analyzer finds LitElement declarations', ({analyzer}) => {
+test('Analyzer finds named LitElement declarations', ({analyzer}) => {
   const result = analyzer.analyzePackage();
   const elementAModule = result.modules.find(
     (m) => m.path === 'src/element-a.ts'
   );
-  assert.equal(elementAModule?.declarations.length, 1);
-  const decl = elementAModule!.declarations[0];
-  assert.equal(decl.name, 'ElementA');
-  assert.instance(decl, LitElementDeclaration);
-  assert.equal((decl as LitElementDeclaration).isLitElement, true);
+  assert.ok(elementAModule);
+  assert.equal(elementAModule.declarations.length, 1);
+  const elementA = elementAModule.declarations[0];
+  assert.equal(elementA.name, 'ElementA');
+  assert.instance(elementA, LitElementDeclaration);
+  assert.equal((elementA as LitElementDeclaration).isLitElement, true);
 
   // TODO (justinfagnani): test for customElements.define()
-  assert.equal((decl as LitElementDeclaration).tagname, 'element-a');
+  assert.equal((elementA as LitElementDeclaration).tagname, 'element-a');
+});
+
+test('Analyzer finds unnamed LitElement declarations', ({analyzer}) => {
+  const result = analyzer.analyzePackage();
+  const defaultElementModule = result.modules.find(
+    (m) => m.path === 'src/default-element.ts'
+  );
+  assert.ok(defaultElementModule);
+  assert.equal(defaultElementModule.declarations.length, 1);
+  const defaultElement = defaultElementModule.declarations[0];
+  assert.equal(defaultElement.name, undefined);
+  assert.equal((defaultElement as LitElementDeclaration).tagname, undefined);
 });
 
 test.run();

--- a/packages/labs/analyzer/test-files/basic-elements/src/class-a.ts
+++ b/packages/labs/analyzer/test-files/basic-elements/src/class-a.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+export class ClassA {
+  foo = 1;
+}

--- a/packages/labs/analyzer/test-files/basic-elements/src/default-element.ts
+++ b/packages/labs/analyzer/test-files/basic-elements/src/default-element.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {LitElement} from 'lit';
+
+export default class extends LitElement {}


### PR DESCRIPTION
This only supports getting the tag name from the `customElement` decorator. I added a TODO for finding `customElement.define()` calls. I want to mirror the custom elements manifest approach of allowing these to be separate, where the `customElement.define()` calls are considered a type of "export" so that you could have more than one, but for many cases it'll be very useful to understand that a class is intended to have a single specific tag name.