### PR TITLE
[infra] Upgrade and standardize TypeScript to ~4.7.4

### DIFF
--- a/.changeset/angry-badgers-swim.md
+++ b/.changeset/angry-badgers-swim.md
@@ -1,0 +1,7 @@
+---
+'@lit-labs/analyzer': patch
+'@lit/localize-tools': patch
+'@lit/ts-transformers': patch
+---
+
+Upgraded TypeScript version to ~4.7.4

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "rollup-plugin-sourcemaps": "^0.6.2",
         "rollup-plugin-summary": "~1.3.0",
         "rollup-plugin-terser": "^7.0.2",
-        "typescript": "~4.4.0",
+        "typescript": "~4.7.4",
         "wireit": "^0.7.1"
       },
       "engines": {
@@ -5570,20 +5570,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/@wdio/config/node_modules/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
-      "dev": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
     "node_modules/@wdio/logger": {
       "version": "7.19.0",
       "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-7.19.0.tgz",
@@ -5675,20 +5661,6 @@
       },
       "peerDependencies": {
         "typescript": "^4.6.2"
-      }
-    },
-    "node_modules/@wdio/utils/node_modules/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
-      "dev": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
       }
     },
     "node_modules/@web/browser-logs": {
@@ -7684,19 +7656,6 @@
       },
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "node_modules/browser-sync-client/node_modules/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
       }
     },
     "node_modules/browser-sync-ui": {
@@ -10678,20 +10637,6 @@
       },
       "peerDependencies": {
         "typescript": "^4.6.2"
-      }
-    },
-    "node_modules/devtools/node_modules/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
-      "dev": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
       }
     },
     "node_modules/devtools/node_modules/uuid": {
@@ -25134,9 +25079,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
-      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -26127,20 +26072,6 @@
         "typescript": "^4.6.2"
       }
     },
-    "node_modules/webdriver/node_modules/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
-      "dev": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
     "node_modules/webdriverio": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-7.20.5.tgz",
@@ -26226,20 +26157,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/webdriverio/node_modules/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
-      "dev": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
       }
     },
     "node_modules/webidl-conversions": {
@@ -26945,8 +26862,7 @@
         "tachometer": "^0.6.0-pre.1"
       },
       "devDependencies": {
-        "chromedriver": "^103.0.0",
-        "typescript": "^4.3.5"
+        "chromedriver": "^103.0.0"
       }
     },
     "packages/internal-scripts": {
@@ -26960,8 +26876,7 @@
         "fast-glob": "^3.2.5",
         "line-reader": "^0.4.0",
         "marked": "^4.0.16",
-        "puppeteer": "^14.3.0",
-        "typescript": "^4.3.5"
+        "puppeteer": "^14.3.0"
       },
       "bin": {
         "release-image": "bin/release-image.js",
@@ -26981,24 +26896,12 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "package-json-type": "^1.0.3",
-        "typescript": "~4.6.2"
+        "typescript": "~4.7.4"
       },
       "devDependencies": {
         "@types/node": "^16.7.8",
         "lit-analyzer-test-files": "./test-files/basic-elements/",
         "uvu": "^0.5.1"
-      }
-    },
-    "packages/labs/analyzer/node_modules/typescript": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
       }
     },
     "packages/labs/analyzer/test-files/basic-elements": {
@@ -27035,7 +26938,6 @@
         "eslint": "^5.16.0",
         "globby": "^10.0.2",
         "stdout-stderr": "^0.1.13",
-        "typescript": "~4.6.2",
         "uvu": "^0.5.3"
       },
       "engines": {
@@ -27529,19 +27431,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "packages/labs/cli/node_modules/typescript": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
     "packages/labs/cli/node_modules/which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
@@ -27572,8 +27461,7 @@
         "chokidar-cli": "^2.1.0",
         "concurrently": "^5.3.0",
         "mocha": "^8.1.3",
-        "rollup": "^2.28.2",
-        "typescript": "^4.1.3"
+        "rollup": "^2.28.2"
       }
     },
     "packages/labs/context/node_modules/@types/mocha": {
@@ -27595,7 +27483,6 @@
         "@web/dev-server": "^0.1.11",
         "@webcomponents/template-shadowroot": "^0.1.0",
         "rimraf": "^3.0.2",
-        "typescript": "^4.1.3",
         "uvu": "^0.5.3"
       },
       "engines": {
@@ -27612,7 +27499,6 @@
       "devDependencies": {
         "@lit-internal/tests": "^0.0.0",
         "@types/node": "^17.0.31",
-        "typescript": "~4.6.2",
         "uvu": "^0.5.3"
       },
       "engines": {
@@ -27624,19 +27510,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
       "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
       "dev": true
-    },
-    "packages/labs/gen-utils/node_modules/typescript": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
     },
     "packages/labs/gen-wrapper-angular": {
       "name": "@lit-labs/gen-wrapper-angular",
@@ -27652,7 +27525,6 @@
         "@types/chai": "^4.0.1",
         "@types/mocha": "^9.0.0",
         "@types/node": "^17.0.31",
-        "typescript": "~4.6.2",
         "uvu": "^0.5.3"
       },
       "engines": {
@@ -27664,19 +27536,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
       "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
       "dev": true
-    },
-    "packages/labs/gen-wrapper-angular/node_modules/typescript": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
     },
     "packages/labs/gen-wrapper-react": {
       "name": "@lit-labs/gen-wrapper-react",
@@ -27690,7 +27549,6 @@
       "devDependencies": {
         "@lit-internal/tests": "^0.0.0",
         "@types/node": "^17.0.31",
-        "typescript": "~4.6.2",
         "uvu": "^0.5.3"
       },
       "engines": {
@@ -27702,19 +27560,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
       "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
       "dev": true
-    },
-    "packages/labs/gen-wrapper-react/node_modules/typescript": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
     },
     "packages/labs/gen-wrapper-vue": {
       "name": "@lit-labs/gen-wrapper-vue",
@@ -27728,7 +27573,6 @@
       "devDependencies": {
         "@lit-internal/tests": "^0.0.0",
         "@types/node": "^17.0.31",
-        "typescript": "^4.6.4",
         "uvu": "^0.5.3"
       },
       "engines": {
@@ -27740,19 +27584,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
       "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
       "dev": true
-    },
-    "packages/labs/gen-wrapper-vue/node_modules/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
     },
     "packages/labs/motion": {
       "name": "@lit-labs/motion",
@@ -27772,8 +27603,7 @@
         "chokidar-cli": "^3.0.0",
         "concurrently": "^6.2.1",
         "mocha": "^9.1.1",
-        "rollup": "^2.70.2",
-        "typescript": "^4.3.5"
+        "rollup": "^2.70.2"
       }
     },
     "packages/labs/motion/node_modules/@types/trusted-types": {
@@ -28444,8 +28274,7 @@
         "chokidar-cli": "^3.0.0",
         "concurrently": "^6.2.1",
         "mocha": "^9.1.1",
-        "rollup": "^2.70.2",
-        "typescript": "^4.3.5"
+        "rollup": "^2.70.2"
       }
     },
     "packages/labs/observers/node_modules/@types/trusted-types": {
@@ -29118,8 +28947,7 @@
         "mocha": "^9.1.1",
         "react": "^17.0.1",
         "react-dom": "^17.0.1",
-        "rollup": "^2.70.2",
-        "typescript": "^4.3.5"
+        "rollup": "^2.70.2"
       }
     },
     "packages/labs/react/node_modules/@types/trusted-types": {
@@ -29791,7 +29619,6 @@
         "concurrently": "^6.2.1",
         "mocha": "^9.1.1",
         "rollup": "^2.70.2",
-        "typescript": "^4.3.5",
         "urlpattern-polyfill": "^4.0.3"
       }
     },
