### PR TITLE
[labs/observers] observed targets are now re-observed when the host is reconnected

### DIFF
--- a/.changeset/spotty-kangaroos-shout.md
+++ b/.changeset/spotty-kangaroos-shout.md
@@ -1,0 +1,6 @@
+---
+'@lit-labs/observers': patch
+---
+
+Controllers now track all observed targets and will restore observing targets
+when host is reconnected.

--- a/packages/labs/observers/src/intersection_controller.ts
+++ b/packages/labs/observers/src/intersection_controller.ts
@@ -126,7 +126,7 @@ export class IntersectionController<T = unknown> implements ReactiveController {
 
   hostConnected() {
     for (const target of this._targets.values()) {
-      this._observe(target);
+      this.observe(target);
     }
   }
 
@@ -145,18 +145,10 @@ export class IntersectionController<T = unknown> implements ReactiveController {
   /**
    * Observe the target element. The controller's `target` is automatically
    * observed when the host connects.
-   * It's a no-op to observe an existing target.
    * @param target Element to observe
    */
   observe(target: Element) {
-    if (this._targets.has(target)) {
-      return;
-    }
     this._targets.add(target);
-    this._observe(target);
-  }
-
-  private _observe(target: Element) {
     // Note, this will always trigger the callback since the initial
     // intersection state is reported.
     this._observer.observe(target);

--- a/packages/labs/observers/src/intersection_controller.ts
+++ b/packages/labs/observers/src/intersection_controller.ts
@@ -125,7 +125,7 @@ export class IntersectionController<T = unknown> implements ReactiveController {
   }
 
   hostConnected() {
-    for (const target of this._targets.values()) {
+    for (const target of this._targets) {
       this.observe(target);
     }
   }

--- a/packages/labs/observers/src/mutation_controller.ts
+++ b/packages/labs/observers/src/mutation_controller.ts
@@ -117,7 +117,7 @@ export class MutationController<T = unknown> implements ReactiveController {
   }
 
   hostConnected() {
-    for (const target of this._targets.values()) {
+    for (const target of this._targets) {
       this.observe(target);
     }
   }

--- a/packages/labs/observers/src/resize_controller.ts
+++ b/packages/labs/observers/src/resize_controller.ts
@@ -116,7 +116,7 @@ export class ResizeController<T = unknown> implements ReactiveController {
   }
 
   hostConnected() {
-    for (const target of this._targets.values()) {
+    for (const target of this._targets) {
       this.observe(target);
     }
   }

--- a/packages/labs/observers/src/resize_controller.ts
+++ b/packages/labs/observers/src/resize_controller.ts
@@ -60,7 +60,7 @@ export interface ResizeControllerConfig<T = unknown> {
  */
 export class ResizeController<T = unknown> implements ReactiveController {
   private _host: ReactiveControllerHost;
-  private _target: Element | null;
+  private _targets: Set<Element> = new Set();
   private _config?: ResizeObserverOptions;
   private _observer!: ResizeObserver;
   private _skipInitial = false;
@@ -82,13 +82,14 @@ export class ResizeController<T = unknown> implements ReactiveController {
    */
   callback?: ResizeValueCallback<T>;
   constructor(
-    host: ReactiveControllerHost,
+    host: ReactiveControllerHost & Element,
     {target, config, callback, skipInitial}: ResizeControllerConfig<T>
   ) {
     this._host = host;
     // Target defaults to `host` unless explicitly `null`.
-    this._target =
-      target === null ? target : target ?? (this._host as unknown as Element);
+    if (target !== null) {
+      this._targets.add(target ?? host);
+    }
     this._config = config;
     this._skipInitial = skipInitial ?? this._skipInitial;
     this.callback = callback;
@@ -115,8 +116,8 @@ export class ResizeController<T = unknown> implements ReactiveController {
   }
 
   hostConnected() {
-    if (this._target) {
-      this.observe(this._target);
+    for (const target of this._targets.values()) {
+      this.observe(target);
     }
   }
 
@@ -140,6 +141,7 @@ export class ResizeController<T = unknown> implements ReactiveController {
    * @param target Element to observe
    */
   observe(target: Element) {
+    this._targets.add(target);
     this._observer.observe(target, this._config);
     this._unobservedUpdate = true;
     this._host.requestUpdate();

--- a/packages/labs/observers/src/test/intersection_controller_test.ts
+++ b/packages/labs/observers/src/test/intersection_controller_test.ts
@@ -417,20 +417,11 @@ const canTest = () => {
     await intersectionComplete();
     assert.isUndefined(el.observerValue);
 
-    // Does report changes when re-connected
+    // Reports changes when re-connected
     container.appendChild(el);
     await intersectionComplete();
     assert.isUndefined(el.observerValue);
     intersectOut(d1);
-    await intersectionComplete();
-    assert.isTrue(el.observerValue);
-
-    el.resetObserverValue();
-    // Re-observing an existing target doesn't invoke callback.
-    el.observer.observe(d1);
-    await intersectionComplete();
-    assert.isUndefined(el.observerValue);
-    intersectIn(d1);
     await intersectionComplete();
     assert.isTrue(el.observerValue);
   });

--- a/packages/labs/observers/src/test/resize_controller_test.ts
+++ b/packages/labs/observers/src/test/resize_controller_test.ts
@@ -328,6 +328,36 @@ if (DEV_MODE) {
     assert.isTrue(el.observerValue);
   });
 
+  test('observed targets are re-observed on host connected', async () => {
+    const el = await getTestElement(() => ({target: null}));
+    const d1 = document.createElement('div');
+    const d2 = document.createElement('div');
+
+    el.renderRoot.appendChild(d1);
+    el.renderRoot.appendChild(d2);
+
+    el.observer.observe(d1);
+    el.observer.observe(d2);
+
+    await resizeComplete();
+    el.resetObserverValue();
+    el.remove();
+
+    container.appendChild(el);
+
+    // Reports change to first observed target.
+    el.resetObserverValue();
+    resizeElement(d1);
+    await resizeComplete();
+    assert.isTrue(el.observerValue);
+
+    // Reports change to second observed target.
+    el.resetObserverValue();
+    resizeElement(d2);
+    await resizeComplete();
+    assert.isTrue(el.observerValue);
+  });
+
   test('observed target respects `skipInitial`', async () => {
     const el = await getTestElement(() => ({
       target: null,
@@ -348,7 +378,7 @@ if (DEV_MODE) {
     assert.isTrue(el.observerValue);
   });
 
-  test('observed target not re-observed on connection', async () => {
+  test('observed target re-observed on connection', async () => {
     const el = await getTestElement(() => ({target: null}));
     const d1 = document.createElement('div');
 
@@ -366,17 +396,16 @@ if (DEV_MODE) {
     await resizeComplete();
     assert.isUndefined(el.observerValue);
 
-    // Does not report change when re-connected
+    // Reports change when re-connected
     container.appendChild(el);
     resizeElement(d1);
     await resizeComplete();
-    assert.isUndefined(el.observerValue);
-
-    // Can re-observe after connection.
-    el.observer.observe(d1);
-    resizeElement(d1);
-    await resizeComplete();
     assert.isTrue(el.observerValue);
+
+    // Re-observing without resize should not trigger callback.
+    el.resetObserverValue();
+    el.observer.observe(d1);
+    assert.isUndefined(el.observerValue);
   });
 
   test('can observe changes when initialized after host connected', async () => {

--- a/packages/labs/observers/src/test/resize_controller_test.ts
+++ b/packages/labs/observers/src/test/resize_controller_test.ts
@@ -401,11 +401,6 @@ if (DEV_MODE) {
     resizeElement(d1);
     await resizeComplete();
     assert.isTrue(el.observerValue);
-
-    // Re-observing without resize should not trigger callback.
-    el.resetObserverValue();
-    el.observer.observe(d1);
-    assert.isUndefined(el.observerValue);
   });
 
   test('can observe changes when initialized after host connected', async () => {

--- a/packages/labs/observers/src/test/resize_controller_test.ts
+++ b/packages/labs/observers/src/test/resize_controller_test.ts
@@ -391,7 +391,7 @@ if (DEV_MODE) {
     await resizeComplete();
     el.remove();
 
-    // Does not reports change when disconnected.
+    // Does not report change when disconnected.
     resizeElement(d1);
     await resizeComplete();
     assert.isUndefined(el.observerValue);


### PR DESCRIPTION
Fixes: https://github.com/lit/lit/issues/2902

### Context

Previously we would only track a single `_target` that was assigned in the constructor. This `_target` would be re-connected on `hostConnected`. Unfortunately this resulted in imperatively added targets via `observe(target)` to not be re-observed.

### Fix

This is a light lift fix where we now store a set of the observed targets. This means any targets that are observed imperatively get re-observed after host is re-connected.

Note this change only impacts: ResizeController, IntersectionController, and MutationController which accept a `target` to observe.

### Future work

This PR makes it very simple to support an "unobserve" public API (https://github.com/lit/lit/issues/3237) which is coming in a followup PR.

### Test plan

Tested via unit tests.