### PR TITLE
[labs/react] Add Node build

### DIFF
--- a/.changeset/eight-elephants-sparkle.md
+++ b/.changeset/eight-elephants-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/react': minor
+---
+
+Add Node build for server rendering. This will allow wrapped components to be added to SSR React frameworks like Next.js.

--- a/.eslintignore
+++ b/.eslintignore
@@ -241,6 +241,7 @@ packages/labs/observers/performance_controller.*
 packages/labs/observers/resize_controller.*
 packages/labs/observers/intersection_controller.*
 packages/labs/react/development/
+packages/labs/react/node/
 packages/labs/react/test/
 packages/labs/react/node_modules/
 packages/labs/react/index.*

--- a/.prettierignore
+++ b/.prettierignore
@@ -227,6 +227,7 @@ packages/labs/observers/performance_controller.*
 packages/labs/observers/resize_controller.*
 packages/labs/observers/intersection_controller.*
 packages/labs/react/development/
+packages/labs/react/node/
 packages/labs/react/test/
 packages/labs/react/node_modules/
 packages/labs/react/index.*

--- a/packages/labs/react/.gitignore
+++ b/packages/labs/react/.gitignore
@@ -1,4 +1,5 @@
 /development/
+/node/
 /test/
 /node_modules/
 /index.*

--- a/packages/labs/react/package.json
+++ b/packages/labs/react/package.json
@@ -20,17 +20,20 @@
     ".": {
       "types": "./development/index.d.ts",
       "development": "./development/index.js",
+      "node": "./node/index.js",
       "default": "./index.js"
     },
     "./use-controller.js": {
       "types": "./development/use-controller.d.ts",
       "development": "./development/use-controller.js",
+      "node": "./node/use-controller.js",
       "default": "./use-controller.js"
     }
   },
   "files": [
     "/development/",
     "!/development/test/",
+    "/node/",
     "/index.{d.ts,d.ts.map,js,js.map}",
     "/create-component.{d.ts,d.ts.map,js,js.map}",
     "/use-controller.{d.ts,d.ts.map,js,js.map}"
@@ -43,6 +46,7 @@
     "test": "wireit",
     "test:dev": "wireit",
     "test:prod": "wireit",
+    "test:node": "wireit",
     "checksize": "wireit"
   },
   "wireit": {
@@ -111,7 +115,8 @@
     "test": {
       "dependencies": [
         "test:dev",
-        "test:prod"
+        "test:prod",
+        "test:node"
       ]
     },
     "test:dev": {
@@ -133,6 +138,13 @@
       ],
       "files": [],
       "output": []
+    },
+    "test:node": {
+      "command": "node development/test/node-render.js",
+      "dependencies": [
+        "build:ts",
+        "build:rollup"
+      ]
     }
   },
   "author": "Google LLC",

--- a/packages/labs/react/rollup.config.js
+++ b/packages/labs/react/rollup.config.js
@@ -10,4 +10,5 @@ import {createRequire} from 'module';
 export default litProdConfig({
   packageName: createRequire(import.meta.url)('./package.json').name,
   entryPoints: ['index', 'create-component', 'use-controller'],
+  includeNodeBuild: true,
 });

--- a/packages/labs/react/src/create-component.ts
+++ b/packages/labs/react/src/create-component.ts
@@ -4,6 +4,14 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+const NODE_MODE = false;
+const global = NODE_MODE ? globalThis : window;
+
+const htmlElementShimNeeded = NODE_MODE && global.HTMLElement === undefined;
+if (htmlElementShimNeeded) {
+  global.HTMLElement = class HTMLElement {} as unknown as typeof HTMLElement;
+}
+
 // Match a prop name to a typed event callback by
 // adding an Event type as an expected property on a string.
 export type EventName<T extends Event = Event> = string & {

--- a/packages/labs/react/src/create-component.ts
+++ b/packages/labs/react/src/create-component.ts
@@ -5,12 +5,6 @@
  */
 
 const NODE_MODE = false;
-const global = NODE_MODE ? globalThis : window;
-
-const htmlElementShimNeeded = NODE_MODE && global.HTMLElement === undefined;
-if (htmlElementShimNeeded) {
-  global.HTMLElement = class HTMLElement {} as unknown as typeof HTMLElement;
-}
 
 // Match a prop name to a typed event callback by
 // adding an Event type as an expected property on a string.
@@ -323,7 +317,7 @@ export function createComponent<
         if (
           eventProps.has(k) ||
           (!reservedReactProperties.has(k) &&
-            !(k in HTMLElement.prototype) &&
+            !(NODE_MODE ? false : k in HTMLElement.prototype) &&
             k in element.prototype)
         ) {
           this._elementProps[k] = v;

--- a/packages/labs/react/src/create-component.ts
+++ b/packages/labs/react/src/create-component.ts
@@ -317,7 +317,11 @@ export function createComponent<
         if (
           eventProps.has(k) ||
           (!reservedReactProperties.has(k) &&
-            !(NODE_MODE ? false : k in HTMLElement.prototype) &&
+            // NODE_MODE check below is to support React SSR where HTMLElement
+            // might not be defined
+            !(NODE_MODE && typeof HTMLElement === 'undefined'
+              ? false
+              : k in HTMLElement.prototype) &&
             k in element.prototype)
         ) {
           this._elementProps[k] = v;

--- a/packages/labs/react/src/test/node-render.ts
+++ b/packages/labs/react/src/test/node-render.ts
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+// This file will be loaded by Node from the node:test script to verify that
+// wrapped components can be server rendered by React.
+
+import {createComponent} from '@lit-labs/react';
+import {ReactiveElement} from '@lit/reactive-element';
+import {customElement} from '@lit/reactive-element/decorators/custom-element.js';
+import React from 'react';
+import {renderToString} from 'react-dom/server.js';
+
+@customElement('my-element')
+class MyElement extends ReactiveElement {}
+
+const Component = createComponent({
+  react: React,
+  tagName: 'my-element',
+  elementClass: MyElement,
+});
+
+renderToString(React.createElement(Component));


### PR DESCRIPTION
Resolves #3397 

This adds a Node build for the `@lit-labs/react` package. ~~The Node build version will provide a minimal shim of an empty `HTMLElement` class to the `createComponent` module, using the same approach as `reactive-element` in #3156.~~

The Node build version skips the `in HTMLElement.prototype` if `HTMLElement` is not defined in global. In that case, relying on `in element.prototype` would be enough, since `ReactiveElement` would be extending an empty `HTMLElement` class from our Node build shim.

This approach will conflict with https://github.com/lit/lit/pull/3128, but it should just be a matter of moving over the `NODE_MODE` check to where `HTMLElement` reference got moved to. We can coordinate depending on which one gets merged first. cc: @taylor-vann 