### PR TITLE
[lit-html] Mark TemplateResult brand as internal

### DIFF
--- a/.changeset/calm-olives-teach.md
+++ b/.changeset/calm-olives-teach.md
@@ -1,0 +1,5 @@
+---
+'lit-html': patch
+---
+
+Mark TemplateResult brand as internal cleaning up generated documentation.

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -457,6 +457,7 @@ const COMMENT_PART = 7;
  */
 export type TemplateResult<T extends ResultType = ResultType> = {
   // This property needs to remain unminified.
+  /** @internal */
   ['_$litType$']: T;
   strings: TemplateStringsArray;
   values: unknown[];

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -932,8 +932,12 @@ class Template {
   parts: Array<TemplatePart> = [];
 
   constructor(
-    // This property needs to remain unminified.
-    {strings, ['_$litType$']: type}: TemplateResult,
+    {
+      strings,
+      // This property needs to remain unminified.
+      /** @internal */
+      ['_$litType$']: type,
+    }: TemplateResult,
     options?: RenderOptions
   ) {
     let node: Node | null;

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -931,15 +931,12 @@ class Template {
   /** @internal */
   parts: Array<TemplatePart> = [];
 
-  constructor(
-    {
+  constructor(templateResult: TemplateResult, options?: RenderOptions) {
+    const {
       strings,
       // This property needs to remain unminified.
-      /** @internal */
       ['_$litType$']: type,
-    }: TemplateResult,
-    options?: RenderOptions
-  ) {
+    } = templateResult;
     let node: Node | null;
     let nodeIndex = 0;
     let attrNameIndex = 0;


### PR DESCRIPTION
Very small documentation change that fixes https://github.com/lit/lit.dev/issues/865