### PR TITLE
[labs/observers] Fix controllers not observing changes if initialized after host connected

### DIFF
--- a/.changeset/modern-turtles-judge.md
+++ b/.changeset/modern-turtles-judge.md
@@ -2,4 +2,4 @@
 '@lit-labs/observers': patch
 ---
 
-Fix exported controllers not observing changes if initialized after the host has connected.
+Fix controllers not observing changes to target element if initialized after the host has connected.

--- a/.changeset/modern-turtles-judge.md
+++ b/.changeset/modern-turtles-judge.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/observers': patch
+---
+
+Fix exported controllers not observing changes if initialized after the host has connected.

--- a/packages/labs/observers/src/intersection_controller.ts
+++ b/packages/labs/observers/src/intersection_controller.ts
@@ -87,7 +87,7 @@ export class IntersectionController implements ReactiveController {
     host: ReactiveControllerHost,
     {target, config, callback, skipInitial}: IntersectionControllerConfig
   ) {
-    (this._host = host).addController(this);
+    this._host = host;
     // Target defaults to `host` unless explicitly `null`.
     this._target =
       target === null ? target : target ?? (this._host as unknown as Element);
@@ -112,6 +112,7 @@ export class IntersectionController implements ReactiveController {
       },
       config
     );
+    host.addController(this);
   }
 
   /**

--- a/packages/labs/observers/src/mutation_controller.ts
+++ b/packages/labs/observers/src/mutation_controller.ts
@@ -86,7 +86,7 @@ export class MutationController implements ReactiveController {
     host: ReactiveControllerHost,
     {target, config, callback, skipInitial}: MutationControllerConfig
   ) {
-    (this._host = host).addController(this);
+    this._host = host;
     // Target defaults to `host` unless explicitly `null`.
     this._target =
       target === null ? target : target ?? (this._host as unknown as Element);
@@ -104,6 +104,7 @@ export class MutationController implements ReactiveController {
       this.handleChanges(records);
       this._host.requestUpdate();
     });
+    host.addController(this);
   }
 
   /**

--- a/packages/labs/observers/src/performance_controller.ts
+++ b/packages/labs/observers/src/performance_controller.ts
@@ -76,7 +76,7 @@ export class PerformanceController implements ReactiveController {
     host: ReactiveControllerHost,
     {config, callback, skipInitial}: PerformanceControllerConfig
   ) {
-    (this._host = host).addController(this);
+    this._host = host;
     this._config = config;
     this._skipInitial = skipInitial ?? this._skipInitial;
     this.callback = callback ?? this.callback;
@@ -93,6 +93,7 @@ export class PerformanceController implements ReactiveController {
         this._host.requestUpdate();
       }
     );
+    host.addController(this);
   }
 
   /**

--- a/packages/labs/observers/src/resize_controller.ts
+++ b/packages/labs/observers/src/resize_controller.ts
@@ -85,7 +85,7 @@ export class ResizeController implements ReactiveController {
     host: ReactiveControllerHost,
     {target, config, callback, skipInitial}: ResizeControllerConfig
   ) {
-    (this._host = host).addController(this);
+    this._host = host;
     // Target defaults to `host` unless explicitly `null`.
     this._target =
       target === null ? target : target ?? (this._host as unknown as Element);
@@ -103,6 +103,7 @@ export class ResizeController implements ReactiveController {
       this.handleChanges(entries);
       this._host.requestUpdate();
     });
+    host.addController(this);
   }
 
   /**

--- a/packages/labs/observers/src/test/resize_controller_test.ts
+++ b/packages/labs/observers/src/test/resize_controller_test.ts
@@ -403,4 +403,39 @@ if (DEV_MODE) {
     await resizeComplete();
     assert.isTrue(el.observerValue);
   });
+
+  test('can observe external element after host connected', async () => {
+    const d = document.createElement('div');
+    container.appendChild(d);
+    class A extends ReactiveElement {
+      observer!: ResizeController;
+      observerValue: true | undefined = undefined;
+      override firstUpdated() {
+        this.observer = new ResizeController(this, {
+          target: d,
+          skipInitial: true,
+        });
+      }
+      override updated() {
+        this.observerValue = this.observer.value as typeof this.observerValue;
+      }
+      resetObserverValue() {
+        this.observer.value = this.observerValue = undefined;
+      }
+    }
+    customElements.define(generateElementName(), A);
+    const el = (await renderTestElement(A)) as A;
+
+    assert.equal(el.observerValue, undefined);
+    resizeElement(d);
+    await resizeComplete();
+    assert.isTrue(el.observerValue);
+
+    // Change again
+    el.resetObserverValue();
+    assert.equal(el.observerValue, undefined);
+    resizeElement(d);
+    await resizeComplete();
+    assert.isTrue(el.observerValue);
+  });
 });

--- a/packages/labs/observers/src/test/resize_controller_test.ts
+++ b/packages/labs/observers/src/test/resize_controller_test.ts
@@ -374,4 +374,33 @@ if (DEV_MODE) {
     await resizeComplete();
     assert.isTrue(el.observerValue);
   });
+
+  test('can observe changes when initialized after host connected', async () => {
+    class TestFirstUpdated extends ReactiveElement {
+      observer!: ResizeController;
+      observerValue: true | undefined = undefined;
+      override firstUpdated() {
+        this.observer = new ResizeController(this, {});
+      }
+      override updated() {
+        this.observerValue = this.observer.value as typeof this.observerValue;
+      }
+      resetObserverValue() {
+        this.observer.value = this.observerValue = undefined;
+      }
+    }
+    customElements.define(generateElementName(), TestFirstUpdated);
+
+    const el = (await renderTestElement(TestFirstUpdated)) as TestFirstUpdated;
+
+    // Reports initial change by default
+    assert.isTrue(el.observerValue);
+
+    // Reports attribute change
+    el.resetObserverValue();
+    assert.isUndefined(el.observerValue);
+    resizeElement(el);
+    await resizeComplete();
+    assert.isTrue(el.observerValue);
+  });
 });


### PR DESCRIPTION
Issue: https://github.com/lit/lit/issues/3147

### Context

When `host.addController(this)` is called on a ReactiveElement that is already connected, the controllers `hostConnected` method is called synchronously. Because in each exported controller `addController` is called before a `_target` is set, the following `hostConnected` logic is executed with an undefined `_target`:

```
    if (this._target) {
      this.observe(this._target);
    }
```

This problem reproduces if the observer is initialized in `firstUpdated`.


### Fix

Move the `addController` call to the end of the constructor after all the initial variables have been initialized.

### Test plan

Tested by adding a unit test for each controller - which failed prior to the controller being updated.
