### PR TITLE
[infra] Pin node version for windows-tools test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,7 +75,9 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: 16
+          # Pin to avoid version with problematic npm. See https://github.com/npm/cli/issues/4980
+          # TODO(augustinekim) Unpin when latest node installed by action includes fixed npm
+          node-version: 16.15.0
           cache: 'npm'
           cache-dependency-path: '**/package-lock.json'
 


### PR DESCRIPTION
The latest patch version of node apparently ships with a version of npm that causes our windows-tools test to fail. (It logs deprecation warnings with every npm script run that messes up our cli test assertions). The latest npm version fixes that. https://github.com/npm/cli/issues/4980

However, updating npm for Windows isn't as simple as `npm i -g npm@latest` https://docs.npmjs.com/try-the-latest-stable-version-of-npm#upgrading-on-windows

It seems easier to just pin the version of node for the windows-tools test to one that shipped with working npm and unpin later once the latest v16 of node includes that.