### PR TITLE
[labs/eleventy-plugin-lit] Use file URLs for resolved module paths

### DIFF
--- a/.changeset/shy-wasps-exercise.md
+++ b/.changeset/shy-wasps-exercise.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/eleventy-plugin-lit': patch
+---
+
+Use file urls for resolved module paths for Windows compatibility

--- a/packages/labs/eleventy-plugin-lit/src/index.ts
+++ b/packages/labs/eleventy-plugin-lit/src/index.ts
@@ -5,6 +5,7 @@
  */
 
 import * as path from 'path';
+import {pathToFileURL} from 'url';
 import {Worker} from 'worker_threads';
 import type {Message} from './worker/types.js';
 
@@ -208,8 +209,8 @@ module.exports = {
       return;
     }
 
-    const resolvedComponentModules = componentModules.map((module) =>
-      path.resolve(process.cwd(), module)
+    const resolvedComponentModules = componentModules.map(
+      (module) => pathToFileURL(path.resolve(process.cwd(), module)).href
     );
 
     switch (mode) {


### PR DESCRIPTION
Fixes #3059 

Due to module file paths having `C:\` for Windows, the imports fail due to unrecognized protocol. Converting them to file URLs fixes that.

Note:
This makes eleventy-plugin-lit now work in `worker` (default) mode for Windows users.
In `vm` mode, it still breaks due to an issue with `ModuleLoader` noted here https://github.com/lit/lit/issues/3202

I was also unable run the eleventy-plugin-lit package test suite in Windows as the testing rig has issues somewhere with the filesystem symlinking, writing, reading.

I did, however, manually test it by running the example eleventy project on a Windows machine and confirmed `worker` mode runs.