### PR TITLE
[labs/ssr] Add URL and URLSearchParams to VM module global

### DIFF
--- a/.changeset/mean-toes-cry.md
+++ b/.changeset/mean-toes-cry.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/ssr': patch
+---
+
+When using `renderModule`, `URL` and `URLSearchParams` are now available in global of the VM module context

--- a/packages/labs/ssr/src/lib/dom-shim.ts
+++ b/packages/labs/ssr/src/lib/dom-shim.ts
@@ -168,6 +168,8 @@ export const getWindow = ({
       clearTimeout() {},
       // Required for node-fetch
       Buffer,
+      URL,
+      URLSearchParams,
       console: {
         log(...args: unknown[]) {
           console.log(...args);


### PR DESCRIPTION
Fixes #3168

Adds `URL` and `URLSearchParams` class to the global that's provided to the VM context when instantiating `ModuleLoader`.