### PR TITLE
[@tests] increase default concurrent browsers to 3

### DIFF
--- a/.changeset/orange-snakes-happen.md
+++ b/.changeset/orange-snakes-happen.md
@@ -1,0 +1,5 @@
+---
+'tests': patch
+---
+
+increase concurrent browsers to 3 in test runs

--- a/packages/tests/web-test-runner.config.js
+++ b/packages/tests/web-test-runner.config.js
@@ -178,7 +178,7 @@ export default {
   ],
   nodeResolve: true,
   concurrency: Number(process.env.CONCURRENT_FRAMES || 6), // default cores / 2
-  concurrentBrowsers: Number(process.env.CONCURRENT_BROWSERS || 2), // default 2
+  concurrentBrowsers: Number(process.env.CONCURRENT_BROWSERS || 3), // default 3
   browsers,
   plugins: [
     fromRollup(resolveRemap)(resolveRemapConfig),


### PR DESCRIPTION
Currently we run 3 browsers with a max default concurrency of 2.
To avoid leaving a browser hanging, all three should run.
During saucelabs runs this becomes more important due to latency.

This PR increases the default concurrency to 3.