### PR TITLE
[cli] Prepare vue-utils for release, remove test prod deps, add publishConfig.access

### DIFF
--- a/.changeset/tidy-lobsters-press.md
+++ b/.changeset/tidy-lobsters-press.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/vue-utils': minor
+---
+
+Initial release

--- a/packages/labs/cli/package.json
+++ b/packages/labs/cli/package.json
@@ -2,6 +2,9 @@
   "name": "@lit-labs/cli",
   "description": "Tooling for Lit development",
   "version": "0.0.1",
+  "publishConfig": {
+    "access": "public"
+  },
   "author": "Google LLC",
   "license": "BSD-3-Clause",
   "bin": {

--- a/packages/labs/gen-utils/package.json
+++ b/packages/labs/gen-utils/package.json
@@ -2,6 +2,9 @@
   "name": "@lit-labs/gen-utils",
   "description": "Utilities for lit code generators",
   "version": "0.0.1",
+  "publishConfig": {
+    "access": "public"
+  },
   "author": "Google LLC",
   "license": "BSD-3-Clause",
   "bugs": "https://github.com/lit/lit/issues",

--- a/packages/labs/gen-wrapper-angular/package.json
+++ b/packages/labs/gen-wrapper-angular/package.json
@@ -3,6 +3,9 @@
   "name": "@lit-labs/gen-wrapper-angular",
   "description": "Code generator for Angular wrappers for Lit components",
   "version": "0.0.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "author": "Google LLC",
   "license": "BSD-3-Clause",
   "bugs": "https://github.com/lit/lit/issues",

--- a/packages/labs/gen-wrapper-angular/package.json
+++ b/packages/labs/gen-wrapper-angular/package.json
@@ -52,11 +52,11 @@
   },
   "dependencies": {
     "@lit-labs/analyzer": "^0.2.0",
-    "@lit-labs/gen-utils": "^0.0.1",
-    "@lit-internal/tests": "0.0.0"
+    "@lit-labs/gen-utils": "^0.0.1"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.1.5",
+    "@lit-internal/tests": "0.0.0",
     "@types/chai": "^4.0.1",
     "@types/mocha": "^9.0.0"
   },

--- a/packages/labs/gen-wrapper-react/package.json
+++ b/packages/labs/gen-wrapper-react/package.json
@@ -2,6 +2,9 @@
   "name": "@lit-labs/gen-wrapper-react",
   "description": "Code generator for React wrapper for Lit components",
   "version": "0.0.1",
+  "publishConfig": {
+    "access": "public"
+  },
   "author": "Google LLC",
   "license": "BSD-3-Clause",
   "bugs": "https://github.com/lit/lit/issues",

--- a/packages/labs/gen-wrapper-react/package.json
+++ b/packages/labs/gen-wrapper-react/package.json
@@ -58,8 +58,7 @@
   },
   "dependencies": {
     "@lit-labs/analyzer": "^0.2.0",
-    "@lit-labs/gen-utils": "^0.0.1",
-    "@lit-internal/tests": "0.0.0"
+    "@lit-labs/gen-utils": "^0.0.1"
   },
   "devDependencies": {
     "@lit-internal/tests": "^0.0.0"

--- a/packages/labs/gen-wrapper-vue/package.json
+++ b/packages/labs/gen-wrapper-vue/package.json
@@ -2,6 +2,9 @@
   "name": "@lit-labs/gen-wrapper-vue",
   "description": "Code generator for Vue wrapper for Lit components",
   "version": "0.0.1",
+  "publishConfig": {
+    "access": "public"
+  },
   "author": "Google LLC",
   "license": "BSD-3-Clause",
   "bugs": "https://github.com/lit/lit/issues",

--- a/packages/labs/vue-utils/package.json
+++ b/packages/labs/vue-utils/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@lit-labs/vue-utils",
   "version": "0.0.1",
+  "publishConfig": {
+    "access": "public"
+  },
   "description": "Utilities for generating a Vue component wrapper for a LitElement.",
   "license": "BSD-3-Clause",
   "homepage": "https://lit.dev/",
@@ -104,8 +107,5 @@
   "devDependencies": {
     "@types/trusted-types": "^2.0.2",
     "@lit-internal/scripts": "^1.0.0"
-  },
-  "publishConfig": {
-    "access": "public"
   }
 }

--- a/packages/labs/vue-utils/package.json
+++ b/packages/labs/vue-utils/package.json
@@ -1,5 +1,4 @@
 {
-  "private": true,
   "name": "@lit-labs/vue-utils",
   "version": "0.0.1",
   "description": "Utilities for generating a Vue component wrapper for a LitElement.",


### PR DESCRIPTION
- I forgot `@lit-labs/vue-utils` in https://github.com/lit/lit/pull/3225, so that's now `private` and has a changeset so that the next publish will release it as `0.1.0`.
- Removed a couple of prod `dependencies` on `@lit-internal/tests`, which should have been `devDependencies`.
- Add missing `publishConfig.access` to new packages `package.json` files.