### PR TITLE
[labs/react] flatter faster types for UserProps

### DIFF
--- a/packages/labs/react/src/create-component.ts
+++ b/packages/labs/react/src/create-component.ts
@@ -141,12 +141,11 @@ export const createComponent = <I extends HTMLElement, E extends Events>(
   // ref, as well as special event and element properties.
   // TODO: we might need to omit more properties from HTMLElement than just
   // 'children', but 'children' is special to JSX, so we must at least do that.
-  type UserProps = React.PropsWithChildren<
-    React.PropsWithRef<
-      Partial<Omit<I, 'children'>> &
-        Partial<EventProps<E>> &
-        Omit<React.HTMLAttributes<HTMLElement>, keyof E>
-    >
+
+  type ReactProps = React.PropsWithChildren<React.HTMLAttributes<I>>;
+  type ElementWithoutChildrenOrEvents = Omit<I, keyof E | keyof ReactProps>;
+  type UserProps = Partial<
+    ElementWithoutChildrenOrEvents & ReactProps & EventProps<E>
   >;
 
   // Props used by this component wrapper. This is the UserProps and the


### PR DESCRIPTION
Currently Typescript struggles to react to changes in a promptly manner.

This is probably due to a couple of nested structures bogging down the type checker.

Replacing the following:

```ts
  type UserProps = React.PropsWithChildren<
    React.PropsWithRef<
      Partial<Omit<I, 'children'>> &
        Partial<EventProps<E>> &
        Omit<React.HTMLAttributes<HTMLElement>, keyof E>
    >
```

With the following set of types
```ts
  type ReactProps = React.PropsWithChildren<React.HTMLAttributes<I>>;
  type ElementWithoutChildrenOrEvents = Omit<I, keyof E | keyof ReactProps>;
  type UserProps = Partial<
    ElementWithoutChildrenOrEvents & ReactProps & EventProps<E>
  >;
```

Helps typescript inference types much faster.