### PR TITLE
[lit-labs/observers] add base class

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -240,6 +240,7 @@ packages/labs/observers/mutation_controller.*
 packages/labs/observers/performance_controller.*
 packages/labs/observers/resize_controller.*
 packages/labs/observers/intersection_controller.*
+packages/labs/observers/base_controller.*
 packages/labs/react/development/
 packages/labs/react/test/
 packages/labs/react/node_modules/

--- a/.prettierignore
+++ b/.prettierignore
@@ -226,6 +226,7 @@ packages/labs/observers/mutation_controller.*
 packages/labs/observers/performance_controller.*
 packages/labs/observers/resize_controller.*
 packages/labs/observers/intersection_controller.*
+packages/labs/observers/base_controller.*
 packages/labs/react/development/
 packages/labs/react/test/
 packages/labs/react/node_modules/

--- a/packages/labs/observers/.gitignore
+++ b/packages/labs/observers/.gitignore
@@ -6,3 +6,4 @@
 /performance_controller.*
 /resize_controller.*
 /intersection_controller.*
+/base_controller.*

--- a/packages/labs/observers/package.json
+++ b/packages/labs/observers/package.json
@@ -41,6 +41,11 @@
       "types": "./development/intersection_controller.d.ts",
       "development": "./development/intersection_controller.js",
       "default": "./intersection_controller.js"
+    },
+    "./base_controller.js": {
+      "types": "./development/base_controller.d.ts",
+      "development": "./development/base_controller.js",
+      "default": "./base_controller.js"
     }
   },
   "files": [
@@ -50,7 +55,8 @@
     "/mutation_controller.{d.ts,d.ts.map,js,js.map}",
     "/performance_controller.{d.ts,d.ts.map,js,js.map}",
     "/resize_controller.{d.ts,d.ts.map,js,js.map}",
-    "/intersection_controller.{d.ts,d.ts.map,js,js.map}"
+    "/intersection_controller.{d.ts,d.ts.map,js,js.map}",
+    "/base_controller.{d.ts,d.ts.map,js,js.map}"
   ],
   "scripts": {
     "build": "wireit",
@@ -109,6 +115,7 @@
       ],
       "output": [
         "index.js{,.map}",
+        "base_controller.js{,.map}",
         "intersection_controller.js{,.map}",
         "mutation_controller.js{,.map}",
         "performance_controller.js{,.map}",

--- a/packages/labs/observers/src/base_controller.ts
+++ b/packages/labs/observers/src/base_controller.ts
@@ -1,0 +1,112 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+import {ReactiveControllerHost} from '@lit/reactive-element/reactive-controller.js';
+
+interface IObserver {
+  observe(element: Element): void;
+  takeRecords?: () => unknown[];
+  disconnect(): void;
+}
+
+export interface BaseControllerConfig {
+  /**
+   * The element to observe. In addition to configuring the target here,
+   * the `observe` method can be called to observe additional targets. When not
+   * specified, the target defaults to the `host`. If set to `null`, no target
+   * is automatically observed. Only the configured target will be re-observed
+   * if the host connects again after unobserving via disconnection.
+   */
+  target?: Element | null;
+  /**
+   * By default the `callback` is called without changes when a target is
+   * observed. This is done to help manage initial state, but this
+   * setup step can be skipped by setting this to true.
+   */
+  skipInitial?: boolean;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export class BaseController<Config, Callback extends (...args: any) => any> {
+  protected _host: ReactiveControllerHost;
+  protected _targets: Set<Element> = new Set();
+  protected _config?: Config;
+  protected _observer!: IObserver;
+  protected _skipInitial = false;
+  /**
+   * Flag used to help manage calling the `callback` when observe is called
+   * and `skipInitial` is set to true. Note that unlike the other observers
+   * IntersectionObserver *does* report its initial state (e.g. whether or not
+   * there is an intersection). This flag is used to avoid handling this
+   * state if `skipInitial` is true.
+   */
+  protected _unobservedUpdate = false;
+  /**
+   * Function that returns a value processed from the observer's changes.
+   * The result is stored in the `value` property.
+   */
+  callback?: Callback;
+  /**
+   * The result of processing the observer's changes via the `callback`
+   * function.
+   */
+  value?: ReturnType<Callback>;
+  constructor(
+    host: ReactiveControllerHost & Element,
+    {
+      config,
+      skipInitial,
+      callback,
+      target,
+    }: {config?: Config; callback?: Callback} & BaseControllerConfig
+  ) {
+    this._host = host;
+    this._skipInitial = skipInitial ?? this._skipInitial;
+    this._config = config;
+    this.callback = callback;
+    // Target defaults to `host` unless explicitly `null`.
+    if (target !== null) {
+      this._targets.add(target ?? host);
+    }
+  }
+
+  /**
+   * Observe the target element. The controller's `target` is automatically
+   * observed when the host connects.
+   * @param target Element to observe
+   */
+  observe(target: Element) {
+    this._targets.add(target);
+    this._observer.observe(target);
+    this._unobservedUpdate = true;
+    this._host.requestUpdate();
+  }
+
+  /**
+   * Process the observer's changes with the controller's `callback`
+   * function to produce a result stored in the `value` property.
+   */
+  protected handleChanges(records: Parameters<Callback>[0]) {
+    this.value = this.callback?.(records, this._observer);
+  }
+
+  hostConnected() {
+    for (const target of this._targets) {
+      this.observe(target);
+    }
+  }
+
+  hostDisconnected() {
+    this.disconnect();
+  }
+
+  /**
+   * Disconnects the observer. This is done automatically when the host
+   * disconnects.
+   */
+  protected disconnect() {
+    this._observer.disconnect();
+  }
+}

--- a/packages/labs/observers/src/intersection_controller.ts
+++ b/packages/labs/observers/src/intersection_controller.ts
@@ -7,7 +7,7 @@ import {
   ReactiveController,
   ReactiveControllerHost,
 } from '@lit/reactive-element/reactive-controller.js';
-
+import {BaseController, type BaseControllerConfig} from './base_controller.js';
 /**
  * The callback function for a IntersectionController.
  */
@@ -18,30 +18,17 @@ export type IntersectionValueCallback<T = unknown> = (
 /**
  * The config options for a IntersectionController.
  */
-export interface IntersectionControllerConfig<T = unknown> {
+export interface IntersectionControllerConfig<T = unknown>
+  extends BaseControllerConfig {
   /**
    * Configuration object for the IntersectionObserver.
    */
   config?: IntersectionObserverInit;
   /**
-   * The element to observe. In addition to configuring the target here,
-   * the `observe` method can be called to observe additional targets. When not
-   * specified, the target defaults to the `host`. If set to `null`, no target
-   * is automatically observed. Only the configured target will be re-observed
-   * if the host connects again after unobserving via disconnection.
-   */
-  target?: Element | null;
-  /**
    * The callback used to process detected changes into a value stored
    * in the controller's `value` property.
    */
   callback?: IntersectionValueCallback<T>;
-  /**
-   * An IntersectionObserver reports the initial intersection state
-   * when observe is called. Setting this flag to true skips processing this
-   * initial state for cases when this is unnecessary.
-   */
-  skipInitial?: boolean;
 }
 
 /**
@@ -60,40 +47,16 @@ export interface IntersectionControllerConfig<T = unknown> {
  * used to process the result into a value which is stored on the controller.
  * The controller's `value` is usable during the host's update cycle.
  */
-export class IntersectionController<T = unknown> implements ReactiveController {
-  private _host: ReactiveControllerHost;
-  private _targets: Set<Element> = new Set();
-  private _observer!: IntersectionObserver;
-  private _skipInitial = false;
-  /**
-   * Flag used to help manage calling the `callback` when observe is called
-   * and `skipInitial` is set to true. Note that unlike the other observers
-   * IntersectionObserver *does* report its initial state (e.g. whether or not
-   * there is an intersection). This flag is used to avoid handling this
-   * state if `skipInitial` is true.
-   */
-  private _unobservedUpdate = false;
-  /**
-   * The result of processing the observer's changes via the `callback`
-   * function.
-   */
-  value?: T;
-  /**
-   * Function that returns a value processed from the observer's changes.
-   * The result is stored in the `value` property.
-   */
-  callback?: IntersectionValueCallback<T>;
+export class IntersectionController<T = unknown>
+  extends BaseController<IntersectionObserverInit, IntersectionValueCallback<T>>
+  implements ReactiveController
+{
+  protected override _observer!: IntersectionObserver;
   constructor(
     host: ReactiveControllerHost & Element,
-    {target, config, callback, skipInitial}: IntersectionControllerConfig<T>
+    opts: IntersectionControllerConfig<T>
   ) {
-    this._host = host;
-    // Target defaults to `host` unless explicitly `null`.
-    if (target !== null) {
-      this._targets.add(target ?? host);
-    }
-    this._skipInitial = skipInitial ?? this._skipInitial;
-    this.callback = callback;
+    super(host, opts);
     // Check browser support.
     if (!window.IntersectionObserver) {
       console.warn(
@@ -111,27 +74,9 @@ export class IntersectionController<T = unknown> implements ReactiveController {
         this.handleChanges(entries);
         this._host.requestUpdate();
       },
-      config
+      opts.config
     );
     host.addController(this);
-  }
-
-  /**
-   * Process the observer's changes with the controller's `callback`
-   * function to produce a result stored in the `value` property.
-   */
-  protected handleChanges(entries: IntersectionObserverEntry[]) {
-    this.value = this.callback?.(entries, this._observer);
-  }
-
-  hostConnected() {
-    for (const target of this._targets) {
-      this.observe(target);
-    }
-  }
-
-  hostDisconnected() {
-    this.disconnect();
   }
 
   async hostUpdated() {
@@ -143,32 +88,11 @@ export class IntersectionController<T = unknown> implements ReactiveController {
   }
 
   /**
-   * Observe the target element. The controller's `target` is automatically
-   * observed when the host connects.
-   * @param target Element to observe
-   */
-  observe(target: Element) {
-    this._targets.add(target);
-    // Note, this will always trigger the callback since the initial
-    // intersection state is reported.
-    this._observer.observe(target);
-    this._unobservedUpdate = true;
-  }
-
-  /**
    * Unobserve the target element.
    * @param target Element to unobserve
    */
   unobserve(target: Element) {
     this._targets.delete(target);
     this._observer.unobserve(target);
-  }
-
-  /**
-   * Disconnects the observer. This is done automatically when the host
-   * disconnects.
-   */
-  protected disconnect() {
-    this._observer.disconnect();
   }
 }

--- a/packages/labs/observers/src/mutation_controller.ts
+++ b/packages/labs/observers/src/mutation_controller.ts
@@ -7,6 +7,7 @@ import {
   ReactiveController,
   ReactiveControllerHost,
 } from '@lit/reactive-element/reactive-controller.js';
+import {BaseController, type BaseControllerConfig} from './base_controller.js';
 
 /**
  * The callback function for a MutationController.
@@ -18,30 +19,17 @@ export type MutationValueCallback<T = unknown> = (
 /**
  * The config options for a MutationController.
  */
-export interface MutationControllerConfig<T = unknown> {
+export interface MutationControllerConfig<T = unknown>
+  extends BaseControllerConfig {
   /**
    * Configuration object for the MutationObserver.
    */
   config: MutationObserverInit;
   /**
-   * The element to observe. In addition to configuring the target here,
-   * the `observe` method can be called to observe additional targets. When not
-   * specified, the target defaults to the `host`. If set to `null`, no target
-   * is automatically observed. Only the configured target will be re-observed
-   * if the host connects again after unobserving via disconnection.
-   */
-  target?: Element | null;
-  /**
    * The callback used to process detected changes into a value stored
    * in the controller's `value` property.
    */
   callback?: MutationValueCallback<T>;
-  /**
-   * By default the `callback` is called without changes when a target is
-   * observed. This is done to help manage initial state, but this
-   * setup step can be skipped by setting this to true.
-   */
-  skipInitial?: boolean;
 }
 
 /**
@@ -59,41 +47,16 @@ export interface MutationControllerConfig<T = unknown> {
  * used to process the result into a value which is stored on the controller.
  * The controller's `value` is usable during the host's update cycle.
  */
-export class MutationController<T = unknown> implements ReactiveController {
-  private _host: ReactiveControllerHost;
-  private _targets: Set<Element> = new Set();
-  private _config: MutationObserverInit;
-  private _observer!: MutationObserver;
-  private _skipInitial = false;
-  /**
-   * Flag used to help manage calling the `callback` when observe is called
-   * in addition to when a mutation occurs. This is done to help setup initial
-   * state and is performed async by requesting a host update and calling
-   * `handleChanges` once by checking and then resetting this flag.
-   */
-  private _unobservedUpdate = false;
-  /**
-   * The result of processing the observer's changes via the `callback`
-   * function.
-   */
-  value?: T;
-  /**
-   * Function that returns a value processed from the observer's changes.
-   * The result is stored in the `value` property.
-   */
-  callback?: MutationValueCallback<T>;
+export class MutationController<T = unknown>
+  extends BaseController<MutationObserverInit, MutationValueCallback<T>>
+  implements ReactiveController
+{
+  protected override _observer!: MutationObserver;
   constructor(
     host: ReactiveControllerHost & Element,
-    {target, config, callback, skipInitial}: MutationControllerConfig<T>
+    opts: MutationControllerConfig<T>
   ) {
-    this._host = host;
-    // Target defaults to `host` unless explicitly `null`.
-    if (target !== null) {
-      this._targets.add(target ?? host);
-    }
-    this._config = config;
-    this._skipInitial = skipInitial ?? this._skipInitial;
-    this.callback = callback;
+    super(host, opts);
     // Check browser support.
     if (!window.MutationObserver) {
       console.warn(
@@ -106,24 +69,6 @@ export class MutationController<T = unknown> implements ReactiveController {
       this._host.requestUpdate();
     });
     host.addController(this);
-  }
-
-  /**
-   * Process the observer's changes with the controller's `callback`
-   * function to produce a result stored in the `value` property.
-   */
-  protected handleChanges(records: MutationRecord[]) {
-    this.value = this.callback?.(records, this._observer);
-  }
-
-  hostConnected() {
-    for (const target of this._targets) {
-      this.observe(target);
-    }
-  }
-
-  hostDisconnected() {
-    this.disconnect();
   }
 
   async hostUpdated() {
@@ -146,18 +91,10 @@ export class MutationController<T = unknown> implements ReactiveController {
    * observed when the host connects.
    * @param target Element to observe
    */
-  observe(target: Element) {
+  override observe(target: Element) {
     this._targets.add(target);
     this._observer.observe(target, this._config);
     this._unobservedUpdate = true;
     this._host.requestUpdate();
-  }
-
-  /**
-   * Disconnects the observer. This is done automatically when the host
-   * disconnects.
-   */
-  protected disconnect() {
-    this._observer.disconnect();
   }
 }

--- a/packages/labs/observers/src/resize_controller.ts
+++ b/packages/labs/observers/src/resize_controller.ts
@@ -8,6 +8,7 @@ import {
   ReactiveControllerHost,
 } from '@lit/reactive-element/reactive-controller.js';
 
+import {BaseController, type BaseControllerConfig} from './base_controller.js';
 /**
  * The callback function for a ResizeController.
  */
@@ -18,30 +19,17 @@ export type ResizeValueCallback<T = unknown> = (
 /**
  * The config options for a ResizeController.
  */
-export interface ResizeControllerConfig<T = unknown> {
+export interface ResizeControllerConfig<T = unknown>
+  extends BaseControllerConfig {
   /**
    * Configuration object for the ResizeController.
    */
   config?: ResizeObserverOptions;
   /**
-   * The element to observe. In addition to configuring the target here,
-   * the `observe` method can be called to observe additional targets. When not
-   * specified, the target defaults to the `host`. If set to `null`, no target
-   * is automatically observed. Only the configured target will be re-observed
-   * if the host connects again after unobserving via disconnection.
-   */
-  target?: Element | null;
-  /**
    * The callback used to process detected changes into a value stored
    * in the controller's `value` property.
    */
   callback?: ResizeValueCallback<T>;
-  /**
-   * By default the `callback` is called without changes when a target is
-   * observed. This is done to help manage initial state, but this
-   * setup step can be skipped by setting this to true.
-   */
-  skipInitial?: boolean;
 }
 
 /**
@@ -58,41 +46,17 @@ export interface ResizeControllerConfig<T = unknown> {
  * used to process the result into a value which is stored on the controller.
  * The controller's `value` is usable during the host's update cycle.
  */
-export class ResizeController<T = unknown> implements ReactiveController {
-  private _host: ReactiveControllerHost;
-  private _targets: Set<Element> = new Set();
-  private _config?: ResizeObserverOptions;
-  private _observer!: ResizeObserver;
-  private _skipInitial = false;
-  /**
-   * Flag used to help manage calling the `callback` when observe is called
-   * in addition to when a mutation occurs. This is done to help setup initial
-   * state and is performed async by requesting a host update and calling
-   * `handleChanges` once by checking and then resetting this flag.
-   */
-  private _unobservedUpdate = false;
-  /**
-   * The result of processing the observer's changes via the `callback`
-   * function.
-   */
-  value?: T;
-  /**
-   * Function that returns a value processed from the observer's changes.
-   * The result is stored in the `value` property.
-   */
-  callback?: ResizeValueCallback<T>;
+export class ResizeController<T = unknown>
+  extends BaseController<ResizeObserverOptions, ResizeValueCallback<T>>
+  implements ReactiveController
+{
+  protected override _observer!: ResizeObserver;
   constructor(
     host: ReactiveControllerHost & Element,
-    {target, config, callback, skipInitial}: ResizeControllerConfig<T>
+    opts: ResizeControllerConfig<T>
   ) {
-    this._host = host;
-    // Target defaults to `host` unless explicitly `null`.
-    if (target !== null) {
-      this._targets.add(target ?? host);
-    }
-    this._config = config;
-    this._skipInitial = skipInitial ?? this._skipInitial;
-    this.callback = callback;
+    super(host, opts);
+
     // Check browser support.
     if (!window.ResizeObserver) {
       console.warn(
@@ -107,24 +71,6 @@ export class ResizeController<T = unknown> implements ReactiveController {
     host.addController(this);
   }
 
-  /**
-   * Process the observer's changes with the controller's `callback`
-   * function to produce a result stored in the `value` property.
-   */
-  protected handleChanges(entries: ResizeObserverEntry[]) {
-    this.value = this.callback?.(entries, this._observer);
-  }
-
-  hostConnected() {
-    for (const target of this._targets) {
-      this.observe(target);
-    }
-  }
-
-  hostDisconnected() {
-    this.disconnect();
-  }
-
   async hostUpdated() {
     // Handle initial state as a set of 0 changes. This helps setup initial
     // state and promotes UI = f(state) since ideally the callback does not
@@ -136,31 +82,11 @@ export class ResizeController<T = unknown> implements ReactiveController {
   }
 
   /**
-   * Observe the target element. The controller's `target` is automatically
-   * observed when the host connects.
-   * @param target Element to observe
-   */
-  observe(target: Element) {
-    this._targets.add(target);
-    this._observer.observe(target, this._config);
-    this._unobservedUpdate = true;
-    this._host.requestUpdate();
-  }
-
-  /**
    * Unobserve the target element.
    * @param target Element to unobserve
    */
   unobserve(target: Element) {
     this._targets.delete(target);
     this._observer.unobserve(target);
-  }
-
-  /**
-   * Disconnects the observer. This is done automatically when the host
-   * disconnects.
-   */
-  protected disconnect() {
-    this._observer.disconnect();
   }
 }


### PR DESCRIPTION
Issue: https://github.com/lit/lit/issues/2350

This PR adds a base class to IntersectionController, ResizeController, and MutationController.


Found a bug that we accept a ResizeController config and then never use it.


TODO: Add size difference before and after.