### PR TITLE
[labs/context] Fixes #2964 and #2965

### DIFF
--- a/.changeset/slimy-comics-study.md
+++ b/.changeset/slimy-comics-study.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/context': patch
+---
+
+Fixes `@contextProvider` when multiple instances of an element are created; updates docs to consistently reference `@contextProvided`.

--- a/packages/labs/context/README.md
+++ b/packages/labs/context/README.md
@@ -32,7 +32,7 @@ export const loggerContext = createContext<Logger>('logger');
 
 Now we can define a consumer for this context - some component in our app needs the logger.
 
-Here we're using the `@contextRequest` property decorator to make a `ContextConsumer` controller
+Here we're using the `@contextProvided` property decorator to make a `ContextConsumer` controller
 and update its value when the context changes:
 
 #### **`my-element.ts`**:
@@ -43,7 +43,7 @@ import {LitElement, property} from 'lit';
 import {Logger, loggerContext} from './logger.js';
 
 export class MyElement extends LitElement {
-  @contextRequest({context: loggerContext, subscribe: true})
+  @contextProvided({context: loggerContext, subscribe: true})
   @property({attribute: false})
   public logger?: Logger;
 

--- a/packages/labs/context/src/lib/decorators/context-provider.ts
+++ b/packages/labs/context/src/lib/decorators/context-provider.ts
@@ -54,10 +54,9 @@ export function contextProvider<ValueType>({
 ) => void | any {
   return decorateProperty({
     finisher: (ctor: typeof ReactiveElement, name: PropertyKey) => {
-      let controller: ContextProvider<ContextKey<unknown, ValueType>>;
+      const controllerMap = new WeakMap();
       ctor.addInitializer((element: ReactiveElement): void => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        controller = new ContextProvider(element, context);
+        controllerMap.set(element, new ContextProvider(element, context));
       });
       // proxy any existing setter for this property and use it to
       // notify the controller of an updated value
@@ -66,7 +65,7 @@ export function contextProvider<ValueType>({
       const newDescriptor = {
         ...descriptor,
         set: function (value: ValueType) {
-          controller?.setValue(value);
+          controllerMap.get(this)?.setValue(value);
           if (oldSetter) {
             oldSetter.call(this, value);
           }

--- a/packages/labs/context/src/test/context-provider_test.ts
+++ b/packages/labs/context/src/test/context-provider_test.ts
@@ -90,29 +90,26 @@ suite('@contextProvided: multiple instances', () => {
   const count = 3;
   setup(async () => {
     container = document.createElement('div');
-    container.innerHTML = new Array(count)
-      .fill(0)
-      .map(
-        (_v, i) => `
+    container.innerHTML = Array.from(
+      {length: count},
+      (_v, i) => `
         <context-provider value="${1000 + i}">
             <context-consumer></context-consumer>
         </context-provider>`
-      )
-      .join('/n');
+    ).join('/n');
     document.body.appendChild(container);
 
     providers = Array.from(
-      container.querySelectorAll('context-provider')
-    ) as ContextProviderElement[];
+      container.querySelectorAll<ContextProviderElement>('context-provider')
+    );
 
     consumers = Array.from(
-      container.querySelectorAll('context-consumer')
-    ) as ContextConsumerElement[];
+      container.querySelectorAll<ContextConsumerElement>('context-consumer')
+    );
 
-    await Promise.all([...providers, ...consumers].map((el) => el.updateComplete));
-    await Promise.all(consumers.map((el) => el.updateComplete));
-
-    consumers.forEach((c) => assert.isDefined(c));
+    await Promise.all(
+      [...providers, ...consumers].map((el) => el.updateComplete)
+    );
   });
 
   teardown(() => {

--- a/packages/labs/context/src/test/context-provider_test.ts
+++ b/packages/labs/context/src/test/context-provider_test.ts
@@ -109,7 +109,7 @@ suite('@contextProvided: multiple instances', () => {
       container.querySelectorAll('context-consumer')
     ) as ContextConsumerElement[];
 
-    await Promise.all(providers.map((el) => el.updateComplete));
+    await Promise.all([...providers, ...consumers].map((el) => el.updateComplete));
     await Promise.all(consumers.map((el) => el.updateComplete));
 
     consumers.forEach((c) => assert.isDefined(c));


### PR DESCRIPTION
* Fixes #2964: @contextProvider now uses a WeakMap to find the controller associated with the given element. This was previously not looked up by element and therefore all setters would find the controller for the last instantiated instance
* Fixes #2965: Changes incorrect references to `@contextRequest` to the proper name `@contextProvided`.