### PR TITLE
Changeset cleanup

### DIFF
--- a/.changeset/perfect-jokes-brush.md
+++ b/.changeset/perfect-jokes-brush.md
@@ -1,5 +1,0 @@
----
-'@lit-labs/cli': patch
----
-
-Initial implementation

--- a/.changeset/thin-ducks-camp.md
+++ b/.changeset/thin-ducks-camp.md
@@ -1,5 +1,0 @@
----
-'@lit-labs/context': patch
----
-
-Removed use of WeakRef in ContextRoot

--- a/packages/labs/context/package-lock.json
+++ b/packages/labs/context/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@lit-labs/context",
-	"version": "1.0.0-pre.1",
+	"version": "0.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@lit-labs/context",
-			"version": "1.0.0-pre.1",
+			"version": "0.0.0",
 			"license": "BSD-3-Clause",
 			"devDependencies": {
 				"@esm-bundle/chai": "^4.1.5",

--- a/packages/labs/context/package.json
+++ b/packages/labs/context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lit-labs/context",
-  "version": "1.0.0-pre.1",
+  "version": "0.0.0",
   "description": "Helpers and controllers for using Context protocol",
   "license": "BSD-3-Clause",
   "homepage": "https://lit.dev/",


### PR DESCRIPTION
- Remove cli changeset so it doesn't get version bumped.
- Remove extra patch note for labs/context so we just have a single "initial release" line.