### PR TITLE
fix(lit-labs/react): Fix style attribute conflicts with the type definition of DOM and ReactModule

### DIFF
--- a/.changeset/lovely-mangos-grin.md
+++ b/.changeset/lovely-mangos-grin.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/react': patch
+---
+
+Fix style attribute conflicts with the type definition of dom and React.

--- a/packages/labs/react/src/create-component.ts
+++ b/packages/labs/react/src/create-component.ts
@@ -127,7 +127,7 @@ type EventProps<R extends Events> = {
  * messages. Default value is inferred from the name of custom element class
  * registered via `customElements.define`.
  */
-export const createComponent = <I extends HTMLElement, E extends Events>(
+export const createComponent = <I extends HTMLElement, E extends Events = {}>(
   React: typeof ReactModule,
   tagName: string,
   elementClass: Constructor<I>,
@@ -143,7 +143,7 @@ export const createComponent = <I extends HTMLElement, E extends Events>(
   // 'children', but 'children' is special to JSX, so we must at least do that.
   type UserProps = React.PropsWithChildren<
     React.PropsWithRef<
-      Partial<Omit<I, 'children'>> &
+      Partial<Omit<I, 'children' | 'style' | 'ref' | 'key'>> &
         Partial<EventProps<E>> &
         Omit<React.HTMLAttributes<HTMLElement>, keyof E>
     >


### PR DESCRIPTION
* Style that conflicts with children, ref, and key, which are reserved words in React, is omitted from the properties of the web component.
Fixes #3021

* Added a default value for the type because if no Events were dispatched I got the following error:
```typescript
'{ children: string; "data-testid": string; appearance: any; }' 형식은 'Partial<EventProps<Events>>' 형식에 할당할 수 없습니다.
  'children' 속성이 인덱스 시그니처와 호환되지 않습니다.
    'string' 형식은 '(e: Event) => void' 형식에 할당할 수 없습니다.ts(2322)
```
