### PR TITLE
Fix motion tests

### DIFF
--- a/.changeset/breezy-days-prove.md
+++ b/.changeset/breezy-days-prove.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/motion': patch
+---
+
+Test fixes.

--- a/.changeset/breezy-days-prove.md
+++ b/.changeset/breezy-days-prove.md
@@ -1,5 +1,0 @@
----
-'@lit-labs/motion': patch
----
-
-Test fixes.

--- a/packages/labs/motion/src/test/animate_test.ts
+++ b/packages/labs/motion/src/test/animate_test.ts
@@ -8,6 +8,7 @@ import {LitElement, css, html, CSSResultGroup, TemplateResult} from 'lit';
 import {customElement, property, query} from 'lit/decorators.js';
 import {classMap} from 'lit/directives/class-map.js';
 import {
+  hasWebAnimationsAPI,
   generateElementName,
   nextFrame,
   sleep,
@@ -40,7 +41,7 @@ if (DEV_MODE) {
  * 4. remove `scaleUp` and maybe `reset` and `commit`.
  */
 
-suite('Animate', () => {
+(hasWebAnimationsAPI ? suite : suite.skip)('Animate', () => {
   let el;
   let container: HTMLElement;
 

--- a/packages/labs/motion/src/test/animate_test.ts
+++ b/packages/labs/motion/src/test/animate_test.ts
@@ -7,7 +7,12 @@
 import {LitElement, css, html, CSSResultGroup, TemplateResult} from 'lit';
 import {customElement, property, query} from 'lit/decorators.js';
 import {classMap} from 'lit/directives/class-map.js';
-import {generateElementName, nextFrame} from './test-helpers.js';
+import {
+  generateElementName,
+  nextFrame,
+  sleep,
+  assertDeepCloseTo,
+} from './test-helpers.js';
 import {
   animate,
   Animate,
@@ -60,6 +65,9 @@ suite('Animate', () => {
   ) => {
     const styles: CSSResultGroup = [
       css`
+        :host {
+          display: block;
+        }
         * {
           box-sizing: border-box;
         }
@@ -422,13 +430,13 @@ suite('Animate', () => {
     shiftGChild = false;
     await el.updateComplete;
     await gChildAnimate!.finished;
-    assert.deepEqual(childAnimateProps!, {
+    assertDeepCloseTo(childAnimateProps!, {
       left: -100,
       top: 40,
       width: 2,
       height: 2,
     });
-    assert.deepEqual(gChildAnimateProps!, {left: -50, top: 20});
+    assertDeepCloseTo(gChildAnimateProps!, {left: -50, top: 20});
   });
 
   test('animates in', async () => {
@@ -654,6 +662,8 @@ suite('Animate', () => {
     oneFrames = twoFrames = undefined;
     await el.updateComplete;
     await twoAnimate?.finished;
+    // Note, workaround Safari flakiness by waiting slightly here.
+    await sleep();
     assert.equal(oneFrames, flyAbove);
     assert.equal(
       (twoFrames![0].transform! as string).trim(),
@@ -664,6 +674,8 @@ suite('Animate', () => {
     el.requestUpdate();
     await el.updateComplete;
     await twoAnimate?.finished;
+    // Note, workaround Safari flakiness by waiting slightly here.
+    await sleep();
     assert.equal(twoFrames, flyBelow);
     assert.equal(
       (oneFrames![0].transform! as string).trim(),

--- a/packages/labs/motion/src/test/test-helpers.ts
+++ b/packages/labs/motion/src/test/test-helpers.ts
@@ -25,3 +25,6 @@ export const assertDeepCloseTo = (
 
 export const sleep = async (delay = 100) =>
   new Promise((r) => setTimeout(r, delay));
+
+export const hasWebAnimationsAPI =
+  'Animation' in window && 'animate' in Element.prototype;

--- a/packages/labs/motion/src/test/test-helpers.ts
+++ b/packages/labs/motion/src/test/test-helpers.ts
@@ -4,8 +4,24 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+import {CSSValues} from '../animate.js';
+import {assert} from '@esm-bundle/chai';
+
 let count = 0;
 export const generateElementName = () => `x-${count++}`;
 
 export const nextFrame = () =>
   new Promise((resolve) => requestAnimationFrame(resolve));
+
+export const assertDeepCloseTo = (
+  source: CSSValues,
+  expected: CSSValues,
+  delta = 0.1
+) => {
+  Object.entries(expected).forEach(([k, v]) => {
+    assert.closeTo(v as number, source[k] as number, delta);
+  });
+};
+
+export const sleep = async (delay = 100) =>
+  new Promise((r) => setTimeout(r, delay));

--- a/packages/tests/web-test-runner.config.js
+++ b/packages/tests/web-test-runner.config.js
@@ -165,8 +165,7 @@ export default {
   // Note this file list can be overridden by wtr command-line arguments.
   files: [
     '../labs/context/development/**/*_test.(js|html)',
-    // Motion tests don't pass?
-    // '../labs/motion/development/**/*_test.(js|html)',
+    '../labs/motion/development/**/*_test.(js|html)',
     '../labs/observers/development/**/*_test.(js|html)',
     '../labs/react/development/**/*_test.(js|html)',
     '../labs/router/development/**/*_test.js',


### PR DESCRIPTION
Some non-ideal workarounds for browser quirks:
* Introduces `closeTo` for numbers that are slightly off and
* adds a sleep to let Safari assert ok.

Fixes https://github.com/lit/lit/issues/2009