### PR TITLE
Fix example with `hasNativeDeclarativeShadowRoots`

### DIFF
--- a/packages/labs/ssr/README.md
+++ b/packages/labs/ssr/README.md
@@ -114,7 +114,7 @@ const ssrResult = render(html`
           hasNativeDeclarativeShadowRoots,
           hydrateShadowRoots
         } from './node_modules/@webcomponents/template-shadowroot/template-shadowroot.js';
-        if (!hasNativeDeclarativeShadowRoots) {
+        if (!hasNativeDeclarativeShadowRoots()) {
           hydrateShadowRoots(document.body);
         }
         // ...


### PR DESCRIPTION
Hey, I just tried the examples and the ponyfill is broken because `hasNativeDeclarativeShadowRoots` is actually a function.

https://github.com/webcomponents/template-shadowroot/blob/62ca5560c757a26e3425dd4c97dc48acd2591e01/src/_implementation/feature_detect.ts#L18