### PR TITLE
Typo fix in @labs/cli README.md

### DIFF
--- a/packages/labs/cli/README.md
+++ b/packages/labs/cli/README.md
@@ -57,7 +57,7 @@ Generate framework wrappers.
 #### Usage
 
 ```sh
-$ lit localize gen --framework=react
+$ lit labs gen --framework=react
 ```
 
 #### Flags


### PR DESCRIPTION
`localize` got mixed up with `labs` on the paragraph about the `labs gen` usage.