### PR TITLE
Make ContextRoot deduplicate context requests by element and callback identity

### DIFF
--- a/.changeset/proud-beans-bake.md
+++ b/.changeset/proud-beans-bake.md
@@ -2,4 +2,4 @@
 '@lit-labs/context': patch
 ---
 
-Make ContextRoot deduplicate context requests by element and callback idendity
+Make ContextRoot deduplicate context requests by element and callback identity

--- a/.changeset/proud-beans-bake.md
+++ b/.changeset/proud-beans-bake.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/context': patch
+---
+
+Make ContextRoot deduplicate context requests by element and callback idendity

--- a/packages/labs/context/README.md
+++ b/packages/labs/context/README.md
@@ -153,7 +153,9 @@ root.attach(document.body);
 
 The `ContextRoot` can be attached to any element and it will gather a list of any context requests which are received at the attached element. The `ContextProvider` controllers will emit `context-provider` events when they are connected to the DOM. These events act as triggers for the `ContextRoot` to redispatch these `context-request` events from their sources.
 
-This solution has a small overhead, in that if a provider is not within the DOM hierarchy of the unsatisfied requests we are unnecessarily refiring these requests, but this approach is safest and most correct in that it is very hard to manage stable DOM hierarchies with the semantics of slotting and reparenting that is common in web components implementations.
+This solution has a small overhead, in that if a provider is not within the DOM hierarchy of the unsatisfied requests we are unnecessarily refiring these requests, but this approach is safest and most correct in that it is very hard to manage unstable DOM hierarchies with the semantics of slotting and reparenting that is common in web components implementations.
+
+Note that ContextRoot uses [WeakRefs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakRef) which are not supported in IE11.
 
 ## Contributing
 

