### PR TITLE
[labs/ssr] Inline source in source maps

### DIFF
--- a/.changeset/fifty-shirts-flash.md
+++ b/.changeset/fifty-shirts-flash.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/ssr': patch
+---
+
+JS source maps now include the TS source inline

--- a/packages/labs/ssr/tsconfig.json
+++ b/packages/labs/ssr/tsconfig.json
@@ -8,6 +8,7 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
+    "inlineSources": true,
     "outDir": ".",
     "rootDir": "./src",
     // For module loader tests:


### PR DESCRIPTION
Fixes #2645 

tsconfig was missing `inlineSources` option for labs/ssr package.

~~Alternative fix would be to actually include the source ts files in the npm package. Since this package is meant for server/node use only, would that potentially be preferable?~~
Will stick with inline sourcemap to be consistent with the rest of our packages.