### PR TITLE
Update release-image such that it can accept multiple packages and versions

### DIFF
--- a/.changeset/small-doors-develop.md
+++ b/.changeset/small-doors-develop.md
@@ -1,5 +1,2 @@
 ---
-'@lit-internal/scripts': minor
 ---
-
-Add multiple changelogs and version support to the release-image tool.

--- a/.changeset/small-doors-develop.md
+++ b/.changeset/small-doors-develop.md
@@ -1,0 +1,5 @@
+---
+'@lit-internal/scripts': minor
+---
+
+Add multiple changelogs and version support to the release-image tool.

--- a/packages/internal-scripts/src/release-image.ts
+++ b/packages/internal-scripts/src/release-image.ts
@@ -12,47 +12,90 @@ import {readFile} from 'fs/promises';
 import path from 'path';
 
 const optionDefinitions = [
-  {name: 'file', type: String, defaultOption: true},
-  {name: 'version', type: String},
+  {
+    name: 'files',
+    alias: 'f',
+    type: String,
+    defaultOption: true,
+    multiple: true,
+  },
+  {name: 'versions', alias: 'v', type: String, multiple: true},
 ];
+
+/**
+ * A cache of the parsed changelogs such that a package may be referenced
+ * multiple times to render multiple versions.
+ */
+const CHANGELOG_CACHE = new Map<string, Changelog>();
 
 export const run = async () => {
   const options = commandLineArgs(optionDefinitions);
 
-  if (!options.file) {
+  if (
+    !options.files ||
+    !Array.isArray(options.files) ||
+    (Array.isArray(options.versions) &&
+      options.versions.length !== options.files.length)
+  ) {
     console.error(
       `
 USAGE
-    release-image CHANGELOG_PATH [--version VERSION]
+    release-image CHANGELOG_PATH
+    release-image (-f CHANGELOG_PATH [-v VERSION])...
 
 EXAMPLES
     To generate the release image for the reactive-element package:
 
         release-image packages/reactive-element/CHANGELOG.md
+
+    For multiple packages in a single image:
+
+        release-image reactive-element/CHANGELOG.md lit-html/CHANGELOG.md
+
+    To generate an image composed of specific version numbers, including
+    multiple versions of the same package:
+
+        release-image -f reactive-element/CHANGELOG.md -v 3.2.0 \\
+                      -f lit-html/CHANGELOG.md -v 2.0.1 \\
+                      -f lit-html/CHANGELOG.md -v 2.0.0
+
           `.trim()
     );
     process.exit(1);
   }
-  const filename: string = options.file;
-  const version: string = options.version;
 
-  const packageJson = JSON.parse(
-    await readFile(path.join(path.dirname(filename), 'package.json'), {
-      encoding: 'utf-8',
-    })
-  );
-  const packageName = packageJson.name;
+  const releasesToRender: Release[] = [];
+  for (let i = 0; i < options.files.length; i++) {
+    const filename: string = options.files[i];
+    const version: string = (options.versions ?? [])[i];
+    let changelog = CHANGELOG_CACHE.get(filename);
+    if (!changelog) {
+      const packageJson = JSON.parse(
+        await readFile(path.join(path.dirname(filename), 'package.json'), {
+          encoding: 'utf-8',
+        })
+      );
+      const packageName = packageJson.name as string;
 
-  console.log(`Reading ${packageName} release ${version} from ${filename}`);
-  const changelog = (await parseChangelog({
-    filePath: filename,
-    removeMarkdown: false,
-  })) as Changelog;
-  const release = await getRelease(changelog, version);
-  if (release === undefined) {
-    throw new Error('no release found');
+      console.log(`Reading ${packageName} release ${version} from ${filename}`);
+      changelog = (await parseChangelog({
+        filePath: filename,
+        removeMarkdown: false,
+      })) as Changelog;
+      changelog.packageName = packageName;
+      CHANGELOG_CACHE.set(filename, changelog);
+    }
+    const release = await getRelease(changelog, version);
+    if (release === undefined) {
+      throw new Error('no release found');
+    }
+    // Fix the release fields since our CHANGELOG files result in `title`
+    // containing the version number.
+    release.version = release.title;
+    release.title = changelog.packageName;
+    releasesToRender.push(release);
   }
-  const body = marked(release.body);
+
   // colors taken from https://github.com/dracula/dracula-theme
   const html = `
      <!doctype html>
@@ -89,8 +132,12 @@ EXAMPLES
          </style>
        </head>
        <body>
-         <h2><span class="name">${packageName}</span> ${release.title}</h2>
-         ${body}
+         ${releasesToRender.map(
+           ({title, body, version}) =>
+             `<h2><span class="name">${title}</span> ${version}</h2>
+           ${marked(body)}
+         `
+         )}
        </body>
      </html>
    `;
@@ -102,7 +149,7 @@ EXAMPLES
   const bounds = (await page.evaluate(`
      document.documentElement.getBoundingClientRect().toJSON()
    `)) as DOMRect;
-  const imageFileName = `${path.basename(packageName)}-${release.title}.png`;
+  const imageFileName = `release.png`;
   await page.screenshot({
     path: imageFileName,
     encoding: 'binary',
@@ -145,6 +192,9 @@ interface Release {
 }
 
 interface Changelog {
+  /** Name of the package, taken from package.json */
+  packageName: string;
+  /** parseChangelog populates this with "Change Log" */
   title: string;
   description: string;
   versions: Array<Release>;

--- a/packages/internal-scripts/src/release-image.ts
+++ b/packages/internal-scripts/src/release-image.ts
@@ -77,7 +77,9 @@ EXAMPLES
       );
       const packageName = packageJson.name as string;
 
-      console.log(`Reading ${packageName} release ${version ?? 'latest'} from ${filename}`);
+      console.log(
+        `Reading ${packageName} release ${version ?? 'latest'} from ${filename}`
+      );
       changelog = (await parseChangelog({
         filePath: filename,
         removeMarkdown: false,
@@ -132,12 +134,13 @@ EXAMPLES
          </style>
        </head>
        <body>
-         ${releasesToRender.map(
-           ({title, body, version}) =>
-             `<h2><span class="name">${title}</span> ${version}</h2>
-           ${marked(body)}
-         `
-         )}
+         ${releasesToRender
+           .map(
+             ({title, body, version}) =>
+               `<h2><span class="name">${title}</span> ${version}</h2>
+              ${marked(body)}`
+           )
+           .join('')}
        </body>
      </html>
    `;

--- a/packages/internal-scripts/src/release-image.ts
+++ b/packages/internal-scripts/src/release-image.ts
@@ -77,7 +77,7 @@ EXAMPLES
       );
       const packageName = packageJson.name as string;
 
-      console.log(`Reading ${packageName} release ${version} from ${filename}`);
+      console.log(`Reading ${packageName} release ${version ?? 'latest'} from ${filename}`);
       changelog = (await parseChangelog({
         filePath: filename,
         removeMarkdown: false,


### PR DESCRIPTION
Part of https://github.com/lit/lit/issues/2503

### Context

Previously the release-image tool could only take one single CHANGELOG and an optional version. This PR extends the tool to concatenate multiple CHANGELOG files and versions making the tool more flexible. This will allow generating a single image for a release.

### Features

 - CLI can now take multiple files and versions with the following pattern: `release-image (-f CHANGELOG_PATH [-v VERSION])...`. If the same changelog is provided multiple times with different versions, the image contains those versions.
 - The packge/release notes are added to the image in the order of the CLI arguments.

For example: `release-image lit-html/CHANGELOG.md -v 2.2.2 -f lit-html/CHANGELOG.md -v 2.2.1` generates the following image:
![release](https://user-images.githubusercontent.com/15080861/179625491-a7029295-1404-40cd-a56d-50afdee43215.png)

If the versions are omitted, the most recent version is returned for each package. For example: `release-image ../lit-html/CHANGELOG.md ../reactive-element/CHANGELOG.md ../lit/CHANGELOG.md` currently generates:
![release](https://user-images.githubusercontent.com/15080861/179625539-afae96da-9e98-4067-8186-31ae246cbb31.png)


This was tested manually and the risk is minimal.
