### PR TITLE
[infra] Test labs production builds and fix class property name mangling collisions

### DIFF
--- a/.changeset/eleven-zebras-crash.md
+++ b/.changeset/eleven-zebras-crash.md
@@ -1,0 +1,6 @@
+---
+'@lit-labs/router': patch
+'@lit-labs/react': patch
+---
+
+Fix a property collision in the minified production build.

--- a/packages/labs/router/rollup.config.js
+++ b/packages/labs/router/rollup.config.js
@@ -9,6 +9,6 @@ import {createRequire} from 'module';
 
 export default litProdConfig({
   packageName: createRequire(import.meta.url)('./package.json').name,
-  entryPoints: ['index', 'router'],
+  entryPoints: ['index', 'router', 'routes'],
   external: ['lit'],
 });

--- a/packages/tests/src/wtr-config.ts
+++ b/packages/tests/src/wtr-config.ts
@@ -26,11 +26,21 @@ export const prodResolveRemapConfig: RemapConfig = {
     {from: 'lit-html/development/test/', to: null},
     {from: 'lit-element/development/test/', to: null},
     {from: 'reactive-element/development/test/', to: null},
+    {from: 'labs/router/development/test/', to: null},
+    {from: 'labs/react/development/test/', to: null},
+    {from: 'labs/task/development/test/', to: null},
+    {from: 'labs/context/development/test/', to: null},
+    {from: 'labs/motion/development/test/', to: null},
     // Remap any other development/ modules up one level to the production
     // version.
     {from: 'lit-html/development/', to: 'lit-html/'},
     {from: 'lit-element/development/', to: 'lit-element/'},
     {from: 'reactive-element/development/', to: 'reactive-element/'},
+    {from: 'labs/router/development/', to: 'labs/router/'},
+    {from: 'labs/react/development/', to: 'labs/react/'},
+    {from: 'labs/task/development/', to: 'labs/task/'},
+    {from: 'labs/context/development/', to: 'labs/context/'},
+    {from: 'labs/motion/development/', to: 'labs/motion/'},
   ],
 };
 

--- a/rollup-common.js
+++ b/rollup-common.js
@@ -306,7 +306,12 @@ export function litProdConfig({
   const nameCacheSeederOutfile = 'name-cache-seeder-throwaway-output.js';
   const nameCacheSeederContents = [
     // Import every entry point so that we see all property accesses.
-    ...entryPoints.map((name) => `import './development/${name}.js';`),
+    // Give a unique named import to prevent duplicate identifier errors.
+    ...entryPoints.map(
+      (name, idx) => `import * as import${idx} from './development/${name}.js';`
+    ),
+    // Prevent tree shaking that occurs during mangling.
+    ...entryPoints.map((_name, idx) => `console.log(import${idx});`),
     // Synthesize a property access for all cross-package mangled property names
     // so that even if we don't access a property in this package, we will still
     // reserve other properties from re-using that name.


### PR DESCRIPTION
Fixes issue https://github.com/lit/lit/issues/3031

### Context

Our labs packages have `test:prod` commands, however they do not have a remapping to the production bundle. This results in the `test:prod` command being a duplicate of the dev mode test.

After fixing the `test:prod` commands, it reproduced the bug in the linked issue, as well as a property mangling failure in labs/React.
An investigation found that the name cache system was tree shaking out the imports, which then meant terser didn't have any context for what property names were in the bundle. Without the name cache terser would rename different subclass properties to the same name.

### Fix

By adding `console.log` statements for each import in the name cache file, it prevents tree shaking and dead code elimination of the classes. This correctly populates the terser name cache preventing naming collisions.

Was verified as the initial commits of this PR are red - with two naming collisions detected in labs/Router and labs/React. After adding the console.log, the tests pass, and the properties are correctly renamed.

### Tests

This PR adds additional testing since it enables correct production testing in our labs packages.

### Risks

This change does modify some of the minified properties - which creates some risk of name collisions.
Spot checked minified changes in go/diff#key=G7taLmvP2t45
 - lit-element and reactive-element are using their module class prefixes.
 - No difference in lit-html, minified output.

Tested checksize outputs. They were pretty much the same between main and this change: go/diff#key=vG22tcDUQTOH
