### PR TITLE
[lit] Add "types" to package exports

### DIFF
--- a/.changeset/red-jars-float.md
+++ b/.changeset/red-jars-float.md
@@ -1,0 +1,5 @@
+---
+'lit': patch
+---
+
+The `lit` package now specifies and "types" export condition allowing TypeScript `moduleResolution` to be `nodenext`.

--- a/packages/lit/package.json
+++ b/packages/lit/package.json
@@ -19,197 +19,158 @@
   "exports": {
     ".": {
       "types": "./development/index.d.ts",
-      "development": "./development/index.js",
       "default": "./index.js"
     },
     "./async-directive.js": {
       "types": "./development/async-directive.d.ts",
-      "development": "./development/async-directive.js",
       "default": "./async-directive.js"
     },
     "./decorators.js": {
       "types": "./development/decorators.d.ts",
-      "development": "./development/decorators.js",
       "default": "./decorators.js"
     },
     "./decorators/custom-element.js": {
       "types": "./development/decorators/custom-element.d.ts",
-      "development": "./development/decorators/custom-element.js",
       "default": "./decorators/custom-element.js"
     },
     "./decorators/event-options.js": {
       "types": "./development/decorators/event-options.d.ts",
-      "development": "./development/decorators/event-options.js",
       "default": "./decorators/event-options.js"
     },
     "./decorators/property.js": {
       "types": "./development/decorators/property.d.ts",
-      "development": "./development/decorators/property.js",
       "default": "./decorators/property.js"
     },
     "./decorators/query-all.js": {
       "types": "./development/decorators/query-all.d.ts",
-      "development": "./development/decorators/query-all.js",
       "default": "./decorators/query-all.js"
     },
     "./decorators/query-assigned-elements.js": {
       "types": "./development/decorators/query-assigned-elements.d.ts",
-      "development": "./development/decorators/query-assigned-elements.js",
       "default": "./decorators/query-assigned-elements.js"
     },
     "./decorators/query-assigned-nodes.js": {
       "types": "./development/decorators/query-assigned-nodes.d.ts",
-      "development": "./development/decorators/query-assigned-nodes.js",
       "default": "./decorators/query-assigned-nodes.js"
     },
     "./decorators/query-async.js": {
       "types": "./development/decorators/query-async.d.ts",
-      "development": "./development/decorators/query-async.js",
       "default": "./decorators/query-async.js"
     },
     "./decorators/query.js": {
       "types": "./development/decorators/query.d.ts",
-      "development": "./development/decorators/query.js",
       "default": "./decorators/query.js"
     },
     "./decorators/state.js": {
       "types": "./development/decorators/state.d.ts",
-      "development": "./development/decorators/state.js",
       "default": "./decorators/state.js"
     },
     "./directive-helpers.js": {
       "types": "./development/directive-helpers.d.ts",
-      "development": "./development/directive-helpers.js",
       "default": "./directive-helpers.js"
     },
     "./directive.js": {
       "types": "./development/directive.d.ts",
-      "development": "./development/directive.js",
       "default": "./directive.js"
     },
     "./directives/async-append.js": {
       "types": "./development/directives/async-append.d.ts",
-      "development": "./development/directives/async-append.js",
       "default": "./directives/async-append.js"
     },
     "./directives/async-replace.js": {
       "types": "./development/directives/async-replace.d.ts",
-      "development": "./development/directives/async-replace.js",
       "default": "./directives/async-replace.js"
     },
     "./directives/cache.js": {
       "types": "./development/directives/cache.d.ts",
-      "development": "./development/directives/cache.js",
       "default": "./directives/cache.js"
     },
     "./directives/choose.js": {
       "types": "./development/directives/choose.d.ts",
-      "development": "./development/directives/choose.js",
       "default": "./directives/choose.js"
     },
     "./directives/class-map.js": {
       "types": "./development/directives/class-map.d.ts",
-      "development": "./development/directives/class-map.js",
       "default": "./directives/class-map.js"
     },
     "./directives/guard.js": {
       "types": "./development/directives/guard.d.ts",
-      "development": "./development/directives/guard.js",
       "default": "./directives/guard.js"
     },
     "./directives/if-defined.js": {
       "types": "./development/directives/if-defined.d.ts",
-      "development": "./development/directives/if-defined.js",
       "default": "./directives/if-defined.js"
     },
     "./directives/join.js": {
       "types": "./development/directives/join.d.ts",
-      "development": "./development/directives/join.js",
       "default": "./directives/join.js"
     },
     "./directives/keyed.js": {
       "types": "./development/directives/keyed.d.ts",
-      "development": "./development/directives/keyed.js",
       "default": "./directives/keyed.js"
     },
     "./directives/live.js": {
       "types": "./development/directives/live.d.ts",
-      "development": "./development/directives/live.js",
       "default": "./directives/live.js"
     },
     "./directives/map.js": {
       "types": "./development/directives/map.d.ts",
-      "development": "./development/directives/map.js",
       "default": "./directives/map.js"
     },
     "./directives/range.js": {
       "types": "./development/directives/range.d.ts",
-      "development": "./development/directives/range.js",
       "default": "./directives/range.js"
     },
     "./directives/ref.js": {
       "types": "./development/directives/ref.d.ts",
-      "development": "./development/directives/ref.js",
       "default": "./directives/ref.js"
     },
     "./directives/repeat.js": {
       "types": "./development/directives/repeat.d.ts",
-      "development": "./development/directives/repeat.js",
       "default": "./directives/repeat.js"
     },
     "./directives/style-map.js": {
       "types": "./development/directives/style-map.d.ts",
-      "development": "./development/directives/style-map.js",
       "default": "./directives/style-map.js"
     },
     "./directives/template-content.js": {
       "types": "./development/directives/template-content.d.ts",
-      "development": "./development/directives/template-content.js",
       "default": "./directives/template-content.js"
     },
     "./directives/unsafe-html.js": {
       "types": "./development/directives/unsafe-html.d.ts",
-      "development": "./development/directives/unsafe-html.js",
       "default": "./directives/unsafe-html.js"
     },
     "./directives/unsafe-svg.js": {
       "types": "./development/directives/unsafe-svg.d.ts",
-      "development": "./development/directives/unsafe-svg.js",
       "default": "./directives/unsafe-svg.js"
     },
     "./directives/until.js": {
       "types": "./development/directives/until.d.ts",
-      "development": "./development/directives/until.js",
       "default": "./directives/until.js"
     },
     "./directives/when.js": {
       "types": "./development/directives/when.d.ts",
-      "development": "./development/directives/when.js",
       "default": "./directives/when.js"
     },
     "./experimental-hydrate-support.js": {
       "types": "./development/experimental-hydrate-support.d.ts",
-      "development": "./development/experimental-hydrate-support.js",
       "default": "./experimental-hydrate-support.js"
     },
     "./experimental-hydrate.js": {
       "types": "./development/experimental-hydrate.d.ts",
-      "development": "./development/experimental-hydrate.js",
       "default": "./experimental-hydrate.js"
     },
     "./html.js": {
       "types": "./development/html.d.ts",
-      "development": "./development/html.js",
       "default": "./html.js"
     },
     "./polyfill-support.js": {
       "types": "./development/polyfill-support.d.ts",
-      "development": "./development/polyfill-support.js",
       "default": "./polyfill-support.js"
     },
     "./static-html.js": {
       "types": "./development/static-html.d.ts",
-      "development": "./development/static-html.js",
       "default": "./static-html.js"
     }
   },

