### PR TITLE
Remove changeset md files for private unpublished packages.

### DIFF
--- a/.changeset/angry-masks-reply.md
+++ b/.changeset/angry-masks-reply.md
@@ -1,5 +1,0 @@
----
-'tests': patch
----
-
-Consolidated test utils in monorepo under tests/utils.

--- a/.changeset/little-ligers-roll.md
+++ b/.changeset/little-ligers-roll.md
@@ -1,5 +1,0 @@
----
-'tests': patch
----
-
-update browser versions to reflect test policy

--- a/.changeset/orange-snakes-happen.md
+++ b/.changeset/orange-snakes-happen.md
@@ -1,5 +1,0 @@
----
-'tests': patch
----
-
-increase concurrent browsers to 3 in test runs

--- a/.changeset/shiny-houses-jog.md
+++ b/.changeset/shiny-houses-jog.md
@@ -1,6 +1,5 @@
 ---
 '@lit-labs/analyzer': minor
-'@lit-labs/cli': minor
 ---
 
 Added basic generation of React wrapper to CLI.

--- a/.changeset/tidy-shirts-sparkle.md
+++ b/.changeset/tidy-shirts-sparkle.md
@@ -1,5 +1,0 @@
----
-'@lit-labs/cli': minor
----
-
-Unbundle the CLI from the commands it uses. Version commands separately from the CLI, and lazily load them at runtime.

--- a/.changeset/wise-coins-wave.md
+++ b/.changeset/wise-coins-wave.md
@@ -1,5 +1,0 @@
----
-'@lit-labs/cli': minor
----
-
-Add stub command to CLI for `gen react`


### PR DESCRIPTION
Fixes: https://github.com/lit/lit/pull/2912

This PR enforces the rule : "We only want changesets for things a user would care about reading in our changelog." ~  @aomarks

For changes to our in-progress cli or test package we have commit history.

### Changes

Remove all changeset files that reference private packages.