@@ -30465,8 +30292,7 @@
         "chokidar-cli": "^3.0.0",
         "concurrently": "^6.2.1",
         "mocha": "^9.1.1",
-        "rollup": "^2.70.2",
-        "typescript": "^4.3.5"
+        "rollup": "^2.70.2"
       }
     },
     "packages/labs/scoped-registry-mixin/node_modules/@types/trusted-types": {
@@ -31159,7 +30985,6 @@
         "koa-node-resolve": "^1.0.0-pre.5",
         "koa-static": "^5.0.0",
         "mocha": "^9.1.1",
-        "typescript": "^4.3.5",
         "uvu": "^0.5.1"
       },
       "engines": {
@@ -31177,8 +31002,7 @@
       },
       "devDependencies": {
         "@lit-internal/scripts": "^1.0.0",
-        "rollup": "^2.70.2",
-        "typescript": "^4.3.5"
+        "rollup": "^2.70.2"
       }
     },
     "packages/labs/ssr/node_modules/ansi-colors": {
@@ -31528,8 +31352,7 @@
         "chokidar-cli": "^3.0.0",
         "concurrently": "^6.2.1",
         "mocha": "^9.1.1",
-        "rollup": "^2.70.2",
-        "typescript": "^4.3.5"
+        "rollup": "^2.70.2"
       }
     },
     "packages/labs/task/node_modules/@types/trusted-types": {
@@ -32190,20 +32013,7 @@
         "lit": "^2.0.0"
       },
       "devDependencies": {
-        "typescript": "~4.3.5"
-      }
-    },
-    "packages/labs/test-projects/test-element-a/node_modules/typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
+        "typescript": "~4.7.4"
       }
     },
     "packages/labs/testing": {
@@ -32247,8 +32057,7 @@
         "rollup-plugin-filesize": "^6.1.1",
         "rollup-plugin-node-resolve": "^4.2.3",
         "rollup-plugin-terser": "^5.0.0",
-        "tachometer": "^0.6.0",
-        "typescript": "^4.1.3"
+        "tachometer": "^0.6.0"
       }
     },
     "packages/labs/virtualizer/node_modules/@types/mocha": {
@@ -33048,8 +32857,7 @@
         "chokidar-cli": "^3.0.0",
         "concurrently": "^6.2.1",
         "mocha": "^9.1.1",
-        "rollup": "^2.70.2",
-        "typescript": "^4.3.5"
+        "rollup": "^2.70.2"
       }
     },
     "packages/labs/vue-utils/node_modules/@types/trusted-types": {
@@ -33723,8 +33531,7 @@
         "downlevel-dts": "^0.7.0",
         "mocha": "^9.1.1",
         "rollup": "^2.70.2",
-        "tslib": "^2.0.3",
-        "typescript": "^4.3.5"
+        "tslib": "^2.0.3"
       }
     },
     "packages/lit-element": {
@@ -33746,8 +33553,7 @@
         "downlevel-dts": "^0.7.0",
         "mocha": "^9.1.1",
         "rollup": "^2.70.2",
-        "tslib": "^2.0.3",
-        "typescript": "^4.3.5"
+        "tslib": "^2.0.3"
       }
     },
     "packages/lit-element/node_modules/ansi-colors": {
@@ -34307,8 +34113,7 @@
         "chokidar-cli": "^3.0.0",
         "concurrently": "^6.2.1",
         "mocha": "^9.1.1",
-        "rollup": "^2.70.2",
-        "typescript": "^4.3.5"
+        "rollup": "^2.70.2"
       }
     },
     "packages/lit-html/node_modules/@types/trusted-types": {
@@ -35091,7 +34896,7 @@
         "rollup": "^2.73.0",
         "rollup-plugin-summary": "^1.4.3",
         "rollup-plugin-terser": "^7.0.2",
-        "typescript": "~4.6.4"
+        "typescript": "~4.7.4"
       }
     },
     "packages/lit-starter-ts/node_modules/commander": {
@@ -35165,19 +34970,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "packages/lit-starter-ts/node_modules/typescript": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
       }
     },
     "packages/lit/node_modules/ansi-colors": {
@@ -35751,7 +35543,7 @@
         "minimist": "^1.2.5",
         "parse5": "^6.0.1",
         "source-map-support": "^0.5.19",
-        "typescript": "~4.4.0"
+        "typescript": "~4.7.4"
       },
       "bin": {
         "lit-localize": "bin/lit-localize.js"
@@ -35793,8 +35585,7 @@
       },
       "devDependencies": {
         "@lit/localize-tools": "^0.6.0",
-        "@web/dev-server": "^0.1.22",
-        "typescript": "^4.4.3"
+        "@web/dev-server": "^0.1.22"
       }
     },
     "packages/localize/examples/transform-js": {
@@ -35829,7 +35620,7 @@
         "rollup": "^2.70.2",
         "rollup-plugin-summary": "^1.3.0",
         "rollup-plugin-terser": "^7.0.2",
-        "typescript": "^4.4.3"
+        "typescript": "~4.7.4"
       }
     },
     "packages/localize/node_modules/ansi-colors": {
@@ -36181,8 +35972,7 @@
         "@webcomponents/webcomponentsjs": "^2.6.0",
         "chokidar-cli": "^3.0.0",
         "mocha": "^9.1.1",
-        "rollup": "^2.70.2",
-        "typescript": "^4.3.5"
+        "rollup": "^2.70.2"
       }
     },
     "packages/reactive-element/node_modules/ansi-colors": {
@@ -36880,7 +36670,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "ts-clone-node": "=0.3.30",
-        "typescript": "~4.4.0"
+        "typescript": "~4.7.4"
       },
       "devDependencies": {
         "@lit/localize": "^0.11.0",
@@ -39182,8 +38972,7 @@
         "chromedriver": "^103.0.0",
         "lit-element": "^3.1.0",
         "lit-html": "^2.1.0",
-        "tachometer": "^0.6.0-pre.1",
-        "typescript": "^4.3.5"
+        "tachometer": "^0.6.0-pre.1"
       }
     },
     "@lit-internal/localize-examples-runtime-js": {
@@ -39203,8 +38992,7 @@
         "@lit/localize-tools": "^0.6.0",
         "@material/mwc-circular-progress": "^0.25.1",
         "@web/dev-server": "^0.1.22",
-        "lit": "^2.0.0",
-        "typescript": "^4.4.3"
+        "lit": "^2.0.0"
       }
     },
     "@lit-internal/localize-examples-transform-js": {
@@ -39233,7 +39021,7 @@
         "rollup": "^2.70.2",
         "rollup-plugin-summary": "^1.3.0",
         "rollup-plugin-terser": "^7.0.2",
-        "typescript": "^4.4.3"
+        "typescript": "~4.7.4"
       }
     },
     "@lit-internal/scripts": {
@@ -39250,23 +39038,14 @@
         "fast-glob": "^3.2.5",
         "line-reader": "^0.4.0",
         "marked": "^4.0.16",
-        "puppeteer": "^14.3.0",
-        "typescript": "^4.3.5"
+        "puppeteer": "^14.3.0"
       }
     },
     "@lit-internal/test-element-a": {
       "version": "file:packages/labs/test-projects/test-element-a",
       "requires": {
         "lit": "^2.0.0",
-        "typescript": "~4.3.5"
-      },
-      "dependencies": {
-        "typescript": {
-          "version": "4.3.5",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-          "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
-          "dev": true
-        }
+        "typescript": "~4.7.4"
       }
     },
     "@lit-internal/tests": {
@@ -39403,15 +39182,8 @@
         "@types/node": "^16.7.8",
         "lit-analyzer-test-files": "./test-files/basic-elements/",
         "package-json-type": "^1.0.3",
-        "typescript": "~4.6.2",
+        "typescript": "~4.7.4",
         "uvu": "^0.5.1"
-      },
-      "dependencies": {
-        "typescript": {
-          "version": "4.6.4",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-          "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg=="
-        }
       }
     },
     "@lit-labs/cli": {
@@ -39434,7 +39206,6 @@
         "globby": "^10.0.2",
         "stdout-stderr": "^0.1.13",
         "tslib": "^1.14.1",
-        "typescript": "~4.6.2",
         "uvu": "^0.5.3"
       },
       "dependencies": {
@@ -39812,12 +39583,6 @@
             "prelude-ls": "~1.1.2"
           }
         },
