### PR TITLE
[infra] Update version script to also update package-lock

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "lerna run test --ignore '{lit,lit-html,lit-element,@lit/reactive-element,@lit-labs/context,@lit-labs/motion,@lit-labs/observers,@lit-labs/react,@lit-labs/router,@lit-labs/scoped-registry-mixin,@lit-labs/task}' --concurrency 1 --stream ",
     "prepare": "husky install",
     "changeset": "changeset",
-    "version": "npm run changeset version && npm run update-version-vars",
+    "version": "npm run changeset version && npm run update-version-vars && lerna bootstrap -- --package-lock-only",
     "update-version-vars": "node scripts/update-version-variables.js",
     "release": "npm run bootstrap && npm run build && npm run changeset publish"
   },


### PR DESCRIPTION
When the changeset action runs, it runs `npm run version` as it creates the Version Release PR as specified here: https://github.com/lit/lit/blob/0594bd8345371cc8fa7a2a1cee65c2debc67a95c/.github/workflows/release.yaml#L60

While this bumps the versions of updated packages in `package.json`, it does not update them in `package-lock.json` which necessitated PRs like this https://github.com/lit/lit/pull/2918

Running `lerna bootstrap` passing in the `--package-lock-only` flag documented here https://docs.npmjs.com/cli/v8/commands/npm-install, it will also update the `package-lock.json` files with the proper versions based on the updated `package.json`.

Tested this locally by creating a new changeset for a package and running `npm run version` which resulted in an updated `package.json`, `changelog.md`, **and** `package-lock.json`.

Edit to add: The `lerna bootstrap -- --package-lock-only` will only update the `package-lock.json` file if the `node_modules` directory for the package is empty, which it would be when this is run in the github actions pipeline. To reproduce locally, make sure the `node_modules` directory of the modified package is removed. Thanks @AndrewJakubowicz!

We should see this work in the next Version Release PR.