--- a/packages/labs/context/src/lib/context-root.ts
+++ b/packages/labs/context/src/lib/context-root.ts
@@ -17,7 +17,8 @@ export class ContextRoot {
   private pendingContextRequests = new Map<
     Context<unknown, unknown>,
     {
-      // The WeakMap lets us detect if we're seen an element/callback pair yet
+      // The WeakMap lets us detect if we're seen an element/callback pair yet,
+      // without needing to iterate the `requests` array
       callbacks: WeakMap<HTMLElement, WeakSet<ContextCallback<unknown>>>;
 
       // Requests lets us iterate over every element/callback that we need to

--- a/packages/labs/context/src/lib/context-root.ts
+++ b/packages/labs/context/src/lib/context-root.ts
@@ -50,15 +50,15 @@ export class ContextRoot {
   }
 
   private onContextProvider = (
-    ev: ContextProviderEvent<Context<unknown, unknown>>
+    event: ContextProviderEvent<Context<unknown, unknown>>
   ) => {
-    const pendingRequests = this.pendingContextRequests.get(ev.context);
+    const pendingRequests = this.pendingContextRequests.get(event.context);
     if (!pendingRequests) {
       return; // no pending requests for this provider at this time
     }
 
     // clear our list, any still unsatisfied requests will re-add themselves
-    this.pendingContextRequests.delete(ev.context);
+    this.pendingContextRequests.delete(event.context);
 
     // loop over all pending requests and re-dispatch them from their source
     pendingRequests.forEach((request) => {
@@ -67,28 +67,28 @@ export class ContextRoot {
       // redispatch if we still have all the parts of the request
       if (element) {
         element.dispatchEvent(
-          new ContextRequestEvent(ev.context, callback, true)
+          new ContextRequestEvent(event.context, callback, true)
         );
       }
     });
   };
 
   private onContextRequest = (
-    ev: ContextRequestEvent<Context<unknown, unknown>>
+    event: ContextRequestEvent<Context<unknown, unknown>>
   ) => {
     // events that are not subscribing should not be captured
-    if (!ev.subscribe) {
+    if (!event.subscribe) {
       return;
     }
     // store a weakref to this element under the context key
     const request: PendingContextRequest = {
-      element: ev.target as HTMLElement,
-      callback: ev.callback,
+      element: event.target as HTMLElement,
+      callback: event.callback,
     };
-    let pendingContextRequests = this.pendingContextRequests.get(ev.context);
+    let pendingContextRequests = this.pendingContextRequests.get(event.context);
     if (!pendingContextRequests) {
       pendingContextRequests = new Set();
-      this.pendingContextRequests.set(ev.context, pendingContextRequests);
+      this.pendingContextRequests.set(event.context, pendingContextRequests);
     }
     // NOTE: if the element is connected multiple times it will add itself
     // to this set multiple times since the set identify of the request

--- a/packages/labs/context/src/lib/controllers/context-consumer.ts
+++ b/packages/labs/context/src/lib/controllers/context-consumer.ts
@@ -4,7 +4,10 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {ContextRequestEvent} from '../context-request-event.js';
+import {
+  ContextCallback,
+  ContextRequestEvent,
+} from '../context-request-event.js';
 import {Context, ContextType} from '../create-context.js';
 import {ReactiveController, ReactiveElement} from 'lit';
 
@@ -48,41 +51,41 @@ export class ContextConsumer<
 
   private dispatchRequest() {
     this.host.dispatchEvent(
-      new ContextRequestEvent(
-        this.context,
-        (value, unsubscribe) => {
-          // some providers will pass an unsubscribe function indicating they may provide future values
-          if (this.unsubscribe) {
-            // if the unsubscribe function changes this implies we have changed provider
-            if (this.unsubscribe !== unsubscribe) {
-              // cleanup the old provider
-              this.provided = false;
-              this.unsubscribe();
-            }
-            // if we don't support subscription, immediately unsubscribe
-            if (!this.subscribe) {
-              this.unsubscribe();
-            }
-          }
-
-          // store the value so that it can be retrieved from the controller
-          this.value = value;
-          // schedule an update in case this value is used in a template
-          this.host.requestUpdate();
-
-          // only invoke callback if we are either expecting updates or have not yet
-          // been provided a value
-          if (!this.provided || this.subscribe) {
-            this.provided = true;
-            if (this.callback) {
-              this.callback(value, unsubscribe);
-            }
-          }
-
-          this.unsubscribe = unsubscribe;
-        },
-        this.subscribe
-      )
+      new ContextRequestEvent(this.context, this._callback, this.subscribe)
     );
   }
+
+  // This function must have stable identity to properly dedupe in ContextRoot
+  // if this element connects multiple times.
+  private _callback: ContextCallback<ContextType<C>> = (value, unsubscribe) => {
+    // some providers will pass an unsubscribe function indicating they may provide future values
+    if (this.unsubscribe) {
+      // if the unsubscribe function changes this implies we have changed provider
+      if (this.unsubscribe !== unsubscribe) {
+        // cleanup the old provider
+        this.provided = false;
+        this.unsubscribe();
+      }
+      // if we don't support subscription, immediately unsubscribe
+      if (!this.subscribe) {
+        this.unsubscribe();
+      }
+    }
+
+    // store the value so that it can be retrieved from the controller
+    this.value = value;
+    // schedule an update in case this value is used in a template
+    this.host.requestUpdate();
+
+    // only invoke callback if we are either expecting updates or have not yet
+    // been provided a value
+    if (!this.provided || this.subscribe) {
+      this.provided = true;
+      if (this.callback) {
+        this.callback(value, unsubscribe);
+      }
+    }
+
+    this.unsubscribe = unsubscribe;
+  };
 }

--- a/packages/labs/context/src/test/late-provider_test.ts
+++ b/packages/labs/context/src/test/late-provider_test.ts
@@ -13,6 +13,7 @@ import {
   provide,
   ContextRoot,
   ContextProvider,
+  ContextConsumer,
 } from '@lit-labs/context';
 import {assert} from '@esm-bundle/chai';
 
@@ -44,13 +45,6 @@ class LateContextProviderElement extends LitElement {
         <slot></slot>
       </div>
     `;
-  }
-}
-
-@customElement('lazy-context-provider')
-export class LazyContextProviderElement extends LitElement {
-  protected render() {
-    return html`<slot></slot>`;
   }
 }
 
@@ -114,10 +108,16 @@ suite('late context provider', () => {
   });
 
   test('lazy added provider', async () => {
+    @customElement('lazy-context-provider')
+    class LazyContextProviderElement extends LitElement {
+      protected render() {
+        return html`<slot></slot>`;
+      }
+    }
     container.innerHTML = `
-        <lazy-context-provider>
-            <context-consumer></context-consumer>
-        </lazy-context-provider>
+      <lazy-context-provider>
+        <context-consumer></context-consumer>
+      </lazy-context-provider>
     `;
 
     const provider = container.querySelector(
@@ -138,5 +138,109 @@ suite('late context provider', () => {
 
     // `value` should now be provided
     assert.strictEqual(consumer.value, 1000);
+  });
+
+  test('late element with multiple properties', async () => {
+    @customElement('context-consumer-2')
+    class ContextConsumer2Element extends LitElement {
+      @consume({context: simpleContext, subscribe: true})
+      @property({type: Number})
+      public value1 = 0;
+
+      @consume({context: simpleContext, subscribe: true})
+      @property({type: Number})
+      public value2 = 0;
+    }
+
+    container.innerHTML = `
+      <late-context-provider-2 value="999">
+        <context-consumer-2></context-consumer-2>
+      </late-context-provider-2>
+    `;
+
+    const provider = container.querySelector(
+      'late-context-provider-2'
+    ) as LateContextProviderElement;
+
+    const consumer = container.querySelector(
+      'context-consumer-2'
+    ) as ContextConsumer2Element;
+
+    // Let consumer update once with no provider
+    await consumer.updateComplete;
+
+    // Define provider element
+    customElements.define(
+      'late-context-provider-2',
+      class extends LateContextProviderElement {}
+    );
+
+    await provider.updateComplete;
+    await consumer.updateComplete;
+
+    // Check that regardless of de-duping in ContextRoot, both @consume()
+    // decorated properties were set.
+    assert.equal(consumer.value1, 999, 'value1');
+    assert.equal(consumer.value2, 999, 'value2');
+  });
+
+  test('a moved component is only provided to once', async () => {
+    @customElement('context-consumer-3')
+    class ContextConsumer3Element extends LitElement {
+      _consume = new ContextConsumer(
+        this,
+        simpleContext,
+        (value) => {
+          this.value = value;
+          this.callCount++;
+        },
+        true
+      );
+
+      value: number | undefined = undefined;
+
+      callCount = 0;
+    }
+
+    container.innerHTML = `
+      <late-context-provider-3 value="999">
+        <div id="parent-1">
+          <context-consumer-3></context-consumer-3>
+        </div>
+        <div id="parent-2"></div>
+      </late-context-provider-3>
+    `;
+
+    const provider = container.querySelector(
+      'late-context-provider-3'
+    ) as LateContextProviderElement;
+
+    const consumer = container.querySelector(
+      'context-consumer-3'
+    ) as ContextConsumer3Element;
+
+    const parent2 = container.querySelector('#parent-2')!;
+
+    // Let consumer update once with no provider
+    await consumer.updateComplete;
+
+    // Re-parent the consumer so it dispatches a new context-request event
+    parent2.append(consumer);
+
+    // Let consumer update again with no provider
+    await consumer.updateComplete;
+
+    // Define provider element
+    customElements.define(
+      'late-context-provider-3',
+      class extends LateContextProviderElement {}
+    );
+
+    await provider.updateComplete;
+    await consumer.updateComplete;
+
+    assert.equal(consumer.value, 999);
+    // Check that the consumer was called only once
+    assert.equal(consumer.callCount, 1);
   });
 });

--- a/packages/labs/context/src/test/late-provider_test.ts
+++ b/packages/labs/context/src/test/late-provider_test.ts
@@ -48,7 +48,13 @@ class LateContextProviderElement extends LitElement {
   }
 }
 
-suite('late context provider', () => {
+const ua = window.navigator.userAgent;
+const isIE = ua.indexOf('Trident/') > 0;
+
+const suiteSkipIE: typeof suite.skip = (...args) =>
+  isIE ? suite.skip(...args) : suite(...args);
+
+suiteSkipIE('late context provider', () => {
   // let consumer: ContextConsumerElement;
   // let provider: LateContextProviderElement;
   let container: HTMLElement;

--- a/packages/tests/src/web-test-runner.config.ts
+++ b/packages/tests/src/web-test-runner.config.ts
@@ -38,7 +38,7 @@ const browserPresets = {
   sauce: [
     'sauce:Windows 10/Firefox@91', // Current ESR. See: https://wiki.mozilla.org/Release_Management/Calendar
     'sauce:Windows 10/Chrome@latest-2',
-    'sauce:macOS 10.15/Safari@latest',
+    'sauce:macOS 11/Safari@latest',
     // 'sauce:Windows 10/MicrosoftEdge@18', // needs globalThis polyfill
   ],
   'sauce-ie11': ['sauce:Windows 10/Internet Explorer@11'],


### PR DESCRIPTION
Fixes https://github.com/lit/lit/issues/2765

This deduplicates context requests by element identity and callback identity, so that if an element moves around the DOM, causing it to fire multiple context-request events before a provider is available, its context callback is only called once. This behavior is similar to addEventListener() which will call a callback only once no matter how many times it's added for a single event.

This PR also fixes a potential memory leak by using WeakRefs to hold on to both elements and their context request callbacks. We need WeakRefs because when we receive a context-provider event we need to loop over all element/callback pairs for that context and dispatch events. WeakMaps do not allow iterating over entries.

cc @benjamind 