-        "typescript": {
-          "version": "4.6.4",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-          "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
-          "dev": true
-        },
         "which": {
           "version": "1.3.1",
           "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
@@ -39843,8 +39608,7 @@
         "concurrently": "^5.3.0",
         "lit": "^2.0.0",
         "mocha": "^8.1.3",
-        "rollup": "^2.28.2",
-        "typescript": "^4.1.3"
+        "rollup": "^2.28.2"
       },
       "dependencies": {
         "@types/mocha": {
@@ -39864,7 +39628,6 @@
         "@webcomponents/template-shadowroot": "^0.1.0",
         "lit": "^2.0.2",
         "rimraf": "^3.0.2",
-        "typescript": "^4.1.3",
         "uvu": "^0.5.3"
       }
     },
@@ -39874,7 +39637,6 @@
         "@lit-internal/tests": "^0.0.0",
         "@lit-labs/analyzer": "^0.2.0",
         "@types/node": "^17.0.31",
-        "typescript": "~4.6.2",
         "uvu": "^0.5.3"
       },
       "dependencies": {
@@ -39882,12 +39644,6 @@
           "version": "17.0.45",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
           "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
-          "dev": true
-        },
-        "typescript": {
-          "version": "4.6.4",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-          "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
           "dev": true
         }
       }
