### PR TITLE
[@lit-labs/router] API for a fallback route

### DIFF
--- a/.changeset/fluffy-zebras-sniff.md
+++ b/.changeset/fluffy-zebras-sniff.md
@@ -2,4 +2,6 @@
 '@lit-labs/router': patch
 ---
 
-Add an optional `fallbackRoute` param to the Routes and Router class.
+Add `fallback` route option to the Routes and Router class. The fallback route
+will always be matched if none of the `routes` match, and implicitly matches to
+the path `/*`.

--- a/.changeset/fluffy-zebras-sniff.md
+++ b/.changeset/fluffy-zebras-sniff.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/router': patch
+---
+
+Add an optional `fallbackRoute` param to the Routes and Router class.

--- a/packages/labs/router/src/routes.ts
+++ b/packages/labs/router/src/routes.ts
@@ -125,11 +125,11 @@ export class Routes implements ReactiveController {
   constructor(
     host: ReactiveControllerHost & HTMLElement,
     routes: Array<RouteConfig>,
-    fallback?: BaseRouteConfig
+    options?: {fallback?: BaseRouteConfig}
   ) {
     (this._host = host).addController(this);
     this.routes = [...routes];
-    this.fallback = fallback;
+    this.fallback = options?.fallback;
   }
 
   /**

--- a/packages/labs/router/src/routes.ts
+++ b/packages/labs/router/src/routes.ts
@@ -88,7 +88,7 @@ export class Routes implements ReactiveController {
   /**
    * A fallback route that is always matched after {@link routes}.
    */
-  readonly fallbackRoute?: RouteConfig;
+  private readonly fallbackRoute?: RouteConfig;
 
   /*
    * The current set of child Routes controllers. These are connected via

--- a/packages/labs/router/src/test/router_test.ts
+++ b/packages/labs/router/src/test/router_test.ts
@@ -6,6 +6,10 @@
 
 import {assert} from '@esm-bundle/chai';
 import type {Test1, Child1, Child2} from './router_test_code.js';
+import type {RouteConfig, PathRouteConfig} from '../routes.js';
+
+const isPathRouteConfig = (route: RouteConfig): route is PathRouteConfig =>
+  route.hasOwnProperty('path');
 
 const canTest =
   window.ShadowRoot &&
@@ -162,6 +166,12 @@ const canTest =
     contentDocument!.body.append(el);
     await el.updateComplete;
 
+    assert.isFalse(
+      el._router.routes.some(
+        (r) => isPathRouteConfig(r) && r.path === '/server-route'
+      )
+    );
+
     //
     // Fallback
     //
@@ -169,10 +179,23 @@ const canTest =
     // '/server-route' is not pre-configured, is dynamically installed
     await el._router.goto('/server-route');
 
+    assert.isTrue(
+      el._router.routes.some(
+        (r) => isPathRouteConfig(r) && r.path === '/server-route'
+      )
+    );
+
     await el.updateComplete;
     assert.include(
       stripExpressionComments(el.shadowRoot!.innerHTML),
       '<h2>Server</h2>'
+    );
+
+    await el._router.goto('/404');
+    await el.updateComplete;
+    assert.include(
+      stripExpressionComments(el.shadowRoot!.innerHTML),
+      '<h2>Not Found</h2>'
     );
   });
 });

--- a/packages/labs/router/src/test/router_test_code.ts
+++ b/packages/labs/router/src/test/router_test_code.ts
@@ -20,37 +20,39 @@ export class Test1 extends LitElement {
       {path: '/child2/*', render: () => html`<child-2></child-2>`},
     ],
     {
-      render: (params: {[key: string]: string | undefined}) =>
-        html`<h2>Not Found</h2>
-          ${params[0]}`,
-      enter: async (params: {[key: string]: string | undefined}) => {
-        // This fallback route will asynchronously install a /server-route
-        // route when the path is /server-route. This simulates checking a
-        // server for a route with an API call then installing it on the client
-        // if it exists.
+      fallback: {
+        render: (params: {[key: string]: string | undefined}) =>
+          html`<h2>Not Found</h2>
+            ${params[0]}`,
+        enter: async (params: {[key: string]: string | undefined}) => {
+          // This fallback route will asynchronously install a /server-route
+          // route when the path is /server-route. This simulates checking a
+          // server for a route with an API call then installing it on the client
+          // if it exists.
 
-        const path = params[0];
-        if (path !== 'server-route') {
-          return true;
-        }
+          const path = params[0];
+          if (path !== 'server-route') {
+            return true;
+          }
 
-        // force the function to take a microtask
-        await 0;
-        const {routes} = this._router;
+          // force the function to take a microtask
+          await 0;
+          const {routes} = this._router;
 
-        // Dynamically insert a new route.
-        routes.push({
-          path: '/server-route',
-          render: () => html`<h2>Server</h2>`,
-        });
+          // Dynamically insert a new route.
+          routes.push({
+            path: '/server-route',
+            render: () => html`<h2>Server</h2>`,
+          });
 
-        // Make the router go again to use the newly installed route
-        await this._router.goto('/' + path);
+          // Make the router go again to use the newly installed route
+          await this._router.goto('/' + path);
 
-        // Tell the router to cancel the original navigation to make it
-        // re-entrant safe. It'll be better if we can detect re-entrant calls
-        // to goto() and do this automatically.
-        return false;
+          // Tell the router to cancel the original navigation to make it
+          // re-entrant safe. It'll be better if we can detect re-entrant calls
+          // to goto() and do this automatically.
+          return false;
+        },
       },
     }
   );

--- a/packages/labs/router/src/test/router_test_code.ts
+++ b/packages/labs/router/src/test/router_test_code.ts
@@ -20,7 +20,6 @@ export class Test1 extends LitElement {
       {path: '/child2/*', render: () => html`<child-2></child-2>`},
     ],
     {
-      path: '/*',
       render: (params: {[key: string]: string | undefined}) =>
         html`<h2>Not Found</h2>
           ${params[0]}`,

--- a/packages/labs/router/src/test/router_test_code.ts
+++ b/packages/labs/router/src/test/router_test_code.ts
@@ -11,11 +11,14 @@ import {Routes} from '../routes.js';
 
 @customElement('router-test-1')
 export class Test1 extends LitElement {
-  _router = new Router(this, [
-    {path: '/', render: () => html`<h2>Root</h2>`},
-    {path: '/test1/:x', render: ({x}) => html`<h2>Test 1: ${x}</h2>`},
-    {path: '/child1/*', render: () => html`<child-1></child-1>`},
-    {path: '/child2/*', render: () => html`<child-2></child-2>`},
+  _router = new Router(
+    this,
+    [
+      {path: '/', render: () => html`<h2>Root</h2>`},
+      {path: '/test1/:x', render: ({x}) => html`<h2>Test 1: ${x}</h2>`},
+      {path: '/child1/*', render: () => html`<child-1></child-1>`},
+      {path: '/child2/*', render: () => html`<child-2></child-2>`},
+    ],
     {
       path: '/*',
       render: (params: {[key: string]: string | undefined}) =>
@@ -36,9 +39,8 @@ export class Test1 extends LitElement {
         await 0;
         const {routes} = this._router;
 
-        // Insert a new route before the last, which is this fallback route
-        // We install before the fallback to give it precedence.
-        routes.splice(routes.length - 1, 0, {
+        // Dynamically insert a new route.
+        routes.push({
           path: '/server-route',
           render: () => html`<h2>Server</h2>`,
         });
@@ -51,8 +53,8 @@ export class Test1 extends LitElement {
         // to goto() and do this automatically.
         return false;
       },
-    },
-  ]);
+    }
+  );
 
   override render() {
     return html`


### PR DESCRIPTION
Fixes: https://github.com/lit/lit/issues/2833

### Context

For dynamically adding routes, we previously needed to push the new route prior to the last one (if the last one is a fallback route).
To make pushing routes dynamically easier, we can instead pass and use a `fallbackRoute` option.

### Testing

Tested by slightly expanding the existing tests. I mostly added assertions to ensure that the dynamic route is added correctly, and that the fallback route is reachable.