### PR TITLE
[labs/observers] Improve controllers value type

### DIFF
--- a/.changeset/seven-fireants-wonder.md
+++ b/.changeset/seven-fireants-wonder.md
@@ -1,0 +1,8 @@
+---
+'@lit-labs/observers': minor
+---
+
+Fix value property of type `unknown` on exported controllers. The type of
+`value` is now generic and can be inferred from the return type of your passed
+in `callback`. The default callback `() => true` was removed, and is now
+undefined by default.

--- a/packages/labs/observers/src/intersection_controller.ts
+++ b/packages/labs/observers/src/intersection_controller.ts
@@ -11,14 +11,14 @@ import {
 /**
  * The callback function for a IntersectionController.
  */
-export type IntersectionValueCallback = (
+export type IntersectionValueCallback<T = unknown> = (
   ...args: Parameters<IntersectionObserverCallback>
-) => unknown;
+) => T;
 
 /**
  * The config options for a IntersectionController.
  */
-export interface IntersectionControllerConfig {
+export interface IntersectionControllerConfig<T = unknown> {
   /**
    * Configuration object for the IntersectionObserver.
    */
@@ -35,7 +35,7 @@ export interface IntersectionControllerConfig {
    * The callback used to process detected changes into a value stored
    * in the controller's `value` property.
    */
-  callback?: IntersectionValueCallback;
+  callback?: IntersectionValueCallback<T>;
   /**
    * An IntersectionObserver reports the initial intersection state
    * when observe is called. Setting this flag to true skips processing this
@@ -60,7 +60,7 @@ export interface IntersectionControllerConfig {
  * used to process the result into a value which is stored on the controller.
  * The controller's `value` is usable during the host's update cycle.
  */
-export class IntersectionController implements ReactiveController {
+export class IntersectionController<T = unknown> implements ReactiveController {
   private _host: ReactiveControllerHost;
   private _target: Element | null;
   private _observer!: IntersectionObserver;
@@ -77,22 +77,22 @@ export class IntersectionController implements ReactiveController {
    * The result of processing the observer's changes via the `callback`
    * function.
    */
-  value?: unknown;
+  value?: T;
   /**
    * Function that returns a value processed from the observer's changes.
    * The result is stored in the `value` property.
    */
-  callback: IntersectionValueCallback = () => true;
+  callback?: IntersectionValueCallback<T>;
   constructor(
     host: ReactiveControllerHost,
-    {target, config, callback, skipInitial}: IntersectionControllerConfig
+    {target, config, callback, skipInitial}: IntersectionControllerConfig<T>
   ) {
     this._host = host;
     // Target defaults to `host` unless explicitly `null`.
     this._target =
       target === null ? target : target ?? (this._host as unknown as Element);
     this._skipInitial = skipInitial ?? this._skipInitial;
-    this.callback = callback ?? this.callback;
+    this.callback = callback;
     // Check browser support.
     if (!window.IntersectionObserver) {
       console.warn(
@@ -120,7 +120,7 @@ export class IntersectionController implements ReactiveController {
    * function to produce a result stored in the `value` property.
    */
   protected handleChanges(entries: IntersectionObserverEntry[]) {
-    this.value = this.callback(entries, this._observer);
+    this.value = this.callback?.(entries, this._observer);
   }
 
   hostConnected() {

--- a/packages/labs/observers/src/mutation_controller.ts
+++ b/packages/labs/observers/src/mutation_controller.ts
@@ -11,14 +11,14 @@ import {
 /**
  * The callback function for a MutationController.
  */
-export type MutationValueCallback = (
+export type MutationValueCallback<T = unknown> = (
   ...args: Parameters<MutationCallback>
-) => unknown;
+) => T;
 
 /**
  * The config options for a MutationController.
  */
-export interface MutationControllerConfig {
+export interface MutationControllerConfig<T = unknown> {
   /**
    * Configuration object for the MutationObserver.
    */
@@ -35,7 +35,7 @@ export interface MutationControllerConfig {
    * The callback used to process detected changes into a value stored
    * in the controller's `value` property.
    */
-  callback?: MutationValueCallback;
+  callback?: MutationValueCallback<T>;
   /**
    * By default the `callback` is called without changes when a target is
    * observed. This is done to help manage initial state, but this
@@ -59,7 +59,7 @@ export interface MutationControllerConfig {
  * used to process the result into a value which is stored on the controller.
  * The controller's `value` is usable during the host's update cycle.
  */
-export class MutationController implements ReactiveController {
+export class MutationController<T = unknown> implements ReactiveController {
   private _host: ReactiveControllerHost;
   private _target: Element | null;
   private _config: MutationObserverInit;
@@ -76,15 +76,15 @@ export class MutationController implements ReactiveController {
    * The result of processing the observer's changes via the `callback`
    * function.
    */
-  value?: unknown;
+  value?: T;
   /**
    * Function that returns a value processed from the observer's changes.
    * The result is stored in the `value` property.
    */
-  callback: MutationValueCallback = () => true;
+  callback?: MutationValueCallback<T>;
   constructor(
     host: ReactiveControllerHost,
-    {target, config, callback, skipInitial}: MutationControllerConfig
+    {target, config, callback, skipInitial}: MutationControllerConfig<T>
   ) {
     this._host = host;
     // Target defaults to `host` unless explicitly `null`.
@@ -92,7 +92,7 @@ export class MutationController implements ReactiveController {
       target === null ? target : target ?? (this._host as unknown as Element);
     this._config = config;
     this._skipInitial = skipInitial ?? this._skipInitial;
-    this.callback = callback ?? this.callback;
+    this.callback = callback;
     // Check browser support.
     if (!window.MutationObserver) {
       console.warn(
@@ -112,7 +112,7 @@ export class MutationController implements ReactiveController {
    * function to produce a result stored in the `value` property.
    */
   protected handleChanges(records: MutationRecord[]) {
-    this.value = this.callback(records, this._observer);
+    this.value = this.callback?.(records, this._observer);
   }
 
   hostConnected() {

--- a/packages/labs/observers/src/performance_controller.ts
+++ b/packages/labs/observers/src/performance_controller.ts
@@ -11,16 +11,16 @@ import {
 /**
  * The callback function for a PerformanceController.
  */
-export type PerformanceValueCallback = (
+export type PerformanceValueCallback<T = unknown> = (
   entries: PerformanceEntryList,
   observer: PerformanceObserver,
   entryList?: PerformanceObserverEntryList
-) => unknown;
+) => T;
 
 /**
  * The config options for a PerformanceController.
  */
-export interface PerformanceControllerConfig {
+export interface PerformanceControllerConfig<T = unknown> {
   /**
    * Configuration object for the PerformanceObserver.
    */
@@ -29,7 +29,7 @@ export interface PerformanceControllerConfig {
    * The callback used to process detected changes into a value stored
    * in the controller's `value` property.
    */
-  callback?: PerformanceValueCallback;
+  callback?: PerformanceValueCallback<T>;
   /**
    * By default the `callback` is called without changes when a target is
    * observed. This is done to help manage initial state, but this
@@ -50,7 +50,7 @@ export interface PerformanceControllerConfig {
  * used to process the result into a value which is stored on the controller.
  * The controller's `value` is usable during the host's update cycle.
  */
-export class PerformanceController implements ReactiveController {
+export class PerformanceController<T = unknown> implements ReactiveController {
   private _host: ReactiveControllerHost;
   private _config: PerformanceObserverInit;
   private _observer!: PerformanceObserver;
@@ -66,20 +66,20 @@ export class PerformanceController implements ReactiveController {
    * The result of processing the observer's changes via the `callback`
    * function.
    */
-  value?: unknown;
+  value?: T;
   /**
    * Function that returns a value processed from the observer's changes.
    * The result is stored in the `value` property.
    */
-  callback: PerformanceValueCallback = () => true;
+  callback?: PerformanceValueCallback<T>;
   constructor(
     host: ReactiveControllerHost,
-    {config, callback, skipInitial}: PerformanceControllerConfig
+    {config, callback, skipInitial}: PerformanceControllerConfig<T>
   ) {
     this._host = host;
     this._config = config;
     this._skipInitial = skipInitial ?? this._skipInitial;
-    this.callback = callback ?? this.callback;
+    this.callback = callback;
     // Check browser support.
     if (!window.PerformanceObserver) {
       console.warn(
@@ -104,7 +104,7 @@ export class PerformanceController implements ReactiveController {
     entries: PerformanceEntryList,
     entryList?: PerformanceObserverEntryList
   ) {
-    this.value = this.callback(entries, this._observer, entryList);
+    this.value = this.callback?.(entries, this._observer, entryList);
   }
 
   hostConnected() {

--- a/packages/labs/observers/src/resize_controller.ts
+++ b/packages/labs/observers/src/resize_controller.ts
@@ -11,14 +11,14 @@ import {
 /**
  * The callback function for a ResizeController.
  */
-export type ResizeValueCallback = (
+export type ResizeValueCallback<T = unknown> = (
   ...args: Parameters<ResizeObserverCallback>
-) => unknown;
+) => T;
 
 /**
  * The config options for a ResizeController.
  */
-export interface ResizeControllerConfig {
+export interface ResizeControllerConfig<T = unknown> {
   /**
    * Configuration object for the ResizeController.
    */
@@ -35,7 +35,7 @@ export interface ResizeControllerConfig {
    * The callback used to process detected changes into a value stored
    * in the controller's `value` property.
    */
-  callback?: ResizeValueCallback;
+  callback?: ResizeValueCallback<T>;
   /**
    * By default the `callback` is called without changes when a target is
    * observed. This is done to help manage initial state, but this
@@ -58,7 +58,7 @@ export interface ResizeControllerConfig {
  * used to process the result into a value which is stored on the controller.
  * The controller's `value` is usable during the host's update cycle.
  */
-export class ResizeController implements ReactiveController {
+export class ResizeController<T = unknown> implements ReactiveController {
   private _host: ReactiveControllerHost;
   private _target: Element | null;
   private _config?: ResizeObserverOptions;
@@ -75,15 +75,15 @@ export class ResizeController implements ReactiveController {
    * The result of processing the observer's changes via the `callback`
    * function.
    */
-  value?: unknown;
+  value?: T;
   /**
    * Function that returns a value processed from the observer's changes.
    * The result is stored in the `value` property.
    */
-  callback: ResizeValueCallback = () => true;
+  callback?: ResizeValueCallback<T>;
   constructor(
     host: ReactiveControllerHost,
-    {target, config, callback, skipInitial}: ResizeControllerConfig
+    {target, config, callback, skipInitial}: ResizeControllerConfig<T>
   ) {
     this._host = host;
     // Target defaults to `host` unless explicitly `null`.
@@ -91,7 +91,7 @@ export class ResizeController implements ReactiveController {
       target === null ? target : target ?? (this._host as unknown as Element);
     this._config = config;
     this._skipInitial = skipInitial ?? this._skipInitial;
-    this.callback = callback ?? this.callback;
+    this.callback = callback;
     // Check browser support.
     if (!window.ResizeObserver) {
       console.warn(
@@ -111,7 +111,7 @@ export class ResizeController implements ReactiveController {
    * function to produce a result stored in the `value` property.
    */
   protected handleChanges(entries: ResizeObserverEntry[]) {
-    this.value = this.callback(entries, this._observer);
+    this.value = this.callback?.(entries, this._observer);
   }
 
   hostConnected() {

--- a/packages/labs/observers/src/test/intersection_controller_test.ts
+++ b/packages/labs/observers/src/test/intersection_controller_test.ts
@@ -476,7 +476,7 @@ const canTest = () => {
     assert.isTrue(el.observerValue);
   });
 
-  test.skip('IntersectionController<T> type-checks', async () => {
+  test('IntersectionController<T> type-checks', async () => {
     // This test only checks compile-type behavior. There are no runtime checks.
     const el = await getTestElement();
     const A = new IntersectionController<number>(el, {

--- a/packages/labs/observers/src/test/mutation_controller_test.ts
+++ b/packages/labs/observers/src/test/mutation_controller_test.ts
@@ -12,6 +12,7 @@ import {
 import {
   MutationController,
   MutationControllerConfig,
+  MutationValueCallback,
 } from '@lit-labs/observers/mutation_controller.js';
 import {generateElementName, nextFrame} from './test-helpers.js';
 import {assert} from '@esm-bundle/chai';
@@ -53,7 +54,10 @@ const canTest =
       constructor() {
         super();
         const config = getControllerConfig(this);
-        this.observer = new MutationController(this, config);
+        this.observer = new MutationController(this, {
+          callback: () => true,
+          ...config,
+        });
       }
 
       override update(props: PropertyValues) {
@@ -371,15 +375,16 @@ const canTest =
 
   test('can observe changes when initialized after host connected', async () => {
     class TestFirstUpdated extends ReactiveElement {
-      observer!: MutationController;
+      observer!: MutationController<true>;
       observerValue: true | undefined = undefined;
       override firstUpdated() {
         this.observer = new MutationController(this, {
           config: {attributes: true},
+          callback: () => true,
         });
       }
       override updated() {
-        this.observerValue = this.observer.value as typeof this.observerValue;
+        this.observerValue = this.observer.value;
       }
       resetObserverValue() {
         this.observer.value = this.observerValue = undefined;
@@ -410,17 +415,18 @@ const canTest =
 
   test('can observe external element after host connected', async () => {
     class A extends ReactiveElement {
-      observer!: MutationController;
+      observer!: MutationController<true>;
       observerValue: true | undefined = undefined;
       override firstUpdated() {
         this.observer = new MutationController(this, {
           target: document.body,
           config: {childList: true},
           skipInitial: true,
+          callback: () => true,
         });
       }
       override updated() {
-        this.observerValue = this.observer.value as typeof this.observerValue;
+        this.observerValue = this.observer.value;
       }
       resetObserverValue() {
         this.observer.value = this.observerValue = undefined;
@@ -438,5 +444,42 @@ const canTest =
     d.remove();
     await nextFrame();
     assert.isTrue(el.observerValue);
+  });
+
+  test.skip('MutationController<T> type-checks', async () => {
+    // This test only checks compile-type behavior. There are no runtime checks.
+    const el = await getTestElement(() => ({
+      target: null,
+      config: {},
+    }));
+    const A = new MutationController<number>(el, {
+      // @ts-expect-error Type 'string' is not assignable to type 'number'
+      callback: () => '',
+    });
+    if (A) {
+      // Suppress no-unused-vars warnings
+    }
+
+    const B = new MutationController(el, {
+      callback: () => '',
+      config: {},
+    });
+    // @ts-expect-error Type 'number' is not assignable to type 'string'.
+    B.value = 2;
+
+    const C = new MutationController(el, {
+      config: {},
+    }) as MutationController<string>;
+    // @ts-expect-error Type 'number' is not assignable to type 'string'.
+    C.value = 3;
+
+    const narrowTypeCb: MutationValueCallback<string | null> = () => '';
+    const D = new MutationController(el, {callback: narrowTypeCb, config: {}});
+
+    D.value = null;
+    D.value = undefined;
+    D.value = '';
+    // @ts-expect-error Type 'number' is not assignable to type 'string'
+    D.value = 3;
   });
 });

--- a/packages/labs/observers/src/test/mutation_controller_test.ts
+++ b/packages/labs/observers/src/test/mutation_controller_test.ts
@@ -446,15 +446,16 @@ const canTest =
     assert.isTrue(el.observerValue);
   });
 
-  test.skip('MutationController<T> type-checks', async () => {
+  test('MutationController<T> type-checks', async () => {
     // This test only checks compile-type behavior. There are no runtime checks.
     const el = await getTestElement(() => ({
       target: null,
-      config: {},
+      config: {attributes: true},
     }));
     const A = new MutationController<number>(el, {
       // @ts-expect-error Type 'string' is not assignable to type 'number'
       callback: () => '',
+      config: {attributes: true},
     });
     if (A) {
       // Suppress no-unused-vars warnings
@@ -462,19 +463,22 @@ const canTest =
 
     const B = new MutationController(el, {
       callback: () => '',
-      config: {},
+      config: {attributes: true},
     });
     // @ts-expect-error Type 'number' is not assignable to type 'string'.
     B.value = 2;
 
     const C = new MutationController(el, {
-      config: {},
+      config: {attributes: true},
     }) as MutationController<string>;
     // @ts-expect-error Type 'number' is not assignable to type 'string'.
     C.value = 3;
 
     const narrowTypeCb: MutationValueCallback<string | null> = () => '';
-    const D = new MutationController(el, {callback: narrowTypeCb, config: {}});
+    const D = new MutationController(el, {
+      callback: narrowTypeCb,
+      config: {attributes: true},
+    });
 
     D.value = null;
     D.value = undefined;

--- a/packages/labs/observers/src/test/performance_controller_test.ts
+++ b/packages/labs/observers/src/test/performance_controller_test.ts
@@ -12,6 +12,7 @@ import {
 import {
   PerformanceController,
   PerformanceControllerConfig,
+  PerformanceValueCallback,
 } from '@lit-labs/observers/performance_controller.js';
 import {generateElementName, nextFrame} from './test-helpers.js';
 import {assert} from '@esm-bundle/chai';
@@ -82,7 +83,10 @@ const canTest = () => {
       constructor() {
         super();
         const config = getControllerConfig(this);
-        this.observer = new PerformanceController(this, config);
+        this.observer = new PerformanceController(this, {
+          callback: () => true,
+          ...config,
+        });
       }
 
       override update(props: PropertyValues) {
@@ -234,15 +238,16 @@ const canTest = () => {
 
   test('can observe changes when initialized after host connected', async () => {
     class TestFirstUpdated extends ReactiveElement {
-      observer!: PerformanceController;
+      observer!: PerformanceController<true>;
       observerValue: true | undefined = undefined;
       override firstUpdated() {
         this.observer = new PerformanceController(this, {
           config: {entryTypes: ['measure']},
+          callback: () => true,
         });
       }
       override updated() {
-        this.observerValue = this.observer.value as typeof this.observerValue;
+        this.observerValue = this.observer.value;
       }
       resetObserverValue() {
         this.observer.value = this.observerValue = undefined;
@@ -268,5 +273,45 @@ const canTest = () => {
     await generateMeasure();
     await observerComplete(el);
     assert.isTrue(el.observerValue);
+  });
+
+  test.skip('PerformanceController<T> type-checks', async () => {
+    // This test only checks compile-type behavior. There are no runtime checks.
+    const el = await getTestElement((_host: ReactiveControllerHost) => ({
+      config: {entryTypes: ['measure']},
+    }));
+    const A = new PerformanceController<number>(el, {
+      // @ts-expect-error Type 'string' is not assignable to type 'number'
+      callback: () => '',
+    });
+    if (A) {
+      // Suppress no-unused-vars warnings
+    }
+
+    const B = new PerformanceController(el, {
+      callback: () => '',
+      config: {entryTypes: ['measure']},
+    });
+    // @ts-expect-error Type 'number' is not assignable to type 'string'.
+    B.value = 2;
+
+    const C = new PerformanceController(el, {
+      callback: () => '',
+      config: {entryTypes: ['measure']},
+    }) as PerformanceController<string>;
+    // @ts-expect-error Type 'number' is not assignable to type 'string'.
+    C.value = 3;
+
+    const narrowTypeCb: PerformanceValueCallback<string | null> = () => '';
+    const D = new PerformanceController(el, {
+      callback: narrowTypeCb,
+      config: {entryTypes: ['measure']},
+    });
+
+    D.value = null;
+    D.value = undefined;
+    D.value = '';
+    // @ts-expect-error Type 'number' is not assignable to type 'string'
+    D.value = 3;
   });
 });

--- a/packages/labs/observers/src/test/performance_controller_test.ts
+++ b/packages/labs/observers/src/test/performance_controller_test.ts
@@ -275,7 +275,7 @@ const canTest = () => {
     assert.isTrue(el.observerValue);
   });
 
-  test.skip('PerformanceController<T> type-checks', async () => {
+  test('PerformanceController<T> type-checks', async () => {
     // This test only checks compile-type behavior. There are no runtime checks.
     const el = await getTestElement((_host: ReactiveControllerHost) => ({
       config: {entryTypes: ['measure']},
@@ -283,6 +283,7 @@ const canTest = () => {
     const A = new PerformanceController<number>(el, {
       // @ts-expect-error Type 'string' is not assignable to type 'number'
       callback: () => '',
+      config: {entryTypes: ['measure']},
     });
     if (A) {
       // Suppress no-unused-vars warnings

--- a/packages/labs/observers/src/test/resize_controller_test.ts
+++ b/packages/labs/observers/src/test/resize_controller_test.ts
@@ -446,7 +446,7 @@ if (DEV_MODE) {
     assert.isTrue(el.observerValue);
   });
 
-  test.skip('ResizeController<T> type-checks', async () => {
+  test('ResizeController<T> type-checks', async () => {
     // This test only checks compile-type behavior. There are no runtime checks.
     const el = await getTestElement();
     const A = new ResizeController<number>(el, {


### PR DESCRIPTION
Issue: https://github.com/lit/lit/issues/2350

### Background

The `value` property was typed as unknown.

```
const resizeController = new ResizeController(host, {callback: () => true});
resizeController.value // Type is unknown.
```

After this change:

```
const resizeController = new ResizeController(host, {callback: () => true});
resizeController.value // Type is `boolean | undefined`.
```

Impact is that using `value` will no longer require unsafe type assertions. Instead the type of `value` is now always `T | undefined`, where `T` is the return type of the user provided `callback`.

### Changes

  - The generic type does not need to be provided and is unknown by default (for backwards compatibility).
  - [**BREAKING**] The callback `() => true` is no longer defined by default. Instead the callback is `undefined` unless provided.
  - Type checking between the return type of the callback and the `value` property now works.

### Test plan

Tested with type-only unit tests with no runtime behavior.