### PR TITLE
Also re-run release image generator on pushes

### DIFF
--- a/.github/workflows/release-image.yaml
+++ b/.github/workflows/release-image.yaml
@@ -4,6 +4,9 @@ on:
   pull_request:
     paths:
       - '**/CHANGELOG.md'
+  push:
+    paths:
+      - '**/CHANGELOG.md'
 
 jobs:
   release-image:


### PR DESCRIPTION
This way it will run not only when a release PR is opened, but also when it's updated.