### PR TITLE
[labs/ssr] Use url module to convert file url to path

### DIFF
--- a/.changeset/wild-ladybugs-flash.md
+++ b/.changeset/wild-ladybugs-flash.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/ssr': patch
+---
+
+Use `url` module to parse file URL to path for Windows compatibility

--- a/packages/labs/ssr/src/lib/module-loader.ts
+++ b/packages/labs/ssr/src/lib/module-loader.ts
@@ -131,7 +131,7 @@ export class ModuleLoader {
     if (moduleURL.protocol !== 'file:') {
       throw new Error(`Unsupported protocol: ${moduleURL.protocol}`);
     }
-    const modulePath = moduleURL.pathname;
+    const modulePath = fileURLToPath(moduleURL);
 
     // Look in the cache
     let moduleRecord = this.cache.get(modulePath);


### PR DESCRIPTION
Fixes #3202 

This will allow SSR with VM modules on Windows machines.

Along with #3203, this should fix `eleventy-plugin-lit` running in `vm` mode for Windows users as well.