### PR TITLE
Task: Do not reset task value or error on pending

### DIFF
--- a/.changeset/friendly-squids-perform.md
+++ b/.changeset/friendly-squids-perform.md
@@ -2,4 +2,4 @@
 '@lit-labs/task': major
 ---
 
-Do not reset value on status change
+Do not reset value or error on status change

--- a/.changeset/friendly-squids-perform.md
+++ b/.changeset/friendly-squids-perform.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/task': major
+---
+
+Do not reset value on status change

--- a/packages/labs/task/src/task.ts
+++ b/packages/labs/task/src/task.ts
@@ -195,7 +195,6 @@ export class Task<
       });
     }
     this.status = TaskStatus.PENDING;
-    this._error = undefined;
     let result!: R | typeof initialState;
     let error: unknown;
     // Request an update to report pending state.

--- a/packages/labs/task/src/task.ts
+++ b/packages/labs/task/src/task.ts
@@ -196,7 +196,6 @@ export class Task<
     }
     this.status = TaskStatus.PENDING;
     this._error = undefined;
-    this._value = undefined;
     let result!: R | typeof initialState;
     let error: unknown;
     // Request an update to report pending state.

--- a/packages/labs/task/src/test/task_test.ts
+++ b/packages/labs/task/src/test/task_test.ts
@@ -169,7 +169,7 @@ suite('Task', () => {
     // Check task pending.
     await tasksUpdateComplete();
     assert.equal(el.task.status, TaskStatus.PENDING);
-    assert.equal(el.taskValue, undefined);
+    assert.equal(el.taskValue, 'a,b');
     // Complete task and check result.
     el.resolveTask();
     await tasksUpdateComplete();
@@ -181,7 +181,7 @@ suite('Task', () => {
     // Check task pending.
     await tasksUpdateComplete();
     assert.equal(el.task.status, TaskStatus.PENDING);
-    assert.equal(el.taskValue, undefined);
+    assert.equal(el.taskValue, 'a1,b');
     // Complete task and check result.
     el.resolveTask();
     await tasksUpdateComplete();
@@ -248,7 +248,7 @@ suite('Task', () => {
     el.task.run();
     await tasksUpdateComplete();
     assert.equal(el.task.status, TaskStatus.PENDING);
-    assert.equal(el.taskValue, undefined);
+    assert.equal(el.taskValue, `a,b`);
     el.resolveTask();
     await tasksUpdateComplete();
     assert.equal(el.task.status, TaskStatus.COMPLETE);

--- a/packages/labs/task/src/test/task_test.ts
+++ b/packages/labs/task/src/test/task_test.ts
@@ -189,6 +189,27 @@ suite('Task', () => {
     assert.equal(el.taskValue, `a1,b1`);
   });
 
+  test('task error is not reset on rerun', async () => {
+    const el = getTestElement({args: () => [el.a, el.b]});
+    await renderElement(el);
+    el.rejectTask();
+    await tasksUpdateComplete();
+    assert.equal(el.task.status, TaskStatus.ERROR);
+    assert.equal(el.taskValue, 'error');
+
+    // *** Changing task argument runs task
+    el.a = 'a1';
+    // Check task pending.
+    await tasksUpdateComplete();
+    assert.equal(el.task.status, TaskStatus.PENDING);
+    assert.equal(el.taskValue, 'error');
+    // Reject task and check result.
+    el.rejectTask();
+    await tasksUpdateComplete();
+    assert.equal(el.task.status, TaskStatus.ERROR);
+    assert.equal(el.taskValue, `error`);
+  });
+
   test('tasks do not run when `autoRun` is `false`', async () => {
     const el = getTestElement({args: () => [el.a, el.b], autoRun: false});
     await renderElement(el);


### PR DESCRIPTION
Fixes #2945

Task will no longer reset its value or error on pending. This allows us to start chaining tasks e.g.

```ts
const a = new Task(this, async ([url]) => await fetch(url), () => [this.url]);
const b = new Task(this, async ([value]) => {/* This is not thrashed */}, () => [a.value]);
```