### PR TITLE
Fix typo.

### DIFF
--- a/.changeset/stupid-geese-change.md
+++ b/.changeset/stupid-geese-change.md
@@ -1,0 +1,6 @@
+---
+'lit-html': patch
+'lit': patch
+---
+
+Fix typo in API docs for live() directive.

--- a/packages/lit-html/src/directives/live.ts
+++ b/packages/lit-html/src/directives/live.ts
@@ -83,7 +83,7 @@ class LiveDirective extends Directive {
  * html`<input .value=${live(x)}>`
  * ```
  *
- * `live()` performs a strict equality check agains the live DOM value, and if
+ * `live()` performs a strict equality check against the live DOM value, and if
  * the new value is equal to the live value, does nothing. This means that
  * `live()` should not be used when the binding will cause a type conversion. If
  * you use `live()` with an attribute binding, make sure that only strings are


### PR DESCRIPTION
Fix is API doc only, error originally reported in https://github.com/lit/lit.dev/pull/769.