### PR TITLE
[@lit-labs/router] Make _ prefixed class members private fixing renaming.

### DIFF
--- a/.changeset/tasty-eyes-end.md
+++ b/.changeset/tasty-eyes-end.md
@@ -1,0 +1,7 @@
+---
+'@lit-labs/router': minor
+---
+
+**[BREAKING]** Router properties prefixed with an underscore have been made
+private. These properties were being renamed in production builds and should not
+have been exposed as part of a public API.

--- a/packages/labs/router/src/routes.ts
+++ b/packages/labs/router/src/routes.ts
@@ -65,7 +65,7 @@ const getPattern = (route: RouteConfig) => {
  * configuration of URL patterns and associated render callbacks.
  */
 export class Routes implements ReactiveController {
-  protected readonly _host: ReactiveControllerHost & HTMLElement;
+  private readonly _host: ReactiveControllerHost & HTMLElement;
 
   /*
    * The currently installed set of routes in precedence order.
@@ -97,7 +97,7 @@ export class Routes implements ReactiveController {
    */
   private readonly _childRoutes: Array<Routes> = [];
 
-  protected _parentRoutes: Routes | undefined;
+  private _parentRoutes: Routes | undefined;
 
   /*
    * State related to the current matching route.
@@ -106,9 +106,9 @@ export class Routes implements ReactiveController {
    * that we can propagate tail matches to child routes if they are added after
    * navigation / matching.
    */
-  protected _currentPathname: string | undefined;
-  protected _currentRoute: RouteConfig | undefined;
-  protected _currentParams: {
+  private _currentPathname: string | undefined;
+  private _currentRoute: RouteConfig | undefined;
+  private _currentParams: {
     [key: string]: string | undefined;
   } = {};
 


### PR DESCRIPTION
Addresses: https://github.com/lit/lit/issues/2925

### Context

Currently we have a [rollup renaming rule](https://github.com/lit/lit/blob/main/rollup-common.js#L239-L241) that renames properties prefixed with `_`.

The renaming is incompatible with subclassing.

### Fix

Make the underscored properties private, and expose getters for public/protected endpoints.

For example, `_currentParams` has a public API: `params`.

We can add a public API as we better understand what is required.