### PR TITLE
[infra] Update changesets and package for release

### DIFF
--- a/.changeset/big-files-attack.md
+++ b/.changeset/big-files-attack.md
@@ -2,7 +2,6 @@
 '@lit-labs/analyzer': minor
 '@lit-labs/cli': minor
 '@lit-labs/gen-wrapper-vue': minor
-'@lit-labs/ssr': minor
 ---
 
 Added support for analyzing JavaScript files.

--- a/.changeset/clean-parents-doubt.md
+++ b/.changeset/clean-parents-doubt.md
@@ -1,6 +1,5 @@
 ---
 '@lit-labs/cli': minor
-'@lit/localize-tools': minor
 ---
 
 Locally version and lazily install the localize command.

--- a/.changeset/clean-parents-doubt.md
+++ b/.changeset/clean-parents-doubt.md
@@ -1,5 +1,6 @@
 ---
 '@lit-labs/cli': minor
+'@lit-labs/cli-localize': minor
 ---
 
 Locally version and lazily install the localize command.

--- a/.changeset/friendly-squids-perform.md
+++ b/.changeset/friendly-squids-perform.md
@@ -2,4 +2,19 @@
 '@lit-labs/task': major
 ---
 
-Do not reset value or error on status change
+**[Breaking]** Task will no longer reset its `value` or `error` on pending. This allows us to start chaining tasks e.g.
+
+```js
+const a = new Task(
+  this,
+  async ([url]) => await fetch(url),
+  () => [this.url]
+);
+const b = new Task(
+  this,
+  async ([value]) => {
+    /* This is not thrashed */
+  },
+  () => [a.value]
+);
+```

--- a/packages/labs/cli-localize/package.json
+++ b/packages/labs/cli-localize/package.json
@@ -1,8 +1,10 @@
 {
-  "private": true,
   "name": "@lit-labs/cli-localize",
   "description": "Implements the `lit localize` command. Use from @lit-labs/cli",
-  "version": "0.0.1",
+  "version": "0.0.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "author": "Google LLC",
   "license": "BSD-3-Clause",
   "bugs": "https://github.com/lit/lit/issues",


### PR DESCRIPTION
Some tidying up of changesets before the next release.

Changes
- Remove `@lit-labs/ssr` from analyzer changes
- Replace `@lit/localize-tools` with `@lit-labs/cli-localize` for lazy loading localize cli changes
- Prepare `@lit-labs/cli-localize`'s package.json for public release
- Add more info on `@lit-labs/task` changelog for the breaking change