### PR TITLE
Throw on custom renderRoot

### DIFF
--- a/packages/labs/ssr/src/lib/dom-shim.ts
+++ b/packages/labs/ssr/src/lib/dom-shim.ts
@@ -48,7 +48,10 @@ export const getWindow = ({
     }
     private _shadowRoot: null | ShadowRoot = null;
     get shadowRoot() {
-      return this._shadowRoot;
+      if (this._shadowRoot?.mode === 'open') {
+        return this._shadowRoot;
+      }
+      return null;
     }
     abstract attributeChangedCallback?(
       name: string,
@@ -67,11 +70,11 @@ export const getWindow = ({
       return attributesForElement(this).has(name);
     }
     attachShadow(init: ShadowRootInit) {
-      const shadowRoot = {host: this};
-      if (init && init.mode === 'open') {
-        this._shadowRoot = shadowRoot;
-      }
-      return shadowRoot;
+      return (this._shadowRoot = new ShadowRoot(
+        shadowRootConstructionToken,
+        this,
+        init
+      ));
     }
     getAttribute(name: string) {
       const value = attributesForElement(this).get(name);
@@ -84,7 +87,29 @@ export const getWindow = ({
     observedAttributes?: string[];
   }
 
-  class ShadowRoot {}
+  const shadowRootConstructionToken = Symbol();
+
+  class ShadowRoot {
+    host: Element;
+    mode: 'open' | 'closed';
+
+    constructor();
+    /**
+     * @internal
+     */
+    constructor(constructionToken: Symbol, host: Element, init: ShadowRootInit);
+    constructor(
+      constructionToken?: Symbol,
+      host?: Element,
+      init?: ShadowRootInit
+    ) {
+      if (constructionToken !== shadowRootConstructionToken) {
+        throw new TypeError('Illegal constructor');
+      }
+      this.host = host!;
+      this.mode = init!.mode;
+    }
+  }
 
   class Document {
     get adoptedStyleSheets() {
@@ -203,4 +228,15 @@ export const installWindowOnGlobal = (props: {[key: string]: unknown} = {}) => {
     // added to the node global
     globalThis.window = globalThis as typeof globalThis & Window;
   }
+};
+
+interface HTMLElementInternals extends HTMLElement {
+  _shadowRoot: ShadowRoot | null;
+}
+
+/**
+ * Returns the shadow root of an HTMLElement even if the mode is 'closed'.
+ */
+export const getShadowRoot = (e: HTMLElement) => {
+  return (e as HTMLElementInternals)._shadowRoot;
 };

--- a/packages/labs/ssr/src/test/integration/client/setup.ts
+++ b/packages/labs/ssr/src/test/integration/client/setup.ts
@@ -244,7 +244,10 @@ export const setupTest = async (
       testFn(testName, async () => {
         // Get the SSR result from the server.
         const response = await fetch(`/render/${mode}/${testFile}/${testName}`);
-        container.innerHTML = await response.text();
+
+        const text = await response.text();
+        console.log('response', text);
+        container.innerHTML = text;
 
         // For element tests, hydrate shadowRoots
         if (typeof registerElements === 'function') {

--- a/packages/labs/ssr/src/test/integration/tests/basic.ts
+++ b/packages/labs/ssr/src/test/integration/tests/basic.ts
@@ -5133,4 +5133,40 @@ export const tests: {[name: string]: SSRTest} = {
       stableSelectors: ['le-defer'],
     };
   },
+
+  'LitElement: light DOM rendering throws': () => {
+    return {
+      only: true,
+      registerElements() {
+        customElements.define(
+          'le-light-dom',
+          class extends LitElement {
+            protected override createRenderRoot() {
+              return this;
+            }
+            override connectedCallback(): void {
+              console.log('BBB connectedCallback');
+              super.connectedCallback();
+            }
+            override render() {
+              return html` <h1>Hello</h1> `;
+            }
+          }
+        );
+      },
+      render() {
+        return html` <le-light-dom></le-light-dom> `;
+      },
+      expectations: [
+        {
+          args: [],
+          throwsOnServer: true,
+          html: {
+            root: `<le-light-dom></le-light-dom>`,
+          },
+        },
+      ],
+      stableSelectors: ['le-basic'],
+    };
+  },
 };

--- a/packages/labs/ssr/src/test/integration/tests/ssr-test.ts
+++ b/packages/labs/ssr/src/test/integration/tests/ssr-test.ts
@@ -19,6 +19,8 @@ export interface SSRTestDescription {
      */
     args: Array<unknown>;
 
+    throwsOnServer?: boolean;
+
     /**
      * The expected HTML string.
      *

--- a/packages/labs/ssr/web-test-runner.config.js
+++ b/packages/labs/ssr/web-test-runner.config.js
@@ -10,7 +10,7 @@ import {ssrMiddleware} from './test/integration/server/server.js';
 
 export default {
   ...baseConfig,
-  files: ['test/integration/client/**/*_test.js'],
+  files: ['test/integration/client/**/basic-global_test.js'],
   nodeResolve: {
     exportConditions: process.env.MODE === 'dev' ? ['development'] : [],
   },

--- a/packages/tests/src/web-test-runner.config.ts
+++ b/packages/tests/src/web-test-runner.config.ts
@@ -36,8 +36,8 @@ const browserPresets = {
   // Default set of Playwright browsers to test when running locally.
   local: [
     'chromium', // keep browsers on separate lines
-    'firefox', // to make it easier to comment out
-    'webkit', // individual browsers
+    // 'firefox', // to make it easier to comment out
+    // 'webkit', // individual browsers
   ],
 
   // Browsers to test during automated continuous integration.
@@ -220,7 +220,7 @@ const config: TestRunnerConfig = {
     }),
   ],
   // Only actually log errors. This helps make test output less spammy.
-  filterBrowserLogs: ({type}) => type === 'error',
+  // filterBrowserLogs: ({type}) => type === 'error',
   browserStartTimeout: 60000, // default 30000
   // For ie11 where tests run more slowly, this timeout needs to be long
   // enough so that blocked tests have time to wait for all previous test files


### PR DESCRIPTION
Closes #3080 

This is attempting to detect when an element has overridden `createRenderRoot()` and returned something other than the result of `this.attachShadow()`.

This PR is a WIP draft because:
- It calls `connectedCallback()` (like #2309) which we have to decide if we can do and how to guard client-side only code if we do.
- I can't see how to capture the error on the server yet (I can't see any logging in the test server actually)