### PR TITLE
[lit-html] Use existing `document` in Node build

### DIFF
--- a/.changeset/selfish-lobsters-cheat.md
+++ b/.changeset/selfish-lobsters-cheat.md
@@ -1,0 +1,6 @@
+---
+'lit-html': patch
+'lit': patch
+---
+
+Use existing `document` in Node build

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -344,13 +344,14 @@ const markerMatch = '?' + marker;
 // syntax because it's slightly smaller, but parses as a comment node.
 const nodeMarker = `<${markerMatch}>`;
 
-const d = NODE_MODE
-  ? ({
-      createTreeWalker() {
-        return {};
-      },
-    } as unknown as Document)
-  : document;
+const d =
+  NODE_MODE && global.document === undefined
+    ? ({
+        createTreeWalker() {
+          return {};
+        },
+      } as unknown as Document)
+    : document;
 
 // Creates a dynamic marker. We never have to search for these in the DOM.
 const createMarker = (v = '') => d.createComment(v);


### PR DESCRIPTION
In Node builds, use the existing `document` if found.

This should allow node builds running in an environment with DOM emulation loaded to still function, like in a node test runner.

Fixes #3216 