@@ -39902,7 +39658,6 @@
         "@types/chai": "^4.0.1",
         "@types/mocha": "^9.0.0",
         "@types/node": "^17.0.31",
-        "typescript": "~4.6.2",
         "uvu": "^0.5.3"
       },
       "dependencies": {
@@ -39910,12 +39665,6 @@
           "version": "17.0.45",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
           "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
-          "dev": true
-        },
-        "typescript": {
-          "version": "4.6.4",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-          "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
           "dev": true
         }
       }
@@ -39927,7 +39676,6 @@
         "@lit-labs/analyzer": "^0.2.0",
         "@lit-labs/gen-utils": "^0.0.1",
         "@types/node": "^17.0.31",
-        "typescript": "~4.6.2",
         "uvu": "^0.5.3"
       },
       "dependencies": {
@@ -39935,12 +39683,6 @@
           "version": "17.0.45",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
           "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
-          "dev": true
-        },
-        "typescript": {
-          "version": "4.6.4",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-          "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
           "dev": true
         }
       }
@@ -39953,7 +39695,6 @@
         "@lit-labs/gen-utils": "^0.0.1",
         "@lit-labs/vue-utils": "^0.0.1",
         "@types/node": "^17.0.31",
-        "typescript": "^4.6.4",
         "uvu": "^0.5.3"
       },
       "dependencies": {
@@ -39961,12 +39702,6 @@
           "version": "17.0.45",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
           "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
-          "dev": true
-        },
-        "typescript": {
-          "version": "4.7.4",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-          "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
           "dev": true
         }
       }
@@ -39985,8 +39720,7 @@
         "concurrently": "^6.2.1",
         "lit": "^2.0.0",
         "mocha": "^9.1.1",
-        "rollup": "^2.70.2",
-        "typescript": "^4.3.5"
+        "rollup": "^2.70.2"
       },
       "dependencies": {
         "@types/trusted-types": {
@@ -40503,8 +40237,7 @@
         "chokidar-cli": "^3.0.0",
         "concurrently": "^6.2.1",
         "mocha": "^9.1.1",
-        "rollup": "^2.70.2",
-        "typescript": "^4.3.5"
+        "rollup": "^2.70.2"
       },
       "dependencies": {
         "@types/trusted-types": {
@@ -41025,8 +40758,7 @@
         "mocha": "^9.1.1",
         "react": "^17.0.1",
         "react-dom": "^17.0.1",
-        "rollup": "^2.70.2",
-        "typescript": "^4.3.5"
+        "rollup": "^2.70.2"
       },
       "dependencies": {
         "@types/trusted-types": {
@@ -41544,7 +41276,6 @@
         "lit": "^2.1.0",
         "mocha": "^9.1.1",
         "rollup": "^2.70.2",
-        "typescript": "^4.3.5",
         "urlpattern-polyfill": "^4.0.3"
       },
       "dependencies": {
@@ -42064,8 +41795,7 @@
         "concurrently": "^6.2.1",
         "lit": "^2.0.0",
         "mocha": "^9.1.1",
-        "rollup": "^2.70.2",
-        "typescript": "^4.3.5"
+        "rollup": "^2.70.2"
       },
       "dependencies": {
         "@types/trusted-types": {
@@ -42604,7 +42334,6 @@
         "node-fetch": "^2.6.0",
         "parse5": "^6.0.1",
         "resolve": "^1.10.1",
-        "typescript": "^4.3.5",
         "uvu": "^0.5.1"
       },
       "dependencies": {
@@ -42852,8 +42581,7 @@
         "@lit/reactive-element": "^1.0.0",
         "lit": "^2.0.0",
         "lit-html": "^2.0.0",
-        "rollup": "^2.70.2",
-        "typescript": "^4.3.5"
+        "rollup": "^2.70.2"
       }
     },
     "@lit-labs/task": {
@@ -42869,8 +42597,7 @@
         "chokidar-cli": "^3.0.0",
         "concurrently": "^6.2.1",
         "mocha": "^9.1.1",
-        "rollup": "^2.70.2",
-        "typescript": "^4.3.5"
+        "rollup": "^2.70.2"
       },
       "dependencies": {
         "@types/trusted-types": {
@@ -43407,8 +43134,7 @@
         "rollup-plugin-node-resolve": "^4.2.3",
         "rollup-plugin-terser": "^5.0.0",
         "tachometer": "^0.6.0",
-        "tslib": "^1.10.0",
-        "typescript": "^4.1.3"
+        "tslib": "^1.10.0"
       },
       "dependencies": {
         "@types/mocha": {
@@ -44036,7 +43762,6 @@
         "concurrently": "^6.2.1",
         "mocha": "^9.1.1",
         "rollup": "^2.70.2",
-        "typescript": "^4.3.5",
         "vue": "^3.2.25"
       },
       "dependencies": {
@@ -44644,7 +44369,7 @@
         "rollup": "^2.73.0",
         "rollup-plugin-summary": "^1.4.3",
         "rollup-plugin-terser": "^7.0.2",
-        "typescript": "~4.6.4"
+        "typescript": "~4.7.4"
       },
       "dependencies": {
         "commander": {
@@ -44698,12 +44423,6 @@
             "commander": "^2.20.0",
             "source-map-support": "~0.5.20"
           }
-        },
-        "typescript": {
-          "version": "4.6.4",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-          "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
-          "dev": true
         }
       }
     },
@@ -44979,7 +44698,7 @@
         "parse5": "^6.0.1",
         "rimraf": "^3.0.2",
         "source-map-support": "^0.5.19",
-        "typescript": "~4.4.0",
+        "typescript": "~4.7.4",
         "typescript-json-schema": "^0.50.0",
         "uvu": "^0.5.1"
       }
@@ -45001,8 +44720,7 @@
         "@webcomponents/webcomponentsjs": "^2.6.0",
         "chokidar-cli": "^3.0.0",
         "mocha": "^9.1.1",
-        "rollup": "^2.70.2",
-        "typescript": "^4.3.5"
+        "rollup": "^2.70.2"
       },
       "dependencies": {
         "ansi-colors": {
@@ -45419,7 +45137,7 @@
         "prettier": "^2.3.2",
         "rimraf": "^3.0.2",
         "ts-clone-node": "=0.3.30",
-        "typescript": "~4.4.0",
+        "typescript": "~4.7.4",
         "uvu": "^0.5.1"
       }
     },
@@ -47498,13 +47216,6 @@
           "requires": {
             "brace-expansion": "^2.0.1"
           }
-        },
-        "typescript": {
-          "version": "4.7.4",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-          "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
-          "dev": true,
-          "peer": true
         }
       }
     },
