### PR TITLE
[infra] Use new projectV2 object in issue workflow

### DIFF
--- a/.github/workflows/add-issues-to-project.yml
+++ b/.github/workflows/add-issues-to-project.yml
@@ -30,7 +30,7 @@ jobs:
               }
             }' -f organization=$ORGANIZATION -F project_number=$PROJECT_NUMBER > project_data.json
 
-          echo 'PROJECT_ID='$(jq '.data.organization.projectNext.id' project_data.json) >> $GITHUB_ENV
+          echo 'PROJECT_ID='$(jq '.data.organization.projectV2.id' project_data.json) >> $GITHUB_ENV
 
       - name: Add issue to project
         env:

--- a/.github/workflows/add-issues-to-project.yml
+++ b/.github/workflows/add-issues-to-project.yml
@@ -24,7 +24,7 @@ jobs:
           gh api graphql -f query='
             query($organization: String!, $project_number: Int!) {
               organization(login: $organization){
-                projectNext(number: $project_number) {
+                projectV2(number: $project_number) {
                   id
                 }
               }
@@ -39,8 +39,8 @@ jobs:
         run: |
           gh api graphql -f query='
             mutation($project_id:ID!, $issue_id:ID!) {
-              addProjectNextItem(input: {projectId: $project_id, contentId: $issue_id}) {
-                projectNextItem {
+              addProjectV2ItemById(input: {projectId: $project_id, contentId: $issue_id}) {
+                item {
                   id
                 }
               }


### PR DESCRIPTION
The workflow that adds all newly opened issue to the project board started failing due to the deprecation of the graphql object `projectNext` we were using, replaced by `projectV2` object.

Announcement: https://github.blog/changelog/2022-06-23-the-new-github-issues-june-23rd-update/

Doc for objects: [ProjectV2](https://docs.github.com/en/graphql/reference/objects#projectv2) is a field on [Organization](https://docs.github.com/en/graphql/reference/objects#organization)
Doc for mutation: [addProjectV2ItemById](https://docs.github.com/en/graphql/reference/mutations#addprojectv2itembyid)

Failing workflow: https://github.com/lit/lit/actions/runs/3382150362/jobs/5616777917

The updated query/mutation was tested by running the `gh api graphql` command locally with the issue that failed in the workflow.