### PR TITLE
[labs/gen-wrapper-vue] Add lib files to npm package

### DIFF
--- a/.changeset/gorgeous-ducks-walk.md
+++ b/.changeset/gorgeous-ducks-walk.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/gen-wrapper-vue': patch
+---
+
+Add lib files to package.

--- a/packages/labs/gen-wrapper-vue/package.json
+++ b/packages/labs/gen-wrapper-vue/package.json
@@ -72,7 +72,8 @@
     "node": ">=14.8.0"
   },
   "files": [
-    "index.js"
+    "/index.js",
+    "/lib/*.js"
   ],
   "homepage": "https://github.com/lit/lit",
   "keywords": [


### PR DESCRIPTION
The `lit labs gen` command with `--framework=vue` was not working due to missing lib files. This fix adds those to the npm package.

I've only included the `.js` files inline with the existing `index.js` and omission of declaration and sourcemaps.