### PR TITLE
[localize] Fix multiple runtime msg call with same template but different expressions

### DIFF
--- a/.changeset/hungry-deers-hang.md
+++ b/.changeset/hungry-deers-hang.md
@@ -1,0 +1,5 @@
+---
+'@lit/localize': patch
+---
+
+Fix multiple runtime msg call with same template but different expressions

--- a/packages/localize/src/internal/runtime-msg.ts
+++ b/packages/localize/src/internal/runtime-msg.ts
@@ -52,13 +52,10 @@ export function runtimeMsg(
           order = localized.values as number[];
           expressionOrders.set(localized, order);
         }
-        // Cast `localized.values` because it's readonly.
-        (
-          localized as {
-            values: TemplateResult['values'];
-          }
-        ).values = order.map((i) => (template as TemplateResult).values[i]);
-        return localized;
+        return {
+          ...localized,
+          values: order.map((i) => (template as TemplateResult).values[i]),
+        };
       }
     }
   }

--- a/packages/localize/src/tests/runtime.test.ts
+++ b/packages/localize/src/tests/runtime.test.ts
@@ -128,6 +128,24 @@ suite('runtime localization configuration', () => {
       assert.equal(container.textContent, 'Hola friend');
     });
 
+    test('renders multiple parameterized template with different expressions in Spanish', async () => {
+      const loaded = setLocale('es-419');
+      lastLoadLocaleResponse.resolve(spanishModule);
+      await loaded;
+
+      const name = 'friend';
+      const name2 = 'buddy';
+      render(
+        html`${msg(html`Hello ${name}`, {
+          id: 'parameterized',
+        })}${' '}${msg(html`Hello ${name2}`, {
+          id: 'parameterized',
+        })}`,
+        container
+      );
+      assert.equal(container.textContent, 'Hola friend Hola buddy');
+    });
+
     test('renders parameterized string template where expression order changed', async () => {
       const loaded = setLocale('es-419');
       lastLoadLocaleResponse.resolve(spanishModule);

--- a/packages/localize/src/tests/runtime.test.ts
+++ b/packages/localize/src/tests/runtime.test.ts
@@ -51,8 +51,9 @@ suite('runtime localization configuration', () => {
     templates: {
       greeting: html`<b>Hola Mundo</b>`,
       parameterized: html`<b>Hola ${0}</b>`,
-      strOrderChange: str`2:${1} 1:${0}`,
       htmlOrderChange: html`<b>2:${1} 1:${0}</b>`,
+      strParameterized: str`Hola ${0}`,
+      strOrderChange: str`2:${1} 1:${0}`,
     },
   };
 
@@ -94,10 +95,10 @@ suite('runtime localization configuration', () => {
       assert.equal(container.textContent, 'Hola Mundo');
     });
 
-    test('renders parameterized template in English', () => {
+    test('renders parameterized HTML template in English', () => {
       const name = 'friend';
       render(
-        msg(html`Hello ${name}`, {
+        msg(html`<b>Hello ${name}</b>`, {
           id: 'parameterized',
         }),
         container
@@ -105,22 +106,13 @@ suite('runtime localization configuration', () => {
       assert.equal(container.textContent, 'Hello friend');
     });
 
-    test('renders parameterized string template in English', () => {
-      const renderAndTest = () => {
-        const x = msg(str`1:${'A'} 2:${'B'}`, {id: 'strOrderChange'});
-        render(x, container);
-        assert.equal(container.textContent, '1:A 2:B');
-      };
-      renderAndTest();
-    });
-
-    test('renders parameterized template in Spanish', async () => {
+    test('renders parameterized HTML template in Spanish', async () => {
       const loaded = setLocale('es-419');
       lastLoadLocaleResponse.resolve(spanishModule);
       await loaded;
       const name = 'friend';
       render(
-        msg(html`Hello ${name}`, {
+        msg(html`<b>Hello ${name}</b>`, {
           id: 'parameterized',
         }),
         container
@@ -128,7 +120,7 @@ suite('runtime localization configuration', () => {
       assert.equal(container.textContent, 'Hola friend');
     });
 
-    test('renders multiple parameterized template with different expressions in Spanish', async () => {
+    test('renders multiple parameterized HTML template with different expressions in Spanish', async () => {
       const loaded = setLocale('es-419');
       lastLoadLocaleResponse.resolve(spanishModule);
       await loaded;
@@ -136,10 +128,73 @@ suite('runtime localization configuration', () => {
       const name = 'friend';
       const name2 = 'buddy';
       render(
-        html`${msg(html`Hello ${name}`, {
+        html`${msg(html`<b>Hello ${name}</b>`, {
           id: 'parameterized',
-        })}${' '}${msg(html`Hello ${name2}`, {
+        })}${' '}${msg(html`<b>Hello ${name2}</b>`, {
           id: 'parameterized',
+        })}`,
+        container
+      );
+      assert.equal(container.textContent, 'Hola friend Hola buddy');
+    });
+
+    test('renders parameterized HTML template where expression order changed', async () => {
+      const loaded = setLocale('es-419');
+      lastLoadLocaleResponse.resolve(spanishModule);
+      await loaded;
+
+      const renderAndTest = () => {
+        render(
+          msg(html`<b>1:${'A'} 2:${'B'}</b>`, {id: 'htmlOrderChange'}),
+          container
+        );
+        assert.equal(container.textContent, '2:B 1:A');
+      };
+
+      renderAndTest();
+
+      // Render again in case we lost our value ordering somehow.
+      renderAndTest();
+    });
+
+    test('renders parameterized string template in English', async () => {
+      const name = 'friend';
+      render(
+        msg(str`Hello ${name}`, {
+          id: 'strParameterized',
+        }),
+        container
+      );
+      assert.equal(container.textContent, 'Hello friend');
+    });
+
+    test('renders parameterized string template in Spanish', async () => {
+      const loaded = setLocale('es-419');
+      lastLoadLocaleResponse.resolve(spanishModule);
+      await loaded;
+
+      const name = 'friend';
+      render(
+        msg(str`Hello ${name}`, {
+          id: 'strParameterized',
+        }),
+        container
+      );
+      assert.equal(container.textContent, 'Hola friend');
+    });
+
+    test('renders multiple parameterized string template in Spanish', async () => {
+      const loaded = setLocale('es-419');
+      lastLoadLocaleResponse.resolve(spanishModule);
+      await loaded;
+
+      const name = 'friend';
+      const name2 = 'buddy';
+      render(
+        `${msg(str`Hello ${name}`, {
+          id: 'strParameterized',
+        })}${' '}${msg(str`Hello ${name2}`, {
+          id: 'strParameterized',
         })}`,
         container
       );
@@ -159,28 +214,6 @@ suite('runtime localization configuration', () => {
       renderAndTest();
 
       // Render again in case we lost our value ordering somehow.
-      renderAndTest();
-    });
-
-    test('renders parameterized HTML template where expression order changed', async () => {
-      const loaded = setLocale('es-419');
-      lastLoadLocaleResponse.resolve(spanishModule);
-      await loaded;
-
-      const renderAndTest = () => {
-        render(
-          msg(html`<b>1:${'A'} 2:${'B'}</b>`, {id: 'htmlOrderChange'}),
-          container
-        );
-        assert.equal(container.textContent, '2:B 1:A');
-      };
-
-      renderAndTest();
-
-      // Render again in case we lost our value ordering somehow. This is a
-      // possible source of bugs, because we do an in-place update of
-      // TemplateResult values, so it's easy to lose track of the original order
-      // if not careful.
       renderAndTest();
     });
   });


### PR DESCRIPTION
Fixes #2971 

We were previously reusing the localized template result object mapped by id for every runtime `msg` call and mutating the values property on it. When multiple `msg` call with template strings that result in the same id were present, it would have the same, latest assigned, value. Changed to return a new object, with the value replaced for each invocation of `msg`.