### PR TITLE
[core] Fix `CSSStyleSheet is not defined` error in Node build

### DIFF
--- a/.changeset/fifty-monkeys-shop.md
+++ b/.changeset/fifty-monkeys-shop.md
@@ -1,0 +1,6 @@
+---
+'lit-element': patch
+'lit': patch
+---
+
+Fix `CSSStyleSheet is not defined` error that would occur when importing a Lit component in Node when both static `styles` and the `@property` decorator were used.

--- a/.changeset/fifty-monkeys-shop.md
+++ b/.changeset/fifty-monkeys-shop.md
@@ -1,5 +1,5 @@
 ---
-'lit-element': patch
+'@lit/reactive-element': patch
 'lit': patch
 ---
 

--- a/packages/lit-element/src/test/node-imports.ts
+++ b/packages/lit-element/src/test/node-imports.ts
@@ -21,13 +21,26 @@ import 'lit-element/decorators/query-assigned-elements.js';
 import 'lit-element/decorators/query-assigned-nodes.js';
 import 'lit-element/decorators/query-async.js';
 
-import {LitElement, html} from 'lit-element';
-import {customElement} from 'lit-element/decorators.js';
+import {LitElement, html, css} from 'lit-element';
+import {customElement, property} from 'lit-element/decorators.js';
 
 @customElement('my-element')
 export class MyElement extends LitElement {
+  // Include both static styles and a @property decorator in the test. The
+  // @property decorator trigggers class initialization, and if there are also
+  // static styles, it will trigger a test for adopted stylesheets, which could
+  // explode if not handled with care in the node build.
+  static override styles = css`
+    p {
+      color: purple;
+    }
+  `;
+
+  @property()
+  name = 'World';
+
   override render() {
-    return html`Hello World`;
+    return html`<p>Hello ${this.name}</p>`;
   }
 }
 

--- a/packages/lit-element/src/test/node-imports.ts
+++ b/packages/lit-element/src/test/node-imports.ts
@@ -21,26 +21,13 @@ import 'lit-element/decorators/query-assigned-elements.js';
 import 'lit-element/decorators/query-assigned-nodes.js';
 import 'lit-element/decorators/query-async.js';
 
-import {LitElement, html, css} from 'lit-element';
-import {customElement, property} from 'lit-element/decorators.js';
+import {LitElement, html} from 'lit-element';
+import {customElement} from 'lit-element/decorators.js';
 
 @customElement('my-element')
 export class MyElement extends LitElement {
-  // Include both static styles and a @property decorator in the test. The
-  // @property decorator trigggers class initialization, and if there are also
-  // static styles, it will trigger a test for adopted stylesheets, which could
-  // explode if not handled with care in the node build.
-  static override styles = css`
-    p {
-      color: purple;
-    }
-  `;
-
-  @property()
-  name = 'World';
-
   override render() {
-    return html`<p>Hello ${this.name}</p>`;
+    return html`Hello World`;
   }
 }
 

--- a/packages/reactive-element/src/css-tag.ts
+++ b/packages/reactive-element/src/css-tag.ts
@@ -11,16 +11,10 @@ const global = NODE_MODE ? globalThis : window;
  * Whether the current browser supports `adoptedStyleSheets`.
  */
 export const supportsAdoptingStyleSheets =
