### PR TITLE
[meta] Fix release changesets

### DIFF
--- a/.changeset/modern-mangos-complain.md
+++ b/.changeset/modern-mangos-complain.md
@@ -1,6 +1,2 @@
 ---
-'@lit-labs/gen-wrapper-vue': minor
-'@lit-labs/vue-utils': minor
 ---
-
-Adds package for Vue wrapper generation

--- a/.changeset/thirty-cobras-clap.md
+++ b/.changeset/thirty-cobras-clap.md
@@ -1,0 +1,6 @@
+---
+'@lit-labs/context': patch
+---
+
+An element can now provide and request the same context. This lets elements
+redefine the context binding in terms of what was provided by the parent.

--- a/packages/labs/vue-utils/package.json
+++ b/packages/labs/vue-utils/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "name": "@lit-labs/vue-utils",
   "version": "0.0.1",
   "description": "Utilities for generating a Vue component wrapper for a LitElement.",


### PR DESCRIPTION
Fixes for the release PR https://github.com/lit/lit/pull/3028

1. Removes the private package change.
2. Add a changeset for the labs/context change added in https://github.com/lit/lit/pull/2858. Related to issues https://github.com/lit/lit/issues/2966, and https://github.com/lit/lit/issues/2843
3. Add `"private": true` to `packages/labs/vue-utils`