### PR TITLE
[labs/testing] Pass module file urls to worker for Windows compatibility

### DIFF
--- a/.changeset/four-rocks-pretend.md
+++ b/.changeset/four-rocks-pretend.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/testing': patch
+---
+
+Make resolved paths sent to worker be file urls. Fixes incompatibility with Windows filepaths.

--- a/package.json
+++ b/package.json
@@ -170,7 +170,8 @@
         "./packages/labs/gen-utils:test",
         "./packages/labs/gen-wrapper-angular:test",
         "./packages/labs/gen-wrapper-react:test",
-        "./packages/labs/gen-wrapper-vue:test"
+        "./packages/labs/gen-wrapper-vue:test",
+        "./packages/labs/testing:test"
       ]
     }
   },

--- a/packages/labs/testing/src/lib/lit-ssr-plugin.ts
+++ b/packages/labs/testing/src/lib/lit-ssr-plugin.ts
@@ -6,6 +6,7 @@
 
 import {Worker} from 'worker_threads';
 import * as pathlib from 'path';
+import {pathToFileURL} from 'node:url';
 import {litSsrPluginCommand} from './constants.js';
 
 import type {TemplateResult} from 'lit';
@@ -29,8 +30,8 @@ export function litSsrPlugin(): TestRunnerPlugin<Payload> {
       }
 
       const {template, modules} = payload;
-      const resolvedModules = modules.map((module) =>
-        pathlib.join(process.cwd(), module)
+      const resolvedModules = modules.map(
+        (module) => pathToFileURL(pathlib.join(process.cwd(), module)).href
       );
 
       let resolve: (value: string) => void;


### PR DESCRIPTION
Fixes #3165 

In Mac/Linux, `process.cwd()` returns an absolute file path starting with `/`.
But in Windows, it returns a path starting with `C:\` which Node's import thinks is specifying some invalid protocol. Converting the absolute file paths to file URLs fixes this as it'll always begin with `file://`.

I also added the test for this package to `windows-tools` test job.