-  // In Node mode, it doesn't really matter whether we believe adopted style
-  // sheets are supported or not, because styles are handled separately as part
-  // of SSR anyway; however if we set this to true then we avoid `instanceof
-  // CSSStyleSheet` checks during initialization, meaning we don't need to shim
-  // that global.
-  NODE_MODE ||
-  (global.ShadowRoot &&
-    (global.ShadyCSS === undefined || global.ShadyCSS.nativeShadow) &&
-    'adoptedStyleSheets' in Document.prototype &&
-    'replace' in CSSStyleSheet.prototype);
+  global.ShadowRoot &&
+  (global.ShadyCSS === undefined || global.ShadyCSS.nativeShadow) &&
+  'adoptedStyleSheets' in Document.prototype &&
+  'replace' in CSSStyleSheet.prototype;
 
 /**
  * A CSSResult or native CSSStyleSheet.
@@ -201,7 +195,9 @@ const cssResultFromStyleSheet = (sheet: CSSStyleSheet) => {
   return unsafeCSS(cssText);
 };
 
-export const getCompatibleStyle = supportsAdoptingStyleSheets
-  ? (s: CSSResultOrNative) => s
-  : (s: CSSResultOrNative) =>
-      s instanceof CSSStyleSheet ? cssResultFromStyleSheet(s) : s;
+export const getCompatibleStyle =
+  supportsAdoptingStyleSheets ||
+  (NODE_MODE && global.CSSStyleSheet === undefined)
+    ? (s: CSSResultOrNative) => s
+    : (s: CSSResultOrNative) =>
+        s instanceof CSSStyleSheet ? cssResultFromStyleSheet(s) : s;

--- a/packages/reactive-element/src/css-tag.ts
+++ b/packages/reactive-element/src/css-tag.ts
@@ -11,10 +11,16 @@ const global = NODE_MODE ? globalThis : window;
  * Whether the current browser supports `adoptedStyleSheets`.
  */
 export const supportsAdoptingStyleSheets =
-  global.ShadowRoot &&
-  (global.ShadyCSS === undefined || global.ShadyCSS.nativeShadow) &&
-  'adoptedStyleSheets' in Document.prototype &&
-  'replace' in CSSStyleSheet.prototype;
+  // In Node mode, it doesn't really matter whether we believe adopted style
+  // sheets are supported or not, because styles are handled separately as part
+  // of SSR anyway; however if we set this to true then we avoid `instanceof
+  // CSSStyleSheet` checks during initialization, meaning we don't need to shim
+  // that global.
+  NODE_MODE ||
+  (global.ShadowRoot &&
+    (global.ShadyCSS === undefined || global.ShadyCSS.nativeShadow) &&
+    'adoptedStyleSheets' in Document.prototype &&
+    'replace' in CSSStyleSheet.prototype);
 
 /**
  * A CSSResult or native CSSStyleSheet.

--- a/packages/reactive-element/src/test/node-imports.ts
+++ b/packages/reactive-element/src/test/node-imports.ts
@@ -22,11 +22,24 @@ import '@lit/reactive-element/decorators/query-assigned-elements.js';
 import '@lit/reactive-element/decorators/query-assigned-nodes.js';
 import '@lit/reactive-element/decorators/query-async.js';
 
-import {customElement} from '@lit/reactive-element/decorators.js';
-import {ReactiveElement} from '@lit/reactive-element';
+import {customElement, property} from '@lit/reactive-element/decorators.js';
+import {ReactiveElement, css} from '@lit/reactive-element';
 
 @customElement('my-element')
-export class MyElement extends ReactiveElement {}
+export class MyElement extends ReactiveElement {
+  // Include both static styles and a @property decorator in the test. The
+  // @property decorator trigggers class initialization, and if there are also
+  // static styles, it will trigger a test for adopted stylesheets, which could
+  // explode if not handled with care in the node build.
+  static override styles = css`
+    p {
+      color: purple;
+    }
+  `;
+
+  @property()
+  name = 'World';
+}
 
 export class MyOtherElement extends ReactiveElement {}
 customElements.define('my-other-element', MyOtherElement);

--- a/packages/reactive-element/src/test/node-imports.ts
+++ b/packages/reactive-element/src/test/node-imports.ts
@@ -29,8 +29,8 @@ import {ReactiveElement, css} from '@lit/reactive-element';
 export class MyElement extends ReactiveElement {
   // Include both static styles and a @property decorator in the test. The
   // @property decorator trigggers class initialization, and if there are also
-  // static styles, it will trigger a test for adopted stylesheets, which could
-  // explode if not handled with care in the node build.
+  // static styles, it will trigger an instanceof check for CSSStyleSheet, which
+  // could explode if not handled with care in the node build.
   static override styles = css`
     p {
       color: purple;


### PR DESCRIPTION
The recently added `node` build would crash when importing a component that had both `static styles` and used the `@property` decorator. That's because the `@property` decorator causes Lit class initialization at module load time, which ran an `instanceof CSSStyleSheet` check before this PR. Since `CSSStyleSheet` is not defined by default, the error would occur.

This PR fixes that by not assuming `CSSStyleSheet` will be defined when in Node mode.

Fixes https://github.com/lit/lit/issues/3218