### PR TITLE
[labs/virtualizer] Added RangeChangedEvent/VisibilityChangedEvent to main module exports

### DIFF
--- a/.changeset/happy-badgers-watch.md
+++ b/.changeset/happy-badgers-watch.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/virtualizer': patch
+---
+
+Exported RangeChangedEvent and VisibilityChangedEvent from main module.

--- a/packages/labs/virtualizer/src/lit-virtualizer.ts
+++ b/packages/labs/virtualizer/src/lit-virtualizer.ts
@@ -6,6 +6,7 @@
 
 import {LitVirtualizer} from './LitVirtualizer.js';
 export {LitVirtualizer};
+export {RangeChangedEvent, VisibilityChangedEvent} from './Virtualizer.js';
 
 /**
  * Import this module to declare the lit-virtualizer custom element.

--- a/packages/labs/virtualizer/src/test/scenarios/main-module.test.ts
+++ b/packages/labs/virtualizer/src/test/scenarios/main-module.test.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {expect} from '@open-wc/testing';
+const MAIN_MODULE = '../../lit-virtualizer.js';
+
+describe('main module', () => {
+  // The side-effect of the `lit-virtualizer` customElements registry entry
+  // is not be cleared between tests, so this test must run first, before the
+  // customElements.define() side-effect is invoked on the import.
+  it('defines lit-virtualizer element', async () => {
+    expect(customElements.get('lit-virtualizer')).to.be.undefined;
+    await import(MAIN_MODULE);
+    expect(customElements.get('lit-virtualizer')).to.be.instanceOf(Function);
+  });
+  it('exports LitVirtualizer', async () => {
+    const {LitVirtualizer} = await import(MAIN_MODULE);
+    expect(LitVirtualizer).to.be.instanceOf(Function);
+  });
+  it('exports RangeChangedEvent', async () => {
+    const {RangeChangedEvent} = await import(MAIN_MODULE);
+    expect(RangeChangedEvent.prototype).to.be.instanceOf(Event);
+  });
+  it('exports VisibilityChangedEvent', async () => {
+    const {VisibilityChangedEvent} = await import(MAIN_MODULE);
+    expect(VisibilityChangedEvent.prototype).to.be.instanceOf(Event);
+  });
+});


### PR DESCRIPTION
Per https://github.com/lit/lit/issues/3051#issuecomment-1163649651 we are exporting the events from the main module to facilitate users (re-)emitting them for certain use-cases.