### PR TITLE
[cli] Prepare for CLI 0.1.0 release

### DIFF
--- a/.changeset/mighty-yaks-compete.md
+++ b/.changeset/mighty-yaks-compete.md
@@ -1,0 +1,8 @@
+---
+'@lit-labs/cli': minor
+'@lit-labs/gen-utils': minor
+'@lit-labs/gen-wrapper-react': minor
+'@lit-labs/gen-wrapper-vue': minor
+---
+
+Initial release

--- a/packages/labs/cli/README.md
+++ b/packages/labs/cli/README.md
@@ -4,6 +4,10 @@ The `lit` command line tool for Lit.
 
 The Lit CLI is a common place for utilities maintained by the Lit team.
 
+> IMPORTANT: ⚠️ `@lit-labs/cli` is currently available only as a _pre-release_
+> for early testing. Feel free to try it out, but expect occasional bugs,
+> missing features, and frequent breaking changes! ⚠️
+
 ## Installation
 
 Install globally, so you can run the `lit` command anywhere on your system:
@@ -22,19 +26,22 @@ npm i -D @lit-labs/cli
 ## Commands
 
 - [`help`](#help)
-- [`localize`]($localize)
+- [`localize`](#localize)
+- [`labs gen`](#gen)
 
 ### `help`
 
-#### Usage:
+Displays a help message with available commands.
+
+#### Usage
 
 ```sh
 $ lit help
 ```
 
-Displays a help message with available commands.
-
 ### `localize`
+
+Extract localization messages or build a localized application.
 
 #### Usage
 
@@ -42,3 +49,21 @@ Displays a help message with available commands.
 $ lit localize extract
 $ lit localize build
 ```
+
+### `labs gen`
+
+Generate framework wrappers.
+
+#### Usage
+
+```sh
+$ lit localize gen --framework=react
+```
+
+#### Flags
+
+| Flag          | Description                                                                                                   |
+| ------------- | ------------------------------------------------------------------------------------------------------------- |
+| `--framework` | Framework(s) to generate wrappers for. Supported frameworks: `react`, `vue`. Can be specified multiple times. |
+| `--package`   | Folder(s) containing a package to generate wrappers for. Default: `./`. Can be specified multiple times.      |
+| `--out`       | Folder to output generated packages to. Default: `./gen/`                                                     |

--- a/packages/labs/cli/package.json
+++ b/packages/labs/cli/package.json
@@ -1,5 +1,4 @@
 {
-  "private": true,
   "name": "@lit-labs/cli",
   "description": "Tooling for Lit development",
   "version": "0.0.1",

--- a/packages/labs/cli/src/lib/commands/labs.ts
+++ b/packages/labs/cli/src/lib/commands/labs.ts
@@ -29,7 +29,7 @@ export const makeLabsCommand = (cli: LitCli): Command => {
             name: 'framework',
             multiple: true,
             description:
-              'Framework to generate wrappers for. Supported frameworks: react.',
+              'Framework to generate wrappers for. Supported frameworks: react, vue.',
           },
           {
             name: 'out',

--- a/packages/labs/gen-utils/package.json
+++ b/packages/labs/gen-utils/package.json
@@ -1,5 +1,4 @@
 {
-  "private": true,
   "name": "@lit-labs/gen-utils",
   "description": "Utilities for lit code generators",
   "version": "0.0.1",

--- a/packages/labs/gen-wrapper-react/package.json
+++ b/packages/labs/gen-wrapper-react/package.json
@@ -1,5 +1,4 @@
 {
-  "private": true,
   "name": "@lit-labs/gen-wrapper-react",
   "description": "Code generator for React wrapper for Lit components",
   "version": "0.0.1",

--- a/packages/labs/gen-wrapper-vue/package.json
+++ b/packages/labs/gen-wrapper-vue/package.json
@@ -1,5 +1,4 @@
 {
-  "private": true,
   "name": "@lit-labs/gen-wrapper-vue",
   "description": "Code generator for Vue wrapper for Lit components",
   "version": "0.0.1",


### PR DESCRIPTION
- Remove `private` and add a changeset, so that the next deploy should release `0.1.0` of everything (because they are all currently `0.0.1`).
- Add disclaimer to README about this being an early release.
- Document the `labs gen` command and its flags in the README.
- Mention that `vue` is also supported in the `help` command text.