### PR TITLE
Support space-separated classInfo properties in classMap

### DIFF
--- a/packages/lit-html/src/test/directives/class-map_test.ts
+++ b/packages/lit-html/src/test/directives/class-map_test.ts
@@ -131,6 +131,24 @@ suite('classMap directive', () => {
     assert.isTrue(el.classList.contains('cc'));
   });
 
+  test('works if there are class names combined into a single string, separated by whitespace', () => {
+    const classInfo = {'foo bar': true, 'baz zonk': false};
+    renderClassMap(classInfo);
+    const el = container.firstElementChild!;
+    assert.isTrue(el.classList.contains('foo'));
+    assert.isTrue(el.classList.contains('bar'));
+    assert.isFalse(el.classList.contains('baz'));
+    assert.isFalse(el.classList.contains('zonk'));
+
+    classInfo['foo bar'] = false;
+    classInfo['baz zonk'] = true;
+    renderClassMap(classInfo);
+    assert.isFalse(el.classList.contains('foo'));
+    assert.isFalse(el.classList.contains('bar'));
+    assert.isTrue(el.classList.contains('baz'));
+    assert.isTrue(el.classList.contains('zonk'));
+  });
+
   test('throws when used on non-class attribute', () => {
     assert.throws(() => {
       render(html`<div id="${classMap({})}"></div>`, container);


### PR DESCRIPTION
Fixes #3095

The main theme of this PR is to insert a small layer of abstraction between `name` and `classInfo`, which is accomplished by iterating over each `key` in the `classInfo` object, and then iterating over each `name` obtained from:
```javascript
key.split(/\s/).filter((s) => s !== '')
```