### PR TITLE
[ssr] Cast setAttribute values to string in SSR DOM shim

### DIFF
--- a/.changeset/khaki-coats-bow.md
+++ b/.changeset/khaki-coats-bow.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/ssr': patch
+---
+
+Fix behavior of setAttribute when value is not a string to match browsers. It is now cast to a string. Fixes problems such as reflection of type:Number properties on ReactiveElements.

--- a/packages/labs/ssr/package.json
+++ b/packages/labs/ssr/package.json
@@ -98,7 +98,10 @@
         "build",
         "../../tests:build"
       ],
-      "files": [],
+      "files": [
+        "web-test-runner.config.js",
+        "../../tests/web-test-runner.config.js"
+      ],
       "output": []
     },
     "test:integration:prod": {
@@ -107,7 +110,10 @@
         "build",
         "../../tests:build"
       ],
-      "files": [],
+      "files": [
+        "web-test-runner.config.js",
+        "../../tests/web-test-runner.config.js"
+      ],
       "output": []
     }
   },

--- a/packages/labs/ssr/src/lib/dom-shim.ts
+++ b/packages/labs/ssr/src/lib/dom-shim.ts
@@ -56,8 +56,8 @@ export const getWindow = ({
       value: string | null
     ): void;
     setAttribute(name: string, value: unknown) {
-      // The browser will silently cast all values to strings. E.g. `42` becomes
-      // `"42"` and `{}` becomes `"[object Object]""`.
+      // Emulate browser behavior that silently casts all values to string. E.g.
+      // `42` becomes `"42"` and `{}` becomes `"[object Object]""`.
       attributesForElement(this).set(name, String(value));
     }
     removeAttribute(name: string) {

--- a/packages/labs/ssr/src/lib/dom-shim.ts
+++ b/packages/labs/ssr/src/lib/dom-shim.ts
@@ -55,8 +55,10 @@ export const getWindow = ({
       old: string | null,
       value: string | null
     ): void;
-    setAttribute(name: string, value: string) {
-      attributesForElement(this).set(name, value);
+    setAttribute(name: string, value: unknown) {
+      // The browser will silently cast all values to strings. E.g. `42` becomes
+      // `"42"` and `{}` becomes `"[object Object]""`.
+      attributesForElement(this).set(name, String(value));
     }
     removeAttribute(name: string) {
       attributesForElement(this).delete(name);

--- a/packages/labs/ssr/src/lib/render-lit-html.ts
+++ b/packages/labs/ssr/src/lib/render-lit-html.ts
@@ -813,7 +813,7 @@ function* renderAttributePart(
 ) {
   if (value !== nothing) {
     if (instance !== undefined) {
-      instance.setAttribute(op.name, value as string);
+      instance.setAttribute(op.name, String(value ?? ''));
     } else {
       yield `${op.name}="${escapeHtml(String(value ?? ''))}"`;
     }

--- a/packages/labs/ssr/src/test/integration/tests/basic.ts
+++ b/packages/labs/ssr/src/test/integration/tests/basic.ts
@@ -4698,6 +4698,178 @@ export const tests: {[name: string]: SSRTest} = {
     };
   },
 
+  'LitElement: Reflected number attribute': () => {
+    return {
+      registerElements() {
+        class LEReflectedNumberAttribute extends LitElement {
+          @property({type: Number, reflect: true})
+          num = 42;
+        }
+        customElements.define(
+          'le-reflected-number-attribute',
+          LEReflectedNumberAttribute
+        );
+      },
+      render() {
+        return html`
+          <le-reflected-number-attribute></le-reflected-number-attribute>
+        `;
+      },
+      expectations: [
+        {
+          args: [],
+          async check(assert: Chai.Assert, dom: HTMLElement) {
+            const el = dom.querySelector(
+              'le-reflected-number-attribute'
+            )! as LitElement;
+            await el.updateComplete;
+            assert.strictEqual((el as unknown as {num: number}).num, 42);
+          },
+          html: {
+            root: `<le-reflected-number-attribute num="42"></le-reflected-number-attribute>`,
+          },
+        },
+      ],
+      stableSelectors: ['le-reflected-number-attribute'],
+      // The property gets re-reflected to an attribute on upgrade.
+      expectMutationsDuringUpgrade: true,
+      expectMutationsDuringHydration: true,
+    };
+  },
+
+  'LitElement: Reflected boolean attribute': () => {
+    return {
+      registerElements() {
+        class LEReflectedBooleanObjectAttribute extends LitElement {
+          @property({type: Boolean, reflect: true})
+          bool = true;
+        }
+        customElements.define(
+          'le-reflected-boolean-attribute',
+          LEReflectedBooleanObjectAttribute
+        );
+      },
+      render() {
+        return html`
+          <le-reflected-boolean-attribute></le-reflected-boolean-attribute>
+        `;
+      },
+      expectations: [
+        {
+          args: [],
+          async check(assert: Chai.Assert, dom: HTMLElement) {
+            const el = dom.querySelector(
+              'le-reflected-boolean-attribute'
+            )! as LitElement;
+            await el.updateComplete;
+            assert.strictEqual((el as unknown as {bool: boolean}).bool, true);
+          },
+          html: {
+            root: `<le-reflected-boolean-attribute bool></le-reflected-boolean-attribute>`,
+          },
+        },
+      ],
+      stableSelectors: ['le-reflected-boolean-attribute'],
+      // The property gets re-reflected to an attribute on upgrade.
+      expectMutationsDuringUpgrade: true,
+      expectMutationsDuringHydration: true,
+    };
+  },
+
+  'LitElement: Reflected object attribute': () => {
+    return {
+      registerElements() {
+        class LEReflectedObjectAttribute extends LitElement {
+          @property({type: Object, reflect: true})
+          obj = {foo: 42};
+        }
+        customElements.define(
+          'le-reflected-object-attribute',
+          LEReflectedObjectAttribute
+        );
+      },
+      render() {
+        return html`
+          <le-reflected-object-attribute></le-reflected-object-attribute>
+        `;
+      },
+      expectations: [
+        {
+          args: [],
+          async check(assert: Chai.Assert, dom: HTMLElement) {
+            const el = dom.querySelector(
+              'le-reflected-object-attribute'
+            )! as LitElement;
+            await el.updateComplete;
+            assert.strictEqual(
+              (el as unknown as {obj: {foo: number}}).obj.foo,
+              42
+            );
+          },
+          html: {
+            root: `<le-reflected-object-attribute obj="{&quot;foo&quot;:42}"></le-reflected-object-attribute>`,
+          },
+        },
+      ],
+      stableSelectors: ['le-reflected-object-attribute'],
+      // The property gets re-reflected to an attribute on upgrade.
+      expectMutationsDuringUpgrade: true,
+      expectMutationsDuringHydration: true,
+    };
+  },
+
+  'LitElement: Reflected custom attribute': () => {
+    return {
+      registerElements() {
+        class LEReflectedCustomAttribute extends LitElement {
+          @property({
+            converter: {
+              fromAttribute: (value: string) => {
+                return [...value].reverse().join('');
+              },
+              toAttribute: (value: string) => {
+                return [...value].reverse().join('');
+              },
+            },
+            reflect: true,
+          })
+          custom = 'abc';
+        }
+        customElements.define(
+          'le-reflected-custom-attribute',
+          LEReflectedCustomAttribute
+        );
+      },
+      render() {
+        return html`
+          <le-reflected-custom-attribute></le-reflected-custom-attribute>
+        `;
+      },
+      expectations: [
+        {
+          args: [],
+          async check(assert: Chai.Assert, dom: HTMLElement) {
+            const el = dom.querySelector(
+              'le-reflected-custom-attribute'
+            )! as LitElement;
+            await el.updateComplete;
+            assert.strictEqual(
+              (el as unknown as {custom: string}).custom,
+              'abc'
+            );
+          },
+          html: {
+            root: `<le-reflected-custom-attribute custom="cba"></le-reflected-custom-attribute>`,
+          },
+        },
+      ],
+      stableSelectors: ['le-reflected-custom-attribute'],
+      // The property gets re-reflected to an attribute on upgrade.
+      expectMutationsDuringUpgrade: true,
+      expectMutationsDuringHydration: true,
+    };
+  },
+
   'LitElement: Static attribute deserializes': () => {
     return {
       registerElements() {

--- a/packages/labs/ssr/src/test/integration/tests/ssr-test.ts
+++ b/packages/labs/ssr/src/test/integration/tests/ssr-test.ts
@@ -30,8 +30,8 @@ export interface SSRTestDescription {
     check?(assert: Chai.Assert, dom: HTMLElement): void | Promise<unknown>;
   }>;
   /**
-   * A list of selectors of elements that should no change between renders.
-   * Used to assert that the DOM reused in hydration, not recreated.
+   * A list of selectors of elements that should not change between renders.
+   * Used to assert that the DOM was reused in hydration, not recreated.
    */
   stableSelectors: Array<string>;
   expectMutationsOnFirstRender?: boolean;


### PR DESCRIPTION
Previously, when our SSR DOM shim for `setAttribute` received a value, it just assumed it was a string and assigned it to its internal attribute map as-is. Later, when trying to serialize an attribute to HTML, we pass it through an escape function, which crashes if the value is not a string.

In browsers, the value passed to `setAttribute` is always cast to a string. So `42` becomes `"42"`. We now mirror this behavior.

This specifically came up in https://github.com/lit/lit/issues/2633 because in `ReactiveElement`, when a property has `{type: Number}`, we do not cast the value to a string ourselves, since we assume the browser will do that automatically (in fact, we don't handle `Number` at all, since the default behavior is correct https://github.com/lit/lit/blob/21ff05104727d088ab577f7178cbc15eed14841a/packages/reactive-element/src/reactive-element.ts#L321).

Fixes https://github.com/lit/lit/issues/2633

cc @daKmoR 