--- a/packages/lit/package.json
+++ b/packages/lit/package.json
@@ -18,120 +18,198 @@
   "type": "module",
   "exports": {
     ".": {
+      "types": "./development/index.d.ts",
+      "development": "./development/index.js",
       "default": "./index.js"
     },
     "./async-directive.js": {
+      "types": "./development/async-directive.d.ts",
+      "development": "./development/async-directive.js",
       "default": "./async-directive.js"
     },
     "./decorators.js": {
+      "types": "./development/decorators.d.ts",
+      "development": "./development/decorators.js",
       "default": "./decorators.js"
     },
     "./decorators/custom-element.js": {
+      "types": "./development/decorators/custom-element.d.ts",
+      "development": "./development/decorators/custom-element.js",
       "default": "./decorators/custom-element.js"
     },
     "./decorators/event-options.js": {
+      "types": "./development/decorators/event-options.d.ts",
+      "development": "./development/decorators/event-options.js",
       "default": "./decorators/event-options.js"
     },
     "./decorators/property.js": {
+      "types": "./development/decorators/property.d.ts",
+      "development": "./development/decorators/property.js",
       "default": "./decorators/property.js"
     },
     "./decorators/query-all.js": {
+      "types": "./development/decorators/query-all.d.ts",
+      "development": "./development/decorators/query-all.js",
       "default": "./decorators/query-all.js"
     },
     "./decorators/query-assigned-elements.js": {
+      "types": "./development/decorators/query-assigned-elements.d.ts",
+      "development": "./development/decorators/query-assigned-elements.js",
       "default": "./decorators/query-assigned-elements.js"
     },
     "./decorators/query-assigned-nodes.js": {
+      "types": "./development/decorators/query-assigned-nodes.d.ts",
+      "development": "./development/decorators/query-assigned-nodes.js",
       "default": "./decorators/query-assigned-nodes.js"
     },
     "./decorators/query-async.js": {
+      "types": "./development/decorators/query-async.d.ts",
+      "development": "./development/decorators/query-async.js",
       "default": "./decorators/query-async.js"
     },
     "./decorators/query.js": {
+      "types": "./development/decorators/query.d.ts",
+      "development": "./development/decorators/query.js",
       "default": "./decorators/query.js"
     },
     "./decorators/state.js": {
+      "types": "./development/decorators/state.d.ts",
+      "development": "./development/decorators/state.js",
       "default": "./decorators/state.js"
     },
     "./directive-helpers.js": {
+      "types": "./development/directive-helpers.d.ts",
+      "development": "./development/directive-helpers.js",
       "default": "./directive-helpers.js"
     },
     "./directive.js": {
+      "types": "./development/directive.d.ts",
+      "development": "./development/directive.js",
       "default": "./directive.js"
     },
     "./directives/async-append.js": {
+      "types": "./development/directives/async-append.d.ts",
+      "development": "./development/directives/async-append.js",
       "default": "./directives/async-append.js"
     },
     "./directives/async-replace.js": {
+      "types": "./development/directives/async-replace.d.ts",
+      "development": "./development/directives/async-replace.js",
       "default": "./directives/async-replace.js"
     },
     "./directives/cache.js": {
+      "types": "./development/directives/cache.d.ts",
+      "development": "./development/directives/cache.js",
       "default": "./directives/cache.js"
     },
     "./directives/choose.js": {
+      "types": "./development/directives/choose.d.ts",
+      "development": "./development/directives/choose.js",
       "default": "./directives/choose.js"
     },
     "./directives/class-map.js": {
+      "types": "./development/directives/class-map.d.ts",
+      "development": "./development/directives/class-map.js",
       "default": "./directives/class-map.js"
     },
     "./directives/guard.js": {
+      "types": "./development/directives/guard.d.ts",
+      "development": "./development/directives/guard.js",
       "default": "./directives/guard.js"
     },
     "./directives/if-defined.js": {
+      "types": "./development/directives/if-defined.d.ts",
+      "development": "./development/directives/if-defined.js",
       "default": "./directives/if-defined.js"
     },
     "./directives/join.js": {
+      "types": "./development/directives/join.d.ts",
+      "development": "./development/directives/join.js",
       "default": "./directives/join.js"
     },
     "./directives/keyed.js": {
+      "types": "./development/directives/keyed.d.ts",
+      "development": "./development/directives/keyed.js",
       "default": "./directives/keyed.js"
     },
     "./directives/live.js": {
+      "types": "./development/directives/live.d.ts",
+      "development": "./development/directives/live.js",
       "default": "./directives/live.js"
     },
     "./directives/map.js": {
+      "types": "./development/directives/map.d.ts",
+      "development": "./development/directives/map.js",
       "default": "./directives/map.js"
     },
     "./directives/range.js": {
+      "types": "./development/directives/range.d.ts",
+      "development": "./development/directives/range.js",
       "default": "./directives/range.js"
     },
     "./directives/ref.js": {
+      "types": "./development/directives/ref.d.ts",
+      "development": "./development/directives/ref.js",
       "default": "./directives/ref.js"
     },
     "./directives/repeat.js": {
+      "types": "./development/directives/repeat.d.ts",
+      "development": "./development/directives/repeat.js",
       "default": "./directives/repeat.js"
     },
     "./directives/style-map.js": {
+      "types": "./development/directives/style-map.d.ts",
+      "development": "./development/directives/style-map.js",
       "default": "./directives/style-map.js"
     },
     "./directives/template-content.js": {
+      "types": "./development/directives/template-content.d.ts",
+      "development": "./development/directives/template-content.js",
       "default": "./directives/template-content.js"
     },
     "./directives/unsafe-html.js": {
+      "types": "./development/directives/unsafe-html.d.ts",
+      "development": "./development/directives/unsafe-html.js",
       "default": "./directives/unsafe-html.js"
     },
     "./directives/unsafe-svg.js": {
+      "types": "./development/directives/unsafe-svg.d.ts",
+      "development": "./development/directives/unsafe-svg.js",
       "default": "./directives/unsafe-svg.js"
     },
     "./directives/until.js": {
+      "types": "./development/directives/until.d.ts",
+      "development": "./development/directives/until.js",
       "default": "./directives/until.js"
     },
     "./directives/when.js": {
+      "types": "./development/directives/when.d.ts",
+      "development": "./development/directives/when.js",
       "default": "./directives/when.js"
     },
     "./experimental-hydrate-support.js": {
+      "types": "./development/experimental-hydrate-support.d.ts",
+      "development": "./development/experimental-hydrate-support.js",
       "default": "./experimental-hydrate-support.js"
     },
     "./experimental-hydrate.js": {
+      "types": "./development/experimental-hydrate.d.ts",
+      "development": "./development/experimental-hydrate.js",
       "default": "./experimental-hydrate.js"
     },
     "./html.js": {
+      "types": "./development/html.d.ts",
+      "development": "./development/html.js",
       "default": "./html.js"
     },
     "./polyfill-support.js": {
+      "types": "./development/polyfill-support.d.ts",
+      "development": "./development/polyfill-support.js",
       "default": "./polyfill-support.js"
     },
     "./static-html.js": {
+      "types": "./development/static-html.d.ts",
+      "development": "./development/static-html.js",
       "default": "./static-html.js"
     }
   },
@@ -284,6 +362,7 @@
     "/static-html.{d.ts.map,d.ts,js.map,js}",
     "/decorators/",
     "/directives/",
+    "/development/",
     "/logo.svg"
   ],
   "dependencies": {


### PR DESCRIPTION
### Problem
I noticed build failing in pipeline like this https://github.com/lit/lit/actions/runs/3148045621/jobs/5118162175#step:7:67
Module self reference wasn't working during TypeScript build due to missing "types" export condition for the `lit` package.

### Solution
Add "types" field. This needed to point to `./development/...` for the module self reference to work during TypeScript build as that is the specified output directory, so this PR also adds `development/` directory to the published package, as well as the "development" export condition. This particular package doesn't really need a "development" export condition at the moment but added those for consistency with our other packages and since the package published to npm would now be including those files anyway.

This also has the benefit of allowing TS `moduleResolution` to be `nodenext`.

Supersedes #3252 