@@ -47578,13 +47289,6 @@
             "@types/node": "^18.0.0",
             "got": "^11.8.1"
           }
-        },
-        "typescript": {
-          "version": "4.7.4",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-          "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
-          "dev": true,
-          "peer": true
         }
       }
     },
@@ -49225,14 +48929,6 @@
         "mitt": "^1.1.3",
         "rxjs": "^5.5.6",
         "typescript": "^4.6.2"
-      },
-      "dependencies": {
-        "typescript": {
-          "version": "4.7.4",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-          "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
-          "dev": true
-        }
       }
     },
     "browser-sync-ui": {
@@ -51537,13 +51233,6 @@
             "@types/node": "^18.0.0",
             "got": "^11.8.1"
           }
-        },
-        "typescript": {
-          "version": "4.7.4",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-          "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
-          "dev": true,
-          "peer": true
         },
         "uuid": {
           "version": "8.3.2",
@@ -56466,8 +56155,7 @@
         "lit-html": "^2.2.0",
         "mocha": "^9.1.1",
         "rollup": "^2.70.2",
-        "tslib": "^2.0.3",
-        "typescript": "^4.3.5"
+        "tslib": "^2.0.3"
       },
       "dependencies": {
         "ansi-colors": {
@@ -57133,8 +56821,7 @@
         "lit-html": "^2.2.0",
         "mocha": "^9.1.1",
         "rollup": "^2.70.2",
-        "tslib": "^2.0.3",
-        "typescript": "^4.3.5"
+        "tslib": "^2.0.3"
       },
       "dependencies": {
         "ansi-colors": {
@@ -57561,8 +57248,7 @@
         "chokidar-cli": "^3.0.0",
         "concurrently": "^6.2.1",
         "mocha": "^9.1.1",
-        "rollup": "^2.70.2",
-        "typescript": "^4.3.5"
+        "rollup": "^2.70.2"
       },
       "dependencies": {
         "@types/trusted-types": {
@@ -64291,9 +63977,9 @@
       }
     },
     "typescript": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
-      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA=="
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="
     },
     "typescript-json-schema": {
       "version": "0.50.1",
@@ -65095,13 +64781,6 @@
             "@types/node": "^18.0.0",
             "got": "^11.8.1"
           }
-        },
-        "typescript": {
-          "version": "4.7.4",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-          "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
-          "dev": true,
-          "peer": true
         }
       }
     },
@@ -65179,13 +64858,6 @@
           "requires": {
             "brace-expansion": "^2.0.1"
           }
-        },
-        "typescript": {
-          "version": "4.7.4",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-          "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
-          "dev": true,
-          "peer": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
     "rollup-plugin-sourcemaps": "^0.6.2",
     "rollup-plugin-summary": "~1.3.0",
     "rollup-plugin-terser": "^7.0.2",
-    "typescript": "~4.4.0",
+    "typescript": "~4.7.4",
     "wireit": "^0.7.1"
   },
   "lint-staged": {

--- a/packages/benchmarks/generator/package.json
+++ b/packages/benchmarks/generator/package.json
@@ -41,7 +41,6 @@
   },
   "devDependencies": {
     "puppeteer": "^4.0.0",
-    "tachometer": "^0.6.0",
-    "typescript": "^4.3.5"
+    "tachometer": "^0.6.0"
   }
 }

--- a/packages/benchmarks/package.json
+++ b/packages/benchmarks/package.json
@@ -65,7 +65,6 @@
     "tachometer": "^0.6.0-pre.1"
   },
   "devDependencies": {
-    "chromedriver": "^103.0.0",
-    "typescript": "^4.3.5"
+    "chromedriver": "^103.0.0"
   }
 }

--- a/packages/internal-scripts/package.json
+++ b/packages/internal-scripts/package.json
@@ -44,8 +44,7 @@
     "fast-glob": "^3.2.5",
     "line-reader": "^0.4.0",
     "marked": "^4.0.16",
