### PR TITLE
[chore] Remove changeset for private packages

### DIFF
--- a/.changeset/fuzzy-lobsters-pretend.md
+++ b/.changeset/fuzzy-lobsters-pretend.md
@@ -1,7 +1,0 @@
----
-'@lit-labs/cli': patch
-'@lit-labs/gen-wrapper-react': minor
-'@lit-labs/gen-wrapper-vue': minor
----
-
-Made the react and vue wrapper generators to lazy, locally controlled deps.


### PR DESCRIPTION
Since we don't need changelogs to be updated for yet to be released packages.