### PR TITLE
[infra] exploratory fix Sauce Safari latest breaking on CI

### DIFF
--- a/packages/labs/scoped-registry-mixin/src/test/scoped-registry-mixin_test.ts
+++ b/packages/labs/scoped-registry-mixin/src/test/scoped-registry-mixin_test.ts
@@ -18,48 +18,48 @@ export const canTest =
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (window as any).ShadowRootInit;
 
-class SimpleGreeting extends LitElement {
-  private name: String;
-
-  static override get properties() {
-    return {name: {type: String}};
-  }
-
-  constructor() {
-    super();
-
-    this.name = 'World';
-  }
-
-  override render() {
-    return html`<span>hello ${this.name}!</span>`;
-  }
-}
-
-class ScopedComponent extends ScopedRegistryHost(LitElement) {
-  static elementDefinitions = {
-    'simple-greeting': SimpleGreeting,
-  };
-
-  static override get styles() {
-    return css`
-      :host {
-        color: #ff0000;
-      }
-    `;
-  }
-
-  override render() {
-    return html` <simple-greeting
-      id="greeting"
-      name="scoped world"
-    ></simple-greeting>`;
-  }
-}
-
-customElements.define('scoped-component', ScopedComponent);
-
 (canTest ? suite : suite.skip)('scoped-registry-mixin', () => {
+  class SimpleGreeting extends LitElement {
+    private name: String;
+
+    static override get properties() {
+      return {name: {type: String}};
+    }
+
+    constructor() {
+      super();
+
+      this.name = 'World';
+    }
+
+    override render() {
+      return html`<span>hello ${this.name}!</span>`;
+    }
+  }
+
+  class ScopedComponent extends ScopedRegistryHost(LitElement) {
+    static elementDefinitions = {
+      'simple-greeting': SimpleGreeting,
+    };
+
+    static override get styles() {
+      return css`
+        :host {
+          color: #ff0000;
+        }
+      `;
+    }
+
+    override render() {
+      return html` <simple-greeting
+        id="greeting"
+        name="scoped world"
+      ></simple-greeting>`;
+    }
+  }
+
+  customElements.define('scoped-component', ScopedComponent);
+
   test(`host element should have a registry`, async () => {
     const container = document.createElement('div');
     container.innerHTML = `<scoped-component></scoped-component>`;


### PR DESCRIPTION
### Context

Exploratory fix for the following error in CI:

```
../labs/scoped-registry-mixin/development/test/scoped-registry-mixin_test.js:

 🚧 Browser logs on macOS 10.15 Safari latest:
      TypeError: Importing a module script failed.

 ❌ Could not import your test module. Check the browser logs or open the browser in debug mode for more information.  (failed on macOS 1
```

Hypothesis is that when we shouldn't be testing - the test fixtures execute and break Safari in Sauce.