-    "puppeteer": "^14.3.0",
-    "typescript": "^4.3.5"
+    "puppeteer": "^14.3.0"
   },
   "devDependencies": {
     "@types/changelog-parser": "^2.8.1",

--- a/packages/labs/analyzer/package.json
+++ b/packages/labs/analyzer/package.json
@@ -55,7 +55,7 @@
   ],
   "dependencies": {
     "package-json-type": "^1.0.3",
-    "typescript": "~4.6.2"
+    "typescript": "~4.7.4"
   },
   "devDependencies": {
     "@types/node": "^16.7.8",

--- a/packages/labs/analyzer/src/test/lit-element/properties_test.ts
+++ b/packages/labs/analyzer/src/test/lit-element/properties_test.ts
@@ -131,22 +131,22 @@ test('property typed with global class', ({element}) => {
 
 test('property typed with union', ({element}) => {
   const property = element.reactiveProperties.get('union')!;
-  assert.equal(property.type.text, 'LocalClass | HTMLElement | ImportedClass');
+  assert.equal(property.type.text, 'ImportedClass | LocalClass | HTMLElement');
   assert.equal(property.type.references.length, 3);
-  assert.equal(property.type.references[0].name, 'LocalClass');
+  assert.equal(property.type.references[1].name, 'LocalClass');
+  assert.equal(
+    property.type.references[1].package,
+    '@lit-internal/test-decorators-properties'
+  );
+  assert.equal(property.type.references[1].module, 'element-a.js');
+  assert.equal(property.type.references[2].name, 'HTMLElement');
+  assert.equal(property.type.references[2].isGlobal, true);
+  assert.equal(property.type.references[0].name, 'ImportedClass');
   assert.equal(
     property.type.references[0].package,
     '@lit-internal/test-decorators-properties'
   );
-  assert.equal(property.type.references[0].module, 'element-a.js');
-  assert.equal(property.type.references[1].name, 'HTMLElement');
-  assert.equal(property.type.references[1].isGlobal, true);
-  assert.equal(property.type.references[2].name, 'ImportedClass');
-  assert.equal(
-    property.type.references[2].package,
-    '@lit-internal/test-decorators-properties'
-  );
-  assert.equal(property.type.references[2].module, 'external.js');
+  assert.equal(property.type.references[0].module, 'external.js');
 });
 
 test('reflect: true', ({element}) => {

--- a/packages/labs/cli/package.json
+++ b/packages/labs/cli/package.json
@@ -95,7 +95,6 @@
     "eslint": "^5.16.0",
     "globby": "^10.0.2",
     "stdout-stderr": "^0.1.13",
-    "typescript": "~4.6.2",
     "uvu": "^0.5.3"
   },
   "engines": {

--- a/packages/labs/context/package.json
+++ b/packages/labs/context/package.json
@@ -144,8 +144,7 @@
     "concurrently": "^5.3.0",
     "@lit-internal/scripts": "^1.0.0",
     "mocha": "^8.1.3",
-    "rollup": "^2.28.2",
-    "typescript": "^4.1.3"
+    "rollup": "^2.28.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/labs/eleventy-plugin-lit/package.json
+++ b/packages/labs/eleventy-plugin-lit/package.json
@@ -98,7 +98,6 @@
     "@web/dev-server": "^0.1.11",
     "@webcomponents/template-shadowroot": "^0.1.0",
     "rimraf": "^3.0.2",
-    "typescript": "^4.1.3",
     "uvu": "^0.5.3"
   }
 }

--- a/packages/labs/gen-utils/package.json
+++ b/packages/labs/gen-utils/package.json
@@ -49,7 +49,6 @@
   "devDependencies": {
     "@types/node": "^17.0.31",
     "@lit-internal/tests": "^0.0.0",
-    "typescript": "~4.6.2",
     "uvu": "^0.5.3"
   },
   "engines": {

--- a/packages/labs/gen-wrapper-angular/goldens/test-element-a/package.json
+++ b/packages/labs/gen-wrapper-angular/goldens/test-element-a/package.json
@@ -14,7 +14,7 @@
     "@angular/core": "^13.3.0"
   },
   "devDependencies": {
-    "typescript": "~4.3.5"
+    "typescript": "~4.7.4"
   },
   "files": [
     "element-a.js"

--- a/packages/labs/gen-wrapper-angular/package.json
+++ b/packages/labs/gen-wrapper-angular/package.json
@@ -60,7 +60,6 @@
     "@types/chai": "^4.0.1",
     "@types/mocha": "^9.0.0",
     "@types/node": "^17.0.31",
-    "typescript": "~4.6.2",
     "uvu": "^0.5.3"
   },
   "engines": {

--- a/packages/labs/gen-wrapper-angular/src/lib/package-json-template.ts
+++ b/packages/labs/gen-wrapper-angular/src/lib/package-json-template.ts
@@ -35,7 +35,7 @@ export const packageJsonTemplate = (
       },
       devDependencies: {
         // Use typescript from source package, assuming it exists
-        typescript: packageJson?.devDependencies?.typescript ?? '~4.3.5',
+        typescript: packageJson?.devDependencies?.typescript ?? '~4.7.4',
       },
       files: [...litModules.map(({module}) => module.jsPath)],
     },

--- a/packages/labs/gen-wrapper-react/goldens/test-element-a/package.json
+++ b/packages/labs/gen-wrapper-react/goldens/test-element-a/package.json
@@ -15,7 +15,7 @@
     "@types/react": "^17 || ^18"
   },
   "devDependencies": {
-    "typescript": "~4.3.5"
+    "typescript": "~4.7.4"
   },
   "files": [
     "element-a.{js,js.map,d.ts,d.ts.map}"

--- a/packages/labs/gen-wrapper-react/package.json
+++ b/packages/labs/gen-wrapper-react/package.json
@@ -65,7 +65,6 @@
   "devDependencies": {
     "@types/node": "^17.0.31",
     "@lit-internal/tests": "^0.0.0",
-    "typescript": "~4.6.2",
     "uvu": "^0.5.3"
   },
   "engines": {

--- a/packages/labs/gen-wrapper-react/src/index.ts
+++ b/packages/labs/gen-wrapper-react/src/index.ts
@@ -98,7 +98,7 @@ const packageJsonTemplate = (pkgJson: PackageJson, litModules: LitModule[]) => {
       },
       devDependencies: {
         // Use typescript from source package, assuming it exists
-        typescript: pkgJson?.devDependencies?.typescript ?? '~4.3.5',
+        typescript: pkgJson?.devDependencies?.typescript ?? '~4.7.4',
       },
       files: [
         ...litModules.map(({module}) =>

--- a/packages/labs/gen-wrapper-vue/goldens/test-element-a/package.json
+++ b/packages/labs/gen-wrapper-vue/goldens/test-element-a/package.json
@@ -15,7 +15,7 @@
     "@lit-labs/vue-utils": "^0.0.1"
   },
   "devDependencies": {
-    "typescript": "~4.3.5",
+    "typescript": "~4.7.4",
     "@vitejs/plugin-vue": "^2.3.1",
     "@rollup/plugin-typescript": "^8.3.2",
     "vite": "^2.9.2",

--- a/packages/labs/gen-wrapper-vue/package.json
+++ b/packages/labs/gen-wrapper-vue/package.json
@@ -66,7 +66,6 @@
   "devDependencies": {
     "@types/node": "^17.0.31",
     "@lit-internal/tests": "^0.0.0",
-    "typescript": "^4.6.4",
     "uvu": "^0.5.3"
   },
   "engines": {

--- a/packages/labs/gen-wrapper-vue/src/lib/package-json-template.ts
+++ b/packages/labs/gen-wrapper-vue/src/lib/package-json-template.ts
@@ -38,7 +38,7 @@ export const packageJsonTemplate = (
       },
       devDependencies: {
         // Use typescript from source package, assuming it exists
-        typescript: pkgJson?.devDependencies?.typescript ?? '^4.6.4',
+        typescript: pkgJson?.devDependencies?.typescript ?? '~4.7.4',
         '@vitejs/plugin-vue': '^2.3.1',
         '@rollup/plugin-typescript': '^8.3.2',
         vite: '^2.9.2',

--- a/packages/labs/gen-wrapper-vue/test-output/package.json
+++ b/packages/labs/gen-wrapper-vue/test-output/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^2.3.1",
-    "typescript": "^4.7.4",
+    "typescript": "~4.7.4",
     "vite": "^2.9.2",
     "vue-tsc": "^0.29.8"
   },

--- a/packages/labs/gen-wrapper-vue/test-output/package.json
+++ b/packages/labs/gen-wrapper-vue/test-output/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^2.3.1",
-    "typescript": "^4.6.4",
+    "typescript": "^4.7.4",
     "vite": "^2.9.2",
     "vue-tsc": "^0.29.8"
   },

--- a/packages/labs/motion/package.json
+++ b/packages/labs/motion/package.json
@@ -149,8 +149,7 @@
     "concurrently": "^6.2.1",
     "@lit-internal/scripts": "^1.0.0",
     "mocha": "^9.1.1",
-    "rollup": "^2.70.2",
-    "typescript": "^4.3.5"
+    "rollup": "^2.70.2"
   },
   "dependencies": {
     "lit": "^2.0.0"

--- a/packages/labs/observers/package.json
+++ b/packages/labs/observers/package.json
@@ -158,7 +158,6 @@
     "concurrently": "^6.2.1",
     "mocha": "^9.1.1",
     "rollup": "^2.70.2",
-    "typescript": "^4.3.5",
     "@lit-internal/scripts": "^1.0.0"
   },
   "dependencies": {

--- a/packages/labs/react/package.json
+++ b/packages/labs/react/package.json
@@ -149,8 +149,7 @@
     "mocha": "^9.1.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
-    "rollup": "^2.70.2",
-    "typescript": "^4.3.5"
+    "rollup": "^2.70.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/labs/router/package.json
+++ b/packages/labs/router/package.json
@@ -154,7 +154,6 @@
     "@lit-internal/scripts": "^1.0.0",
     "mocha": "^9.1.1",
     "rollup": "^2.70.2",
-    "typescript": "^4.3.5",
     "urlpattern-polyfill": "^4.0.3"
   },
   "dependencies": {

--- a/packages/labs/scoped-registry-mixin/package.json
+++ b/packages/labs/scoped-registry-mixin/package.json
@@ -148,7 +148,6 @@
     "concurrently": "^6.2.1",
     "mocha": "^9.1.1",
     "rollup": "^2.70.2",
-    "typescript": "^4.3.5",
     "@lit-internal/scripts": "^1.0.0"
   },
   "publishConfig": {

--- a/packages/labs/ssr-client/package.json
+++ b/packages/labs/ssr-client/package.json
@@ -104,7 +104,6 @@
   "author": "Google LLC",
   "devDependencies": {
     "rollup": "^2.70.2",
-    "typescript": "^4.3.5",
     "@lit-internal/scripts": "^1.0.0"
   },
   "dependencies": {

--- a/packages/labs/ssr/package.json
+++ b/packages/labs/ssr/package.json
@@ -152,7 +152,6 @@
     "koa-node-resolve": "^1.0.0-pre.5",
     "koa-static": "^5.0.0",
     "mocha": "^9.1.1",
-    "typescript": "^4.3.5",
     "uvu": "^0.5.1"
   },
   "dependencies": {

--- a/packages/labs/task/package.json
+++ b/packages/labs/task/package.json
@@ -140,7 +140,6 @@
     "concurrently": "^6.2.1",
     "mocha": "^9.1.1",
     "rollup": "^2.70.2",
-    "typescript": "^4.3.5",
     "@lit-internal/scripts": "^1.0.0"
   },
   "dependencies": {

--- a/packages/labs/test-projects/test-element-a/package.json
+++ b/packages/labs/test-projects/test-element-a/package.json
@@ -13,7 +13,7 @@
     "lit": "^2.0.0"
   },
   "devDependencies": {
-    "typescript": "~4.3.5"
+    "typescript": "~4.7.4"
   },
   "wireit": {
     "build": {

--- a/packages/labs/virtualizer/package.json
+++ b/packages/labs/virtualizer/package.json
@@ -116,8 +116,7 @@
     "rollup-plugin-filesize": "^6.1.1",
     "rollup-plugin-node-resolve": "^4.2.3",
     "rollup-plugin-terser": "^5.0.0",
-    "tachometer": "^0.6.0",
-    "typescript": "^4.1.3"
+    "tachometer": "^0.6.0"
   },
   "dependencies": {
     "event-target-shim": "^5.0.1",

--- a/packages/labs/vue-utils/package.json
+++ b/packages/labs/vue-utils/package.json
@@ -112,8 +112,7 @@
     "concurrently": "^6.2.1",
     "@lit-internal/scripts": "^1.0.0",
     "mocha": "^9.1.1",
-    "rollup": "^2.70.2",
-    "typescript": "^4.3.5"
+    "rollup": "^2.70.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/lit-element/package.json
+++ b/packages/lit-element/package.json
@@ -233,8 +233,7 @@
     "@lit-internal/scripts": "^1.0.0",
     "mocha": "^9.1.1",
     "rollup": "^2.70.2",
-    "tslib": "^2.0.3",
-    "typescript": "^4.3.5"
+    "tslib": "^2.0.3"
   },
   "directories": {
     "test": "test"

--- a/packages/lit-html/package.json
+++ b/packages/lit-html/package.json
@@ -292,8 +292,7 @@
     "concurrently": "^6.2.1",
     "@lit-internal/scripts": "^1.0.0",
     "mocha": "^9.1.1",
-    "rollup": "^2.70.2",
-    "typescript": "^4.3.5"
+    "rollup": "^2.70.2"
   },
   "typings": "lit-html.d.ts",
   "directories": {

--- a/packages/lit-starter-ts/package.json
+++ b/packages/lit-starter-ts/package.json
@@ -64,7 +64,7 @@
     "rollup": "^2.73.0",
     "rollup-plugin-summary": "^1.4.3",
     "rollup-plugin-terser": "^7.0.2",
-    "typescript": "~4.6.4"
+    "typescript": "~4.7.4"
   },
   "customElements": "custom-elements.json"
 }

--- a/packages/lit/package.json
+++ b/packages/lit/package.json
@@ -292,8 +292,7 @@
     "@lit-internal/scripts": "^1.0.0",
     "mocha": "^9.1.1",
     "rollup": "^2.70.2",
-    "tslib": "^2.0.3",
-    "typescript": "^4.3.5"
+    "tslib": "^2.0.3"
   },
   "typings": "index.d.ts"
 }

--- a/packages/localize-tools/package.json
+++ b/packages/localize-tools/package.json
@@ -139,7 +139,7 @@
     "minimist": "^1.2.5",
     "parse5": "^6.0.1",
     "source-map-support": "^0.5.19",
-    "typescript": "~4.4.0"
+    "typescript": "~4.7.4"
   },
   "devDependencies": {
     "@lit-labs/ssr": "^2.1.0",

--- a/packages/localize/examples/runtime-ts/package.json
+++ b/packages/localize/examples/runtime-ts/package.json
@@ -57,7 +57,6 @@
   },
   "devDependencies": {
     "@lit/localize-tools": "^0.6.0",
-    "@web/dev-server": "^0.1.22",
-    "typescript": "^4.4.3"
+    "@web/dev-server": "^0.1.22"
   }
 }

--- a/packages/localize/examples/transform-ts/package.json
+++ b/packages/localize/examples/transform-ts/package.json
@@ -63,6 +63,6 @@
     "rollup": "^2.70.2",
     "rollup-plugin-summary": "^1.3.0",
     "rollup-plugin-terser": "^7.0.2",
-    "typescript": "^4.4.3"
+    "typescript": "~4.7.4"
   }
 }

--- a/packages/reactive-element/package.json
+++ b/packages/reactive-element/package.json
@@ -235,8 +235,7 @@
     "chokidar-cli": "^3.0.0",
     "@lit-internal/scripts": "^1.0.0",
     "mocha": "^9.1.1",
-    "rollup": "^2.70.2",
-    "typescript": "^4.3.5"
+    "rollup": "^2.70.2"
   },
   "typings": "reactive-element.d.ts",
   "directories": {

--- a/packages/ts-transformers/package.json
+++ b/packages/ts-transformers/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "ts-clone-node": "=0.3.30",
-    "typescript": "~4.4.0"
+    "typescript": "~4.7.4"
   },
   "devDependencies": {
     "@lit/localize": "^0.11.0",

--- a/packages/ts-transformers/src/tests/idiomatic-decorators-test.ts
+++ b/packages/ts-transformers/src/tests/idiomatic-decorators-test.ts
@@ -2001,17 +2001,17 @@ const tests = (test: uvu.Test<uvu.Context>, options: ts.CompilerOptions) => {
 
 const baseOptions = () => {
   const options = ts.getDefaultCompilerOptions();
-  options.target = ts.ScriptTarget.ESNext;
-  options.module = ts.ModuleKind.ESNext;
   options.moduleResolution = ts.ModuleResolutionKind.NodeJs;
   options.importHelpers = true;
   return options;
 };
 
 const standardOptions = baseOptions();
+standardOptions.target = ts.ScriptTarget.ESNext;
 standardOptions.useDefineForClassFields = true;
 tests(suite('standard class field emit'), standardOptions);
 
 const legacyOptions = baseOptions();
+legacyOptions.target = ts.ScriptTarget.ES2021;
 legacyOptions.useDefineForClassFields = false;
 tests(suite('legacy class field emit'), legacyOptions);


### PR DESCRIPTION
- All packages now depend on TypeScript `~4.7.4`.
- `~` is used instead of `^` because TypeScript doesn't follow semver.
- I took `typescript` out of the `devDependencies` for most packages, so that they just rely on the one in the top-level `package.json`. This is to make it more likely we'll upgrade all packages at once in the future, instead of one at a time.
- `@lit/ts-transformers`, `@lit/localize-tools`, and `@lit-labs/analyzer` include `typescript` in their production dependencies, so those get a changeset and will get releases.
- `@lit/ts-transformers` needed a fix in the tests so that the "legacy" output emits `ES2021` instead of `ESNext`, since it will include static class initializer blocks otherwise.
- A `@lit-labs/analyzer` test had to be upgraded to due some minor change in the way a generated type union was formatted.
- This drops 800MB off our total npm install size, if you can believe that, since each typescript version is ~65MB, and we had a bunch of versions which needed to get duplicated into multiple sub-package `node_modules/` folders.