### PR TITLE
Export StaticValue from lit-html/static

### DIFF
--- a/.changeset/hip-eels-ring.md
+++ b/.changeset/hip-eels-ring.md
@@ -1,5 +1,4 @@
 ---
-'lit': patch
 'lit-html': patch
 ---
 

--- a/.changeset/hip-eels-ring.md
+++ b/.changeset/hip-eels-ring.md
@@ -1,0 +1,6 @@
+---
+'lit': patch
+'lit-html': patch
+---
+
+export StaticValue type

--- a/.changeset/hip-eels-ring.md
+++ b/.changeset/hip-eels-ring.md
@@ -3,4 +3,4 @@
 'lit-html': patch
 ---
 
-export StaticValue type
+`StaticValue` interface type is now exported.

--- a/packages/lit-html/src/static.ts
+++ b/packages/lit-html/src/static.ts
@@ -9,7 +9,7 @@
 
 import {html as coreHtml, svg as coreSvg, TemplateResult} from './lit-html.js';
 
-interface StaticValue {
+export interface StaticValue {
   /** The value to interpolate as-is into the template. */
   _$litStatic$: string;
 

--- a/packages/lit/src/index.all.ts
+++ b/packages/lit/src/index.all.ts
@@ -36,7 +36,6 @@ export {
   svg as staticSvg,
   unsafeStatic,
   withStatic,
-  StaticValue,
 } from './static-html.js';
 
 if (!window.litDisableBundleWarning) {

--- a/packages/lit/src/index.all.ts
+++ b/packages/lit/src/index.all.ts
@@ -36,6 +36,7 @@ export {
   svg as staticSvg,
   unsafeStatic,
   withStatic,
+  StaticValue,
 } from './static-html.js';
 
 if (!window.litDisableBundleWarning) {


### PR DESCRIPTION
Class properties initialized with a literal are implicitly typed as
`any` because `StaticValue` is not exported.