### PR TITLE
[infra] Remove gen-wrapper-angular from changesets

### DIFF
--- a/.changeset/famous-dolls-cheer.md
+++ b/.changeset/famous-dolls-cheer.md
@@ -1,6 +1,5 @@
 ---
 '@lit-labs/analyzer': minor
-'@lit-labs/gen-wrapper-angular': minor
 '@lit-labs/gen-wrapper-react': minor
 '@lit-labs/gen-wrapper-vue': minor
 ---

--- a/.changeset/moody-colts-trade.md
+++ b/.changeset/moody-colts-trade.md
@@ -1,6 +1,5 @@
 ---
 '@lit-labs/analyzer': minor
-'@lit-labs/gen-wrapper-angular': minor
 '@lit-labs/gen-wrapper-react': minor
 '@lit-labs/gen-wrapper-vue': minor
 ---


### PR DESCRIPTION
`@lit-labs/cli` doesn't have a command for generating angular wrapper yet so no point in bumping `@lit-labs/gen-wrapper-angular`