### PR TITLE
[@lit-labs/context]: fix(#2839): lower target version

### DIFF
--- a/.changeset/famous-dots-dance.md
+++ b/.changeset/famous-dots-dance.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/context': patch
+---
+
+lower target js version

--- a/packages/labs/context/tsconfig.json
+++ b/packages/labs/context/tsconfig.json
@@ -3,7 +3,7 @@
     "composite": true,
     "target": "es2019",
     "module": "es2015",
-    "lib": ["es2020", "DOM", "DOM.Iterable"],
+    "lib": ["es2021", "DOM", "DOM.Iterable"],
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,

--- a/packages/labs/context/tsconfig.json
+++ b/packages/labs/context/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
     "composite": true,
-    "target": "es2021",
+    "target": "es2019",
     "module": "es2015",
-    "lib": ["es2021", "DOM", "DOM.Iterable"],
+    "lib": ["es2020", "DOM", "DOM.Iterable"],
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,


### PR DESCRIPTION
Fixes #2839

I tried using the context API.

One problem I met is that there are optional chaining operators in the code (?.) which fails at runtime in environments that do not support it.

Since lit is transpiled to es2019, I lowered `@lit-labs/context` to the same version. This ensures tha the dependency won't require additional transpiling step.