### PR TITLE
[labs/react] remove StringValued type

### DIFF
--- a/.changeset/thin-bees-build.md
+++ b/.changeset/thin-bees-build.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/react': patch
+---
+
+Reduced number of types in createComponent

--- a/.changeset/thin-bees-build.md
+++ b/.changeset/thin-bees-build.md
@@ -2,4 +2,4 @@
 '@lit-labs/react': patch
 ---
 
-Reduced number of types in createComponent
+Removed the unexposed and unnecessary `StringValued` type used to correlate property names with event listener names.

--- a/packages/labs/react/src/create-component.ts
+++ b/packages/labs/react/src/create-component.ts
@@ -55,14 +55,14 @@ const addOrUpdateEventListener = (
  * Sets properties and events on custom elements. These properties and events
  * have been pre-filtered so we know they should apply to the custom element.
  */
-const setProperty = <E extends Element, T>(
+const setProperty = <E extends Element>(
   node: E,
   name: string,
   value: unknown,
   old: unknown,
-  events?: StringValued<T>
+  events?: Events
 ) => {
-  const event = events?.[name as keyof T];
+  const event = events?.[name];
   if (event !== undefined) {
     // Dirty check event value.
     if (value !== old) {
@@ -82,10 +82,6 @@ const setRef = (ref: React.Ref<unknown>, value: Element | null) => {
   } else {
     (ref as {current: Element | null}).current = value;
   }
-};
-
-type StringValued<T> = {
-  [P in keyof T]: string;
 };
 
 type Constructor<T> = {new (): T};


### PR DESCRIPTION
This PR removes the `StringValued` type.

It can be replaced by the `Events` type.