### PR TITLE
[@labs/react] Add '__forwardRef' to reservedProperties in rollup

### DIFF
--- a/rollup-common.js
+++ b/rollup-common.js
@@ -78,6 +78,7 @@ const reservedProperties = [
   '_$litElement$',
   '_$litStatic$',
   '_$cssResult$',
+  // @lit-labs/react
   '__forwardedRef',
 ];
 

--- a/rollup-common.js
+++ b/rollup-common.js
@@ -78,6 +78,7 @@ const reservedProperties = [
   '_$litElement$',
   '_$litStatic$',
   '_$cssResult$',
+  '__forwardedRef',
 ];
 
 // Private properties which should be stable between versions but are used on


### PR DESCRIPTION
Related to:
https://github.com/lit/lit/issues/3329
https://github.com/lit/lit/pull/3217

To avoid mangling and console logs in production, add `__fowardedRef` to the reservedProperties in the common rollup config