### PR TITLE
Remove private Lit 2 migration helpers

### DIFF
--- a/.changeset/swift-months-double.md
+++ b/.changeset/swift-months-double.md
@@ -1,0 +1,6 @@
+---
+'lit-html': patch
+'lit': patch
+---
+
+Remove private Lit 2 migration helpers: `INTERNAL` and `clearContainerForLit2MigrationOnly`. This logic is no longer depended on.

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -207,13 +207,6 @@ const debugLogEvent = DEV_MODE
 // called.
 let debugLogRenderId = 0;
 
-/**
- * `true` if we're building for google3 with temporary back-compat helpers.
- * This export is not present in prod builds.
- * @internal
- */
-export const INTERNAL = true;
-
 let issueWarning: (code: string, warning: string) => void;
 
 if (DEV_MODE) {
@@ -615,18 +608,6 @@ export interface RenderOptions {
 }
 
 /**
- * Internally we can export this interface and change the type of
- * render()'s options.
- */
-interface InternalRenderOptions extends RenderOptions {
-  /**
-   * An internal-only migration flag
-   * @internal
-   */
-  clearContainerForLit2MigrationOnly?: boolean;
-}
-
-/**
  * Renders a value, usually a lit-html TemplateResult, to the container.
  * @param value
  * @param container
@@ -659,20 +640,6 @@ export const render = (
   });
   if (part === undefined) {
     const endNode = options?.renderBefore ?? null;
-    // Internal modification: don't clear container to match lit-html 2.0
-    if (
-      INTERNAL &&
-      (options as InternalRenderOptions)?.clearContainerForLit2MigrationOnly ===
-        true
-    ) {
-      let n = container.firstChild;
-      // Clear only up to the `endNode` aka `renderBefore` node.
-      while (n && n !== endNode) {
-        const next = n.nextSibling;
-        n.remove();
-        n = next;
-      }
-    }
     // This property needs to remain unminified.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (partOwnerNode as any)['_$litPart$'] = part = new ChildPart(

--- a/packages/lit-html/src/test/lit-html_test.ts
+++ b/packages/lit-html/src/test/lit-html_test.ts
@@ -49,10 +49,6 @@ const isIe = ua.indexOf('Trident/') > 0;
 // We don't have direct access to DEV_MODE, but this is a good enough
 // proxy.
 const DEV_MODE = render.setSanitizer != null;
-/**
- * litHtmlLib.INTERNAL is not exported in prod mode
- */
-const INTERNAL = litHtmlLib.INTERNAL === true;
 
 class FireEventDirective extends Directive {
   render() {
@@ -3195,9 +3191,7 @@ suite('lit-html', () => {
       } as RenderOptions);
       assert.equal(
         stripExpressionComments(container.innerHTML),
-        INTERNAL
-          ? `<p>HELLO</p>${remainingHtml}`
-          : `${clearedHtml}<p>HELLO</p>${remainingHtml}`
+        `${clearedHtml}<p>HELLO</p>${remainingHtml}`
       );
     });
   });

--- a/packages/lit-html/src/test/lit-html_test.ts
+++ b/packages/lit-html/src/test/lit-html_test.ts
@@ -18,7 +18,6 @@ import {
   Part,
   CompiledTemplate,
 } from '../lit-html.js';
-import * as litHtmlLib from '../lit-html.js';
 
 import {
   directive,

--- a/packages/lit-html/src/test/lit-html_test.ts
+++ b/packages/lit-html/src/test/lit-html_test.ts
@@ -3178,20 +3178,4 @@ suite('lit-html', () => {
       assertNoWarning();
     });
   });
-
-  suite('internal', () => {
-    test('clearContainerForLit2MigrationOnly', () => {
-      const clearedHtml = `<div>TEST 1</div><div>TEST 2</div>`;
-      const remainingHtml = `<div class="renderBefore">REMAIN 1</div><div>REMAIN 2</div>`;
-      container.innerHTML = `${clearedHtml}${remainingHtml}`;
-      render(html`<p>HELLO</p>`, container, {
-        clearContainerForLit2MigrationOnly: true,
-        renderBefore: container.querySelector('.renderBefore'),
-      } as RenderOptions);
-      assert.equal(
-        stripExpressionComments(container.innerHTML),
-        `${clearedHtml}<p>HELLO</p>${remainingHtml}`
-      );
-    });
-  });
 });

--- a/rollup-common.js
+++ b/rollup-common.js
@@ -379,7 +379,6 @@ export function litProdConfig({
             'const ENABLE_EXTRA_SECURITY_HOOKS = false',
           'const ENABLE_SHADYDOM_NOPATCH = true':
             'const ENABLE_SHADYDOM_NOPATCH = false',
-          'export const INTERNAL = true': 'const INTERNAL = false',
         }),
         // This plugin automatically composes the existing TypeScript -> raw JS
         // sourcemap with the raw JS -> minified JS one that we're generating here.
@@ -448,12 +447,10 @@ const litMonoBundleConfig = ({
         'const ENABLE_EXTRA_SECURITY_HOOKS = false',
       'const ENABLE_SHADYDOM_NOPATCH = true':
         'const ENABLE_SHADYDOM_NOPATCH = false',
-      'export const INTERNAL = true': 'const INTERNAL = false',
       // For downleveled ES5 build of polyfill-support
       'var DEV_MODE = true': 'var DEV_MODE = false',
       'var ENABLE_EXTRA_SECURITY_HOOKS = true':
         'var ENABLE_EXTRA_SECURITY_HOOKS = false',
-      'var INTERNAL = true': 'var INTERNAL = false',
       'var ENABLE_SHADYDOM_NOPATCH = true':
         'var ENABLE_SHADYDOM_NOPATCH = false',
     }),


### PR DESCRIPTION
### Context

While migrating internal to Lit 2, we had these additional options to change how the `render` function behaved. However these are no longer required as they are not referenced internally.

### Testing

Tested internally with a TGP using the same change, and checking for all references of `INTERNAL` and `clearContainerForLit2MigrationOnly`. Manually checked that copy.bara wouldn't need changes.

I also removed a unit test that was testing the `INTERNAL` and `clearContainerForLit2MigrationOnly` option behavior.