### PR TITLE
Fix a couple of release issues

### DIFF
--- a/.changeset/lovely-months-agree.md
+++ b/.changeset/lovely-months-agree.md
@@ -1,5 +1,0 @@
----
-'@lit-labs/gen-wrapper-angular': patch
----
-
-Initial implementation of Angular wrapper generator

--- a/.changeset/modern-parrots-talk.md
+++ b/.changeset/modern-parrots-talk.md
@@ -1,5 +1,6 @@
 ---
 'lit-html': patch
+'lit': patch
 ---
 
 Fix SSR hydration bug relating to <input> and other void elements having attribute bindings.


### PR DESCRIPTION
Found in https://github.com/lit/lit/pull/2954

- Delete `@lit-labs/gen-wrapper-angular` changeset, because it's not released.
- Also bump `lit`, should have been included in https://github.com/lit/lit/pull/2952.