### PR TITLE
[labs/gen-manifest] Adds `exports` and more metadata to manifest generator

### DIFF
--- a/.changeset/dull-months-prove.md
+++ b/.changeset/dull-months-prove.md
@@ -1,0 +1,6 @@
+---
+'@lit-labs/analyzer': minor
+'@lit-labs/gen-manifest': minor
+---
+
+Added support for export, slot, cssPart, and cssProperty to analyzer and manifest generator. Also improved JS project analysis performance.

--- a/packages/labs/analyzer/src/index.ts
+++ b/packages/labs/analyzer/src/index.ts
@@ -17,6 +17,7 @@ export type {
   VariableDeclaration,
   ClassDeclaration,
   LitElementDeclaration,
+  LitElementExport,
   PackageJson,
   ModuleWithLitElementDeclarations,
 } from './lib/model.js';

--- a/packages/labs/analyzer/src/lib/javascript/classes.ts
+++ b/packages/labs/analyzer/src/lib/javascript/classes.ts
@@ -23,7 +23,7 @@ import {
   isLitElementSubclass,
   getLitElementDeclaration,
 } from '../lit-element/lit-element.js';
-import {isExport, getReferenceForIdentifier} from '../references.js';
+import {hasExportKeyword, getReferenceForIdentifier} from '../references.js';
 
 /**
  * Returns an analyzer `ClassDeclaration` model for the given
@@ -74,7 +74,7 @@ export const getClassDeclarationInfo = (
   return {
     name: getClassDeclarationName(declaration),
     factory: () => getClassDeclaration(declaration, analyzer),
-    isExport: isExport(declaration),
+    isExport: hasExportKeyword(declaration),
   };
 };
 

--- a/packages/labs/analyzer/src/lib/javascript/jsdoc.ts
+++ b/packages/labs/analyzer/src/lib/javascript/jsdoc.ts
@@ -1,0 +1,134 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import ts from 'typescript';
+import {DiagnosticsError} from '../errors.js';
+import {AnalyzerInterface, NamedJSDocInfo, NodeJSDocInfo} from '../model.js';
+
+/**
+ * @fileoverview
+ *
+ * Utilities for parsing JSDoc comments.
+ */
+
+/**
+ * Remove line feeds from JSDoc summaries, so they are normalized to
+ * unix `\n` line endings.
+ */
+const normalizeLineEndings = (s: string) => s.replace(/\r/g, '');
+
+// Regex for parsing name, summary, and descriptions from JSDoc comments
+const parseNameDescSummaryRE =
+  /^\s*(?<name>[^\s:]+)([\s-:]+)?(?<summary>[^\n\r]+)?([\n\r]+(?<description>[\s\S]*))?$/m;
+
+// Regex for parsing summary and description from JSDoc comments
+const parseDescSummaryRE =
+  /^\s*(?<summary>[^\n\r]+)\r?\n\r?\n(?<description>[\s\S]*)$/m;
+
+/**
+ * Parses name, summary, and description from JSDoc tag for things like @slot,
+ * @cssPart, and @cssProp.
+ *
+ * Supports the following patterns following the tag (TS parses the tag for us):
+ * * @slot name
+ * * @slot name summary
+ * * @slot name: summary
+ * * @slot name - summary
+ * * @slot name - summary...
+ * *
+ * * description (multiline)
+ */
+export const parseNameDescSummary = (
+  tag: ts.JSDocTag
+): NamedJSDocInfo | undefined => {
+  const {comment} = tag;
+  if (comment == undefined) {
+    return undefined;
+  }
+  if (typeof comment !== 'string') {
+    throw new DiagnosticsError(tag, `Internal error: unsupported node type`);
+  }
+  const nameDescSummary = comment.match(parseNameDescSummaryRE);
+  if (nameDescSummary === null) {
+    throw new DiagnosticsError(tag, 'Unexpected JSDoc format');
+  }
+  const {name, description, summary} = nameDescSummary.groups!;
+  const v: NamedJSDocInfo = {name};
+  if (summary !== undefined) {
+    v.summary = summary;
+  }
+  if (description !== undefined) {
+    v.description = normalizeLineEndings(description);
+  }
+  return v;
+};
+
+/**
+ * Parse summary, description, and deprecated information from JSDoc comments on
+ * a given node.
+ */
+export const parseNodeJSDocInfo = (
+  node: ts.Node,
+  analyzer: AnalyzerInterface
+): NodeJSDocInfo => {
+  const v: NodeJSDocInfo = {};
+  const jsDocTags = ts.getJSDocTags(node);
+  if (jsDocTags !== undefined) {
+    for (const tag of jsDocTags) {
+      const {comment} = tag;
+      if (comment !== undefined && typeof comment !== 'string') {
+        throw new DiagnosticsError(
+          tag,
+          `Internal error: unsupported node type`
+        );
+      }
+      switch (tag.tagName.text) {
+        case 'description':
+          if (comment !== undefined) {
+            v.description = normalizeLineEndings(comment);
+          }
+          break;
+        case 'summary':
+          if (comment !== undefined) {
+            v.summary = comment;
+          }
+          break;
+        case 'deprecated':
+          v.deprecated = comment !== undefined ? comment : true;
+          break;
+      }
+    }
+  }
+  // If we didn't have a tagged @description, we'll use any untagged text as
+  // the description. If we also didn't have a @summary and the untagged text
+  // has a line break, we'll use the first chunk as the summary, and the
+  // remainder as a description.
+  if (v.description === undefined) {
+    // Strangely, it only seems possible to get the untagged jsdoc comments
+    // via the typechecker/symbol API
+    const checker = analyzer.program.getTypeChecker();
+    const symbol =
+      checker.getSymbolAtLocation(node) ??
+      checker.getTypeAtLocation(node).getSymbol();
+    const comments = symbol?.getDocumentationComment(checker);
+    if (comments !== undefined) {
+      const comment = comments.map((c) => c.text).join('\n');
+      if (v.summary !== undefined) {
+        v.description = normalizeLineEndings(comment);
+      } else {
+        const info = comment.match(parseDescSummaryRE);
+        if (info === null) {
+          v.description = normalizeLineEndings(comment);
+        } else {
+          const {summary, description} = info.groups!;
+          v.summary = summary;
+          v.description = normalizeLineEndings(description);
+        }
+      }
+    }
+  }
+  return v;
+};

--- a/packages/labs/analyzer/src/lib/javascript/modules.ts
+++ b/packages/labs/analyzer/src/lib/javascript/modules.ts
@@ -23,7 +23,10 @@ import {
   LocalNameOrReference,
 } from '../model.js';
 import {getClassDeclarationInfo} from './classes.js';
-import {getVariableDeclarationInfo} from './variables.js';
+import {
+  getExportAssignmentVariableDeclarationInfo,
+  getVariableDeclarationInfo,
+} from './variables.js';
 import {AbsolutePath, PackagePath, absoluteToPackage} from '../paths.js';
 import {getPackageInfo} from './packages.js';
 import {DiagnosticsError} from '../errors.js';
@@ -130,6 +133,10 @@ export const getModule = (
             exportMap.set(exportName, decNameOrRef)
         );
       }
+    } else if (ts.isExportAssignment(statement)) {
+      addDeclaration(
+        getExportAssignmentVariableDeclarationInfo(statement, analyzer)
+      );
     } else if (ts.isImportDeclaration(statement)) {
       dependencies.add(
         getPathForModuleSpecifierExpression(statement.moduleSpecifier, analyzer)

--- a/packages/labs/analyzer/src/lib/javascript/variables.ts
+++ b/packages/labs/analyzer/src/lib/javascript/variables.ts
@@ -95,3 +95,37 @@ const getVariableDeclarationInfoList = (
     );
   }
 };
+
+/**
+ * Returns declaration info & factory for a default export assignment.
+ */
+export const getExportAssignmentVariableDeclarationInfo = (
+  exportAssignment: ts.ExportAssignment,
+  analyzer: AnalyzerInterface
+): DeclarationInfo => {
+  return {
+    name: 'default',
+    factory: () =>
+      getExportAssignmentVariableDeclaration(exportAssignment, analyzer),
+    isExport: true,
+  };
+};
+
+/**
+ * Returns an analyzer `VariableDeclaration` model for the given default
+ * ts.ExportAssignment, handling the case of: `export const 'some expression'`;
+ *
+ * Note that even though this technically isn't a VariableDeclaration in
+ * TS, we model it as one since it could unobservably be implemented as
+ * `const varDec = 'some expression'; export {varDec as default} `
+ */
+const getExportAssignmentVariableDeclaration = (
+  exportAssignment: ts.ExportAssignment,
+  analyzer: AnalyzerInterface
+): VariableDeclaration => {
+  return new VariableDeclaration({
+    name: 'default',
+    node: exportAssignment,
+    type: getTypeForNode(exportAssignment.expression, analyzer),
+  });
+};

--- a/packages/labs/analyzer/src/lib/lit-element/lit-element.ts
+++ b/packages/labs/analyzer/src/lib/lit-element/lit-element.ts
@@ -53,7 +53,7 @@ export const getLitElementDeclaration = (
 // *
 // * description (multiline)
 const parseNameDescSummary =
-  /^\s*(?<name>[^\s:]+)([\s-:]+)?(?<summary>[^\n]+)?([\n\r]+(?<description>[\s\S]*))?$/m;
+  /^\s*(?<name>[^\s:]+)([\s-:]+)?(?<summary>[^\n\r]+)?([\n\r]+(?<description>[\s\S]*))?$/m;
 
 /**
  * Parses element metadata from jsDoc tags from a LitElement declaration into
@@ -116,13 +116,22 @@ const addNamedDescriptionToMap = (
     const {name, description, summary} = nameDescSummary.groups!;
     map.set(name, {
       name,
-      description,
       summary,
+      description:
+        description !== undefined
+          ? normalizeLineEndings(description)
+          : undefined,
     });
   } else {
     throw new DiagnosticsError(tag, `Internal error: unsupported node type`);
   }
 };
+
+/**
+ * Remove line feeds from jsdoc summaries, so they are normalized to
+ * unix `\n` line endings.
+ */
+const normalizeLineEndings = (s: string) => s.replace(/\r/g, '');
 
 /**
  * Returns true if this type represents the actual LitElement class.

--- a/packages/labs/analyzer/src/lib/lit-element/lit-element.ts
+++ b/packages/labs/analyzer/src/lib/lit-element/lit-element.ts
@@ -53,7 +53,7 @@ export const getLitElementDeclaration = (
 // *
 // * description (multiline)
 const parseNameDescSummary =
-  /^\s*(?<name>[^\s:]+)([\s-:]+)?(?<summary>[^\n]+)?(\n(?<description>[\s\S]*))?$/m;
+  /^\s*(?<name>[^\s:]+)([\s-:]+)?(?<summary>[^\n]+)?([\n\r]+(?<description>[\s\S]*))?$/m;
 
 /**
  * Parses element metadata from jsDoc tags from a LitElement declaration into

--- a/packages/labs/analyzer/src/lib/model.ts
+++ b/packages/labs/analyzer/src/lib/model.ts
@@ -282,12 +282,12 @@ export abstract class Declaration {
 }
 
 export interface VariableDeclarationInit extends DeclarationInit {
-  node: ts.VariableDeclaration;
+  node: ts.VariableDeclaration | ts.ExportAssignment;
   type: Type | undefined;
 }
 
 export class VariableDeclaration extends Declaration {
-  readonly node: ts.VariableDeclaration;
+  readonly node: ts.VariableDeclaration | ts.ExportAssignment;
   readonly type: Type | undefined;
   constructor(init: VariableDeclarationInit) {
     super(init);

--- a/packages/labs/analyzer/src/lib/model.ts
+++ b/packages/labs/analyzer/src/lib/model.ts
@@ -255,14 +255,20 @@ export class Module {
   }
 }
 
-interface DeclarationInit {
+interface DeclarationInit extends NodeJSDocInfo {
   name: string;
 }
 
 export abstract class Declaration {
-  name: string;
+  readonly name: string;
+  readonly description?: string | undefined;
+  readonly summary?: string | undefined;
+  readonly deprecated?: string | boolean | undefined;
   constructor(init: DeclarationInit) {
     this.name = init.name;
+    this.description = init.description;
+    this.summary = init.summary;
+    this.deprecated = init.deprecated;
   }
   isVariableDeclaration(): this is VariableDeclaration {
     return this instanceof VariableDeclaration;
@@ -316,19 +322,25 @@ export class ClassDeclaration extends Declaration {
   }
 }
 
-export interface NameDescSummary {
+export interface NamedJSDocInfo {
   name: string;
-  description: string | undefined;
-  summary: string | undefined;
+  description?: string | undefined;
+  summary?: string | undefined;
+}
+
+export interface NodeJSDocInfo {
+  description?: string | undefined;
+  summary?: string | undefined;
+  deprecated?: string | boolean | undefined;
 }
 
 interface LitElementDeclarationInit extends ClassDeclarationInit {
   tagname: string | undefined;
   reactiveProperties: Map<string, ReactiveProperty>;
   events: Map<string, Event>;
-  slots: Map<string, NameDescSummary>;
-  cssProperties: Map<string, NameDescSummary>;
-  cssParts: Map<string, NameDescSummary>;
+  slots: Map<string, NamedJSDocInfo>;
+  cssProperties: Map<string, NamedJSDocInfo>;
+  cssParts: Map<string, NamedJSDocInfo>;
 }
 
 export class LitElementDeclaration extends ClassDeclaration {
@@ -345,9 +357,9 @@ export class LitElementDeclaration extends ClassDeclaration {
 
   readonly reactiveProperties: Map<string, ReactiveProperty>;
   readonly events: Map<string, Event>;
-  readonly slots: Map<string, NameDescSummary>;
-  readonly cssProperties: Map<string, NameDescSummary>;
-  readonly cssParts: Map<string, NameDescSummary>;
+  readonly slots: Map<string, NamedJSDocInfo>;
+  readonly cssProperties: Map<string, NamedJSDocInfo>;
+  readonly cssParts: Map<string, NamedJSDocInfo>;
 
   constructor(init: LitElementDeclarationInit) {
     super(init);

--- a/packages/labs/analyzer/src/lib/model.ts
+++ b/packages/labs/analyzer/src/lib/model.ts
@@ -316,10 +316,19 @@ export class ClassDeclaration extends Declaration {
   }
 }
 
+export interface NameDescSummary {
+  name: string;
+  description: string | undefined;
+  summary: string | undefined;
+}
+
 interface LitElementDeclarationInit extends ClassDeclarationInit {
   tagname: string | undefined;
   reactiveProperties: Map<string, ReactiveProperty>;
-  readonly events: Map<string, Event>;
+  events: Map<string, Event>;
+  slots: Map<string, NameDescSummary>;
+  cssProperties: Map<string, NameDescSummary>;
+  cssParts: Map<string, NameDescSummary>;
 }
 
 export class LitElementDeclaration extends ClassDeclaration {
@@ -335,14 +344,19 @@ export class LitElementDeclaration extends ClassDeclaration {
   readonly tagname: string | undefined;
 
   readonly reactiveProperties: Map<string, ReactiveProperty>;
-
   readonly events: Map<string, Event>;
+  readonly slots: Map<string, NameDescSummary>;
+  readonly cssProperties: Map<string, NameDescSummary>;
+  readonly cssParts: Map<string, NameDescSummary>;
 
   constructor(init: LitElementDeclarationInit) {
     super(init);
     this.tagname = init.tagname;
     this.reactiveProperties = init.reactiveProperties;
     this.events = init.events;
+    this.slots = init.slots;
+    this.cssProperties = init.cssProperties;
+    this.cssParts = init.cssParts;
   }
 }
 

--- a/packages/labs/analyzer/src/lib/references.ts
+++ b/packages/labs/analyzer/src/lib/references.ts
@@ -17,9 +17,28 @@ import {AbsolutePath} from './paths.js';
 const npmModule = /^(?<package>(@[^/]+\/[^/]+)|[^/]+)\/?(?<module>.*)$/;
 
 /**
+ * Returns a ts.Symbol for a name in scope at a given location in the AST.
+ * TODO(kschaaf): There are ~1748 symbols in scope of a typical hello world,
+ * due to DOM globals. Perf might become an issue here.
+ */
+export const getSymbolForName = (
+  name: string,
+  location: ts.Node,
+  analyzer: AnalyzerInterface
+): ts.Symbol | undefined => {
+  return analyzer.program
+    .getTypeChecker()
+    .getSymbolsInScope(
+      location,
+      (ts.SymbolFlags as unknown as {All: number}).All
+    )
+    .filter((s) => s.name === name)[0];
+};
+
+/**
  * Returns if the given declaration is exported from the module or not.
  */
-export const isExport = (node: ts.Declaration) =>
+export const hasExportKeyword = (node: ts.Statement) =>
   !!node.modifiers?.find((m) => m.kind === ts.SyntaxKind.ExportKeyword);
 
 interface ModuleSpecifierInfo {
@@ -300,7 +319,9 @@ export const getExportReferences = (
     [];
   if (ts.isNamedExports(exportClause)) {
     for (const el of exportClause.elements) {
-      const exportName = (el.propertyName ?? el.name).getText();
+      const exportName = el.name.getText();
+      const localNameNode = el.propertyName ?? el.name;
+      const localName = localNameNode.getText();
       if (moduleSpecifier !== undefined) {
         // This was an explicit re-export (e.g. `export {a} from 'foo'`), so add
         // a Reference
@@ -310,16 +331,17 @@ export const getExportReferences = (
           decNameOrRef: getImportReference(
             specifier,
             moduleSpecifier,
-            el.name.getText(),
+            localName,
             analyzer
           ),
         });
       } else {
         // Get the declaration for this symbol, so we can determine if
-        // it was declared locally or not
-        const symbol = analyzer.program
-          .getTypeChecker()
-          .getSymbolAtLocation(el.name);
+        // it was declared locally or not. Note we use name-based searching
+        // to find the symbol, because `getSymbolAtLocation()` for
+        // `export {Foo}` will annoyingly just point back to the export
+        // line, rather than the location it was actually declared.
+        const symbol = getSymbolForName(localName, localNameNode, analyzer);
         const decl = symbol?.declarations?.[0];
         if (symbol === undefined || decl === undefined) {
           throw new DiagnosticsError(
@@ -337,7 +359,7 @@ export const getExportReferences = (
         } else {
           // Otherwise, the declaration is local, so just add its name; this
           // can be looked up directly in `getDeclaration` for the module
-          refs.push({exportName, decNameOrRef: el.name.getText()});
+          refs.push({exportName, decNameOrRef: localName});
         }
       }
     }

--- a/packages/labs/analyzer/src/lib/types.ts
+++ b/packages/labs/analyzer/src/lib/types.ts
@@ -14,26 +14,11 @@ import {
   PackagePath,
   resolveExtension,
 } from './paths.js';
-import {getImportReference, getReferenceForSymbol} from './references.js';
-
-/**
- * Returns a ts.Symbol for a name in scope at a given location in the AST.
- * TODO(kschaaf): There are ~1748 symbols in scope of a typical hello world,
- * due to DOM globals. Perf might become an issue here.
- */
-export const getSymbolForName = (
-  name: string,
-  location: ts.Node,
-  analyzer: AnalyzerInterface
-): ts.Symbol | undefined => {
-  return analyzer.program
-    .getTypeChecker()
-    .getSymbolsInScope(
-      location,
-      (ts.SymbolFlags as unknown as {All: number}).All
-    )
-    .filter((s) => s.name === name)[0];
-};
+import {
+  getImportReference,
+  getReferenceForSymbol,
+  getSymbolForName,
+} from './references.js';
 
 /**
  * Returns an analyzer `Type` object for the given jsDoc tag.

--- a/packages/labs/analyzer/src/test/javascript/exports_test.ts
+++ b/packages/labs/analyzer/src/test/javascript/exports_test.ts
@@ -1,0 +1,263 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {suite} from 'uvu';
+// eslint-disable-next-line import/extensions
+import * as assert from 'uvu/assert';
+import {AbsolutePath} from '../../lib/paths.js';
+import {getSourceFilename, InMemoryAnalyzer, languages} from '../utils.js';
+
+for (const lang of languages) {
+  const test = suite<{
+    analyzer: InMemoryAnalyzer;
+  }>(`Exports tests (${lang})`);
+
+  test.before.each((ctx) => {
+    ctx.analyzer = new InMemoryAnalyzer(lang, {
+      '/package.json': JSON.stringify({name: '@lit-internal/in-memory-test'}),
+    });
+  });
+
+  test('local declaration export via export keyword', ({analyzer}) => {
+    analyzer.setFile(
+      '/a',
+      `
+      export const a = 'a';
+      `
+    );
+    const module = analyzer.getModule(
+      getSourceFilename('/a', lang) as AbsolutePath
+    );
+    assert.equal(module.exportNames.sort(), ['a']);
+    const a = module.getExportReference('a');
+    assert.equal(a.name, 'a');
+    assert.equal(a.module, undefined);
+  });
+
+  test('local declaration export via export statement', ({analyzer}) => {
+    analyzer.setFile(
+      '/a',
+      `
+      const a = 'a';
+      export {a};
+      `
+    );
+    const module = analyzer.getModule(
+      getSourceFilename('/a', lang) as AbsolutePath
+    );
+    assert.equal(module.exportNames.sort(), ['a']);
+    const a = module.getExportReference('a');
+    assert.equal(a.name, 'a');
+    assert.equal(a.module, undefined);
+  });
+
+  test('local declaration export via export statement, renamed', ({
+    analyzer,
+  }) => {
+    analyzer.setFile(
+      '/a',
+      `
+      const aInternal = 'a';
+      export {aInternal as a};
+      `
+    );
+    const module = analyzer.getModule(
+      getSourceFilename('/a', lang) as AbsolutePath
+    );
+    assert.equal(module.exportNames.sort(), ['a']);
+    const a = module.getExportReference('a');
+    assert.equal(a.name, 'aInternal');
+    assert.equal(a.module, undefined);
+  });
+
+  test('local declaration export via export statement, multiple', ({
+    analyzer,
+  }) => {
+    analyzer.setFile(
+      '/a',
+      `
+      const aInternal = 'a';
+      const b = 'b';
+      export {aInternal as a, b, aInternal as c};
+      `
+    );
+    const module = analyzer.getModule(
+      getSourceFilename('/a', lang) as AbsolutePath
+    );
+    assert.equal(module.exportNames.sort(), ['a', 'b', 'c']);
+    const a = module.getExportReference('a');
+    assert.equal(a.name, 'aInternal');
+    assert.equal(a.module, undefined);
+    const b = module.getExportReference('b');
+    assert.equal(b.name, 'b');
+    assert.equal(b.module, undefined);
+    const c = module.getExportReference('c');
+    assert.equal(c.name, 'aInternal');
+    assert.equal(c.module, undefined);
+  });
+
+  test('reexport via export statement with specifier', ({analyzer}) => {
+    analyzer.setFile('/a', `export const a = 'a';`);
+    analyzer.setFile(
+      '/b',
+      `
+      export {a} from './a.js';
+      `
+    );
+    const module = analyzer.getModule(
+      getSourceFilename('/b', lang) as AbsolutePath
+    );
+    assert.equal(module.exportNames.sort(), ['a']);
+    const a = module.getExportReference('a');
+    assert.equal(a.name, 'a');
+    assert.equal(a.module, 'a.js');
+  });
+
+  test('reexport via export statement with specifier, renamed', ({
+    analyzer,
+  }) => {
+    analyzer.setFile('/a', `export const a = 'a';`);
+    analyzer.setFile(
+      '/b',
+      `
+      export {a as a2} from './a.js';
+      `
+    );
+    const module = analyzer.getModule(
+      getSourceFilename('/b', lang) as AbsolutePath
+    );
+    assert.equal(module.exportNames.sort(), ['a2']);
+    const a = module.getExportReference('a2');
+    assert.equal(a.name, 'a');
+    assert.equal(a.module, 'a.js');
+  });
+
+  test('reexport via export statement with specifier, multiple', ({
+    analyzer,
+  }) => {
+    analyzer.setFile(
+      '/a',
+      `
+      export const a = 'a';
+      export const b = 'b';
+      `
+    );
+    analyzer.setFile(
+      '/b',
+      `
+      export {a as a2, b} from './a.js';
+      `
+    );
+    const module = analyzer.getModule(
+      getSourceFilename('/b', lang) as AbsolutePath
+    );
+    assert.equal(module.exportNames.sort(), ['a2', 'b']);
+    const a = module.getExportReference('a2');
+    assert.equal(a.name, 'a');
+    assert.equal(a.module, 'a.js');
+    const b = module.getExportReference('b');
+    assert.equal(b.name, 'b');
+    assert.equal(b.module, 'a.js');
+  });
+
+  test('reexport via export statement of imported symbol', ({analyzer}) => {
+    analyzer.setFile('/a', `export const a = 'a';`);
+    analyzer.setFile(
+      '/b',
+      `
+      import {a} from './a.js'
+      export {a};
+      `
+    );
+    const module = analyzer.getModule(
+      getSourceFilename('/b', lang) as AbsolutePath
+    );
+    assert.equal(module.exportNames.sort(), ['a']);
+    const a = module.getExportReference('a');
+    assert.equal(a.name, 'a');
+    assert.equal(a.module, 'a.js');
+  });
+
+  test('reexport via export statement of renamed imported symbol', ({
+    analyzer,
+  }) => {
+    analyzer.setFile('/a', `export const a = 'a';`);
+    analyzer.setFile(
+      '/b',
+      `
+      import {a as a2} from './a.js'
+      export {a2};
+      `
+    );
+    const module = analyzer.getModule(
+      getSourceFilename('/b', lang) as AbsolutePath
+    );
+    assert.equal(module.exportNames.sort(), ['a2']);
+    const a = module.getExportReference('a2');
+    assert.equal(a.name, 'a');
+    assert.equal(a.module, 'a.js');
+  });
+
+  test('reexport via export statement of renamed imported symbol, renamed', ({
+    analyzer,
+  }) => {
+    analyzer.setFile('/a', `export const a = 'a';`);
+    analyzer.setFile(
+      '/b',
+      `
+      import {a as a2} from './a.js'
+      export {a2 as a3};
+      `
+    );
+    const module = analyzer.getModule(
+      getSourceFilename('/b', lang) as AbsolutePath
+    );
+    assert.equal(module.exportNames.sort(), ['a3']);
+    const a = module.getExportReference('a3');
+    assert.equal(a.name, 'a');
+    assert.equal(a.module, 'a.js');
+  });
+
+  test('reexport via export statement of imported symbols, multiple', ({
+    analyzer,
+  }) => {
+    analyzer.setFile(
+      '/a',
+      `
+      export const a = 'a';
+      export const b = 'b';
+      export const c = 'c';
+      `
+    );
+    analyzer.setFile(
+      '/b',
+      `
+      import {a} from './a.js'
+      import {b, c as c2} from './a.js'
+      export {a, b, c2 as c};
+      export {c2}
+      `
+    );
+    const module = analyzer.getModule(
+      getSourceFilename('/b', lang) as AbsolutePath
+    );
+    assert.equal(module.exportNames.sort(), ['a', 'b', 'c', 'c2']);
+    const a = module.getExportReference('a');
+    assert.equal(a.name, 'a');
+    assert.equal(a.module, 'a.js');
+    const b = module.getExportReference('b');
+    assert.equal(b.name, 'b');
+    assert.equal(b.module, 'a.js');
+    const c = module.getExportReference('c');
+    assert.equal(c.name, 'c');
+    assert.equal(c.module, 'a.js');
+    const c2 = module.getExportReference('c2');
+    assert.equal(c2.name, 'c');
+    assert.equal(c2.module, 'a.js');
+  });
+
+  test.run();
+}

--- a/packages/labs/analyzer/src/test/lit-element/jsdoc_test.ts
+++ b/packages/labs/analyzer/src/test/lit-element/jsdoc_test.ts
@@ -1,0 +1,224 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {suite} from 'uvu';
+// eslint-disable-next-line import/extensions
+import * as assert from 'uvu/assert';
+import {fileURLToPath} from 'url';
+import {getSourceFilename, languages} from '../utils.js';
+
+import {
+  createPackageAnalyzer,
+  Analyzer,
+  AbsolutePath,
+  LitElementDeclaration,
+} from '../../index.js';
+
+for (const lang of languages) {
+  const test = suite<{
+    analyzer: Analyzer;
+    packagePath: AbsolutePath;
+    element: LitElementDeclaration;
+  }>(`LitElement event tests (${lang})`);
+
+  test.before((ctx) => {
+    try {
+      const packagePath = fileURLToPath(
+        new URL(`../../test-files/${lang}/jsdoc`, import.meta.url).href
+      ) as AbsolutePath;
+      const analyzer = createPackageAnalyzer(packagePath);
+
+      const result = analyzer.getPackage();
+      const elementAModule = result.modules.find(
+        (m) => m.sourcePath === getSourceFilename('element-a', lang)
+      );
+      const element = elementAModule!.declarations.filter((d) =>
+        d.isLitElementDeclaration()
+      )[0] as LitElementDeclaration;
+
+      ctx.packagePath = packagePath;
+      ctx.analyzer = analyzer;
+      ctx.element = element;
+    } catch (error) {
+      // Uvu has a bug where it silently ignores failures in before and after,
+      // see https://github.com/lukeed/uvu/issues/191.
+      console.error('uvu before error', error);
+      process.exit(1);
+    }
+  });
+
+  // slots
+
+  test('slots - Correct number found', ({element}) => {
+    assert.equal(element.slots.size, 5);
+  });
+
+  test('slots - basic', ({element}) => {
+    const slot = element.slots.get('basic');
+    assert.ok(slot);
+    assert.equal(slot.summary, undefined);
+    assert.equal(slot.description, undefined);
+  });
+
+  test('slots - with-summary', ({element}) => {
+    const slot = element.slots.get('with-summary');
+    assert.ok(slot);
+    assert.equal(slot.summary, 'Summary for with-summary');
+    assert.equal(slot.description, undefined);
+  });
+
+  test('slots - with-summary-dash', ({element}) => {
+    const slot = element.slots.get('with-summary-dash');
+    assert.ok(slot);
+    assert.equal(slot.summary, 'Summary for with-summary-dash');
+    assert.equal(slot.description, undefined);
+  });
+
+  test('slots - with-summary-colon', ({element}) => {
+    const slot = element.slots.get('with-summary-colon');
+    assert.ok(slot);
+    assert.equal(slot.summary, 'Summary for with-summary-colon');
+    assert.equal(slot.description, undefined);
+  });
+
+  test('slots - with-description', ({element}) => {
+    const slot = element.slots.get('with-description');
+    assert.ok(slot);
+    assert.equal(slot.summary, 'Summary for with-description');
+    assert.equal(
+      slot.description,
+      'Description for with-description\nMore description for with-description\n\nEven more description for with-description'
+    );
+  });
+
+  // cssParts
+
+  test('cssParts - Correct number found', ({element}) => {
+    assert.equal(element.cssParts.size, 5);
+  });
+
+  test('cssParts - basic', ({element}) => {
+    const part = element.cssParts.get('basic');
+    assert.ok(part);
+    assert.equal(part.summary, undefined);
+    assert.equal(part.description, undefined);
+  });
+
+  test('cssParts - with-summary', ({element}) => {
+    const part = element.cssParts.get('with-summary');
+    assert.ok(part);
+    assert.equal(part.summary, 'Summary for :part(with-summary)');
+    assert.equal(part.description, undefined);
+  });
+
+  test('cssParts - with-summary-dash', ({element}) => {
+    const part = element.cssParts.get('with-summary-dash');
+    assert.ok(part);
+    assert.equal(part.summary, 'Summary for :part(with-summary-dash)');
+    assert.equal(part.description, undefined);
+  });
+
+  test('cssParts - with-summary-colon', ({element}) => {
+    const part = element.cssParts.get('with-summary-colon');
+    assert.ok(part);
+    assert.equal(part.summary, 'Summary for :part(with-summary-colon)');
+    assert.equal(part.description, undefined);
+  });
+
+  test('cssParts - with-description', ({element}) => {
+    const part = element.cssParts.get('with-description');
+    assert.ok(part);
+    assert.equal(part.summary, 'Summary for :part(with-description)');
+    assert.equal(
+      part.description,
+      'Description for :part(with-description)\nMore description for :part(with-description)\n\nEven more description for :part(with-description)'
+    );
+  });
+
+  // cssProperties
+
+  test('cssProperties - Correct number found', ({element}) => {
+    assert.equal(element.cssProperties.size, 10);
+  });
+
+  test('cssProperties - basic', ({element}) => {
+    const prop = element.cssProperties.get('--basic');
+    assert.ok(prop);
+    assert.equal(prop.summary, undefined);
+    assert.equal(prop.description, undefined);
+  });
+
+  test('cssProperties - with-summary', ({element}) => {
+    const prop = element.cssProperties.get('--with-summary');
+    assert.ok(prop);
+    assert.equal(prop.summary, 'Summary for --with-summary');
+    assert.equal(prop.description, undefined);
+  });
+
+  test('cssProperties - with-summary-colon', ({element}) => {
+    const prop = element.cssProperties.get('--with-summary-colon');
+    assert.ok(prop);
+    assert.equal(prop.summary, 'Summary for --with-summary-colon');
+    assert.equal(prop.description, undefined);
+  });
+
+  test('cssProperties - with-summary-dash', ({element}) => {
+    const prop = element.cssProperties.get('--with-summary-dash');
+    assert.ok(prop);
+    assert.equal(prop.summary, 'Summary for --with-summary-dash');
+    assert.equal(prop.description, undefined);
+  });
+
+  test('cssProperties - with-description', ({element}) => {
+    const prop = element.cssProperties.get('--with-description');
+    assert.ok(prop);
+    assert.equal(prop.summary, 'Summary for --with-description');
+    assert.equal(
+      prop.description,
+      'Description for --with-description\nMore description for --with-description\n\nEven more description for --with-description'
+    );
+  });
+
+  test('cssProperties - short-basic', ({element}) => {
+    const prop = element.cssProperties.get('--short-basic');
+    assert.ok(prop);
+    assert.equal(prop.summary, undefined);
+    assert.equal(prop.description, undefined);
+  });
+
+  test('cssProperties - short-with-summary', ({element}) => {
+    const prop = element.cssProperties.get('--short-with-summary');
+    assert.ok(prop);
+    assert.equal(prop.summary, 'Summary for --short-with-summary');
+    assert.equal(prop.description, undefined);
+  });
+
+  test('cssProperties - short-with-summary-colon', ({element}) => {
+    const prop = element.cssProperties.get('--short-with-summary-colon');
+    assert.ok(prop);
+    assert.equal(prop.summary, 'Summary for --short-with-summary-colon');
+    assert.equal(prop.description, undefined);
+  });
+
+  test('cssProperties - short-with-summary-dash', ({element}) => {
+    const prop = element.cssProperties.get('--short-with-summary-dash');
+    assert.ok(prop);
+    assert.equal(prop.summary, 'Summary for --short-with-summary-dash');
+    assert.equal(prop.description, undefined);
+  });
+
+  test('cssProperties - short-with-description', ({element}) => {
+    const prop = element.cssProperties.get('--short-with-description');
+    assert.ok(prop);
+    assert.equal(prop.summary, 'Summary for --short-with-description');
+    assert.equal(
+      prop.description,
+      'Description for --short-with-description\nMore description for --short-with-description\n\nEven more description for --short-with-description'
+    );
+  });
+
+  test.run();
+}

--- a/packages/labs/analyzer/src/test/lit-element/jsdoc_test.ts
+++ b/packages/labs/analyzer/src/test/lit-element/jsdoc_test.ts
@@ -10,18 +10,11 @@ import * as assert from 'uvu/assert';
 import {fileURLToPath} from 'url';
 import {getSourceFilename, languages} from '../utils.js';
 
-import {
-  createPackageAnalyzer,
-  Analyzer,
-  AbsolutePath,
-  LitElementDeclaration,
-} from '../../index.js';
+import {createPackageAnalyzer, Module, AbsolutePath} from '../../index.js';
 
 for (const lang of languages) {
   const test = suite<{
-    analyzer: Analyzer;
-    packagePath: AbsolutePath;
-    element: LitElementDeclaration;
+    getModule: (name: string) => Module;
   }>(`LitElement event tests (${lang})`);
 
   test.before((ctx) => {
@@ -30,18 +23,13 @@ for (const lang of languages) {
         new URL(`../../test-files/${lang}/jsdoc`, import.meta.url).href
       ) as AbsolutePath;
       const analyzer = createPackageAnalyzer(packagePath);
-
-      const result = analyzer.getPackage();
-      const elementAModule = result.modules.find(
-        (m) => m.sourcePath === getSourceFilename('element-a', lang)
-      );
-      const element = elementAModule!.declarations.filter((d) =>
-        d.isLitElementDeclaration()
-      )[0] as LitElementDeclaration;
-
-      ctx.packagePath = packagePath;
-      ctx.analyzer = analyzer;
-      ctx.element = element;
+      ctx.getModule = (name: string) =>
+        analyzer.getModule(
+          getSourceFilename(
+            analyzer.path.join(packagePath, name),
+            lang
+          ) as AbsolutePath
+        );
     } catch (error) {
       // Uvu has a bug where it silently ignores failures in before and after,
       // see https://github.com/lukeed/uvu/issues/191.
@@ -52,39 +40,51 @@ for (const lang of languages) {
 
   // slots
 
-  test('slots - Correct number found', ({element}) => {
+  test('slots - Correct number found', ({getModule}) => {
+    const element = getModule('element-a').getDeclaration('ElementA');
+    assert.ok(element.isLitElementDeclaration());
     assert.equal(element.slots.size, 5);
   });
 
-  test('slots - basic', ({element}) => {
+  test('slots - basic', ({getModule}) => {
+    const element = getModule('element-a').getDeclaration('ElementA');
+    assert.ok(element.isLitElementDeclaration());
     const slot = element.slots.get('basic');
     assert.ok(slot);
     assert.equal(slot.summary, undefined);
     assert.equal(slot.description, undefined);
   });
 
-  test('slots - with-summary', ({element}) => {
+  test('slots - with-summary', ({getModule}) => {
+    const element = getModule('element-a').getDeclaration('ElementA');
+    assert.ok(element.isLitElementDeclaration());
     const slot = element.slots.get('with-summary');
     assert.ok(slot);
     assert.equal(slot.summary, 'Summary for with-summary');
     assert.equal(slot.description, undefined);
   });
 
-  test('slots - with-summary-dash', ({element}) => {
+  test('slots - with-summary-dash', ({getModule}) => {
+    const element = getModule('element-a').getDeclaration('ElementA');
+    assert.ok(element.isLitElementDeclaration());
     const slot = element.slots.get('with-summary-dash');
     assert.ok(slot);
     assert.equal(slot.summary, 'Summary for with-summary-dash');
     assert.equal(slot.description, undefined);
   });
 
-  test('slots - with-summary-colon', ({element}) => {
+  test('slots - with-summary-colon', ({getModule}) => {
+    const element = getModule('element-a').getDeclaration('ElementA');
+    assert.ok(element.isLitElementDeclaration());
     const slot = element.slots.get('with-summary-colon');
     assert.ok(slot);
     assert.equal(slot.summary, 'Summary for with-summary-colon');
     assert.equal(slot.description, undefined);
   });
 
-  test('slots - with-description', ({element}) => {
+  test('slots - with-description', ({getModule}) => {
+    const element = getModule('element-a').getDeclaration('ElementA');
+    assert.ok(element.isLitElementDeclaration());
     const slot = element.slots.get('with-description');
     assert.ok(slot);
     assert.equal(slot.summary, 'Summary for with-description');
@@ -96,39 +96,51 @@ for (const lang of languages) {
 
   // cssParts
 
-  test('cssParts - Correct number found', ({element}) => {
+  test('cssParts - Correct number found', ({getModule}) => {
+    const element = getModule('element-a').getDeclaration('ElementA');
+    assert.ok(element.isLitElementDeclaration());
     assert.equal(element.cssParts.size, 5);
   });
 
-  test('cssParts - basic', ({element}) => {
+  test('cssParts - basic', ({getModule}) => {
+    const element = getModule('element-a').getDeclaration('ElementA');
+    assert.ok(element.isLitElementDeclaration());
     const part = element.cssParts.get('basic');
     assert.ok(part);
     assert.equal(part.summary, undefined);
     assert.equal(part.description, undefined);
   });
 
-  test('cssParts - with-summary', ({element}) => {
+  test('cssParts - with-summary', ({getModule}) => {
+    const element = getModule('element-a').getDeclaration('ElementA');
+    assert.ok(element.isLitElementDeclaration());
     const part = element.cssParts.get('with-summary');
     assert.ok(part);
     assert.equal(part.summary, 'Summary for :part(with-summary)');
     assert.equal(part.description, undefined);
   });
 
-  test('cssParts - with-summary-dash', ({element}) => {
+  test('cssParts - with-summary-dash', ({getModule}) => {
+    const element = getModule('element-a').getDeclaration('ElementA');
+    assert.ok(element.isLitElementDeclaration());
     const part = element.cssParts.get('with-summary-dash');
     assert.ok(part);
     assert.equal(part.summary, 'Summary for :part(with-summary-dash)');
     assert.equal(part.description, undefined);
   });
 
-  test('cssParts - with-summary-colon', ({element}) => {
+  test('cssParts - with-summary-colon', ({getModule}) => {
+    const element = getModule('element-a').getDeclaration('ElementA');
+    assert.ok(element.isLitElementDeclaration());
     const part = element.cssParts.get('with-summary-colon');
     assert.ok(part);
     assert.equal(part.summary, 'Summary for :part(with-summary-colon)');
     assert.equal(part.description, undefined);
   });
 
-  test('cssParts - with-description', ({element}) => {
+  test('cssParts - with-description', ({getModule}) => {
+    const element = getModule('element-a').getDeclaration('ElementA');
+    assert.ok(element.isLitElementDeclaration());
     const part = element.cssParts.get('with-description');
     assert.ok(part);
     assert.equal(part.summary, 'Summary for :part(with-description)');
@@ -140,39 +152,51 @@ for (const lang of languages) {
 
   // cssProperties
 
-  test('cssProperties - Correct number found', ({element}) => {
+  test('cssProperties - Correct number found', ({getModule}) => {
+    const element = getModule('element-a').getDeclaration('ElementA');
+    assert.ok(element.isLitElementDeclaration());
     assert.equal(element.cssProperties.size, 10);
   });
 
-  test('cssProperties - basic', ({element}) => {
+  test('cssProperties - basic', ({getModule}) => {
+    const element = getModule('element-a').getDeclaration('ElementA');
+    assert.ok(element.isLitElementDeclaration());
     const prop = element.cssProperties.get('--basic');
     assert.ok(prop);
     assert.equal(prop.summary, undefined);
     assert.equal(prop.description, undefined);
   });
 
-  test('cssProperties - with-summary', ({element}) => {
+  test('cssProperties - with-summary', ({getModule}) => {
+    const element = getModule('element-a').getDeclaration('ElementA');
+    assert.ok(element.isLitElementDeclaration());
     const prop = element.cssProperties.get('--with-summary');
     assert.ok(prop);
     assert.equal(prop.summary, 'Summary for --with-summary');
     assert.equal(prop.description, undefined);
   });
 
-  test('cssProperties - with-summary-colon', ({element}) => {
+  test('cssProperties - with-summary-colon', ({getModule}) => {
+    const element = getModule('element-a').getDeclaration('ElementA');
+    assert.ok(element.isLitElementDeclaration());
     const prop = element.cssProperties.get('--with-summary-colon');
     assert.ok(prop);
     assert.equal(prop.summary, 'Summary for --with-summary-colon');
     assert.equal(prop.description, undefined);
   });
 
-  test('cssProperties - with-summary-dash', ({element}) => {
+  test('cssProperties - with-summary-dash', ({getModule}) => {
+    const element = getModule('element-a').getDeclaration('ElementA');
+    assert.ok(element.isLitElementDeclaration());
     const prop = element.cssProperties.get('--with-summary-dash');
     assert.ok(prop);
     assert.equal(prop.summary, 'Summary for --with-summary-dash');
     assert.equal(prop.description, undefined);
   });
 
-  test('cssProperties - with-description', ({element}) => {
+  test('cssProperties - with-description', ({getModule}) => {
+    const element = getModule('element-a').getDeclaration('ElementA');
+    assert.ok(element.isLitElementDeclaration());
     const prop = element.cssProperties.get('--with-description');
     assert.ok(prop);
     assert.equal(prop.summary, 'Summary for --with-description');
@@ -182,35 +206,45 @@ for (const lang of languages) {
     );
   });
 
-  test('cssProperties - short-basic', ({element}) => {
+  test('cssProperties - short-basic', ({getModule}) => {
+    const element = getModule('element-a').getDeclaration('ElementA');
+    assert.ok(element.isLitElementDeclaration());
     const prop = element.cssProperties.get('--short-basic');
     assert.ok(prop);
     assert.equal(prop.summary, undefined);
     assert.equal(prop.description, undefined);
   });
 
-  test('cssProperties - short-with-summary', ({element}) => {
+  test('cssProperties - short-with-summary', ({getModule}) => {
+    const element = getModule('element-a').getDeclaration('ElementA');
+    assert.ok(element.isLitElementDeclaration());
     const prop = element.cssProperties.get('--short-with-summary');
     assert.ok(prop);
     assert.equal(prop.summary, 'Summary for --short-with-summary');
     assert.equal(prop.description, undefined);
   });
 
-  test('cssProperties - short-with-summary-colon', ({element}) => {
+  test('cssProperties - short-with-summary-colon', ({getModule}) => {
+    const element = getModule('element-a').getDeclaration('ElementA');
+    assert.ok(element.isLitElementDeclaration());
     const prop = element.cssProperties.get('--short-with-summary-colon');
     assert.ok(prop);
     assert.equal(prop.summary, 'Summary for --short-with-summary-colon');
     assert.equal(prop.description, undefined);
   });
 
-  test('cssProperties - short-with-summary-dash', ({element}) => {
+  test('cssProperties - short-with-summary-dash', ({getModule}) => {
+    const element = getModule('element-a').getDeclaration('ElementA');
+    assert.ok(element.isLitElementDeclaration());
     const prop = element.cssProperties.get('--short-with-summary-dash');
     assert.ok(prop);
     assert.equal(prop.summary, 'Summary for --short-with-summary-dash');
     assert.equal(prop.description, undefined);
   });
 
-  test('cssProperties - short-with-description', ({element}) => {
+  test('cssProperties - short-with-description', ({getModule}) => {
+    const element = getModule('element-a').getDeclaration('ElementA');
+    assert.ok(element.isLitElementDeclaration());
     const prop = element.cssProperties.get('--short-with-description');
     assert.ok(prop);
     assert.equal(prop.summary, 'Summary for --short-with-description');
@@ -218,6 +252,54 @@ for (const lang of languages) {
       prop.description,
       'Description for --short-with-description\nMore description for --short-with-description\n\nEven more description for --short-with-description'
     );
+  });
+
+  // description, summary, deprecated
+
+  test('tagged description and summary', ({getModule}) => {
+    const element = getModule('element-a').getDeclaration('TaggedDescription');
+    assert.ok(element.isLitElementDeclaration());
+    assert.equal(
+      element.description,
+      `TaggedDescription description. Lorem ipsum dolor sit amet, consectetur
+adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
+aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris
+nisi ut aliquip ex ea commodo consequat.`
+    );
+    assert.equal(element.summary, `TaggedDescription summary.`);
+    assert.equal(element.deprecated, `TaggedDescription deprecated message.`);
+  });
+
+  test('untagged description', ({getModule}) => {
+    const element = getModule('element-a').getDeclaration(
+      'UntaggedDescription'
+    );
+    assert.ok(element.isLitElementDeclaration());
+    assert.equal(
+      element.description,
+      `UntaggedDescription description. Lorem ipsum dolor sit amet, consectetur
+adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
+aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris
+nisi ut aliquip ex ea commodo consequat.`
+    );
+    assert.equal(element.summary, `UntaggedDescription summary.`);
+    assert.equal(element.deprecated, `UntaggedDescription deprecated message.`);
+  });
+
+  test('untagged description and summary', ({getModule}) => {
+    const element = getModule('element-a').getDeclaration(
+      'UntaggedDescSummary'
+    );
+    assert.ok(element.isLitElementDeclaration());
+    assert.equal(
+      element.description,
+      `UntaggedDescSummary description. Lorem ipsum dolor sit amet, consectetur
+adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
+aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris
+nisi ut aliquip ex ea commodo consequat.`
+    );
+    assert.equal(element.summary, `UntaggedDescSummary summary.`);
+    assert.equal(element.deprecated, true);
   });
 
   test.run();

--- a/packages/labs/analyzer/test-files/js/jsdoc/element-a.js
+++ b/packages/labs/analyzer/test-files/js/jsdoc/element-a.js
@@ -51,3 +51,36 @@ import {LitElement} from 'lit';
  */
 export class ElementA extends LitElement {}
 customElements.define('element-a', ElementA);
+
+/**
+ * @description TaggedDescription description. Lorem ipsum dolor sit amet, consectetur
+ * adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
+ * aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris
+ * nisi ut aliquip ex ea commodo consequat.
+ * @summary TaggedDescription summary.
+ * @deprecated TaggedDescription deprecated message.
+ */
+export class TaggedDescription extends LitElement {}
+
+/**
+ * UntaggedDescription description. Lorem ipsum dolor sit amet, consectetur
+ * adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
+ * aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris
+ * nisi ut aliquip ex ea commodo consequat.
+ *
+ * @deprecated UntaggedDescription deprecated message.
+ * @summary UntaggedDescription summary.
+ */
+export class UntaggedDescription extends LitElement {}
+
+/**
+ * UntaggedDescSummary summary.
+ *
+ * UntaggedDescSummary description. Lorem ipsum dolor sit amet, consectetur
+ * adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
+ * aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris
+ * nisi ut aliquip ex ea commodo consequat.
+ *
+ * @deprecated
+ */
+export class UntaggedDescSummary extends LitElement {}

--- a/packages/labs/analyzer/test-files/js/jsdoc/element-a.js
+++ b/packages/labs/analyzer/test-files/js/jsdoc/element-a.js
@@ -1,0 +1,53 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {LitElement} from 'lit';
+
+/**
+ * A cool custom element.
+ *
+ * @slot basic
+ * @slot with-summary Summary for with-summary
+ * @slot with-summary-dash - Summary for with-summary-dash
+ * @slot with-summary-colon: Summary for with-summary-colon
+ * @slot with-description - Summary for with-description
+ * Description for with-description
+ * More description for with-description
+ *
+ * Even more description for with-description
+ *
+ * @cssPart basic
+ * @cssPart with-summary Summary for :part(with-summary)
+ * @cssPart with-summary-dash - Summary for :part(with-summary-dash)
+ * @cssPart with-summary-colon: Summary for :part(with-summary-colon)
+ * @cssPart with-description - Summary for :part(with-description)
+ * Description for :part(with-description)
+ * More description for :part(with-description)
+ *
+ * Even more description for :part(with-description)
+ *
+ * @cssProperty --basic
+ * @cssProperty --with-summary Summary for --with-summary
+ * @cssProperty --with-summary-dash - Summary for --with-summary-dash
+ * @cssProperty --with-summary-colon: Summary for --with-summary-colon
+ * @cssProperty --with-description - Summary for --with-description
+ * Description for --with-description
+ * More description for --with-description
+ *
+ * Even more description for --with-description
+ *
+ * @cssProp --short-basic
+ * @cssProp --short-with-summary Summary for --short-with-summary
+ * @cssProp --short-with-summary-dash - Summary for --short-with-summary-dash
+ * @cssProp --short-with-summary-colon: Summary for --short-with-summary-colon
+ * @cssProp --short-with-description - Summary for --short-with-description
+ * Description for --short-with-description
+ * More description for --short-with-description
+ *
+ * Even more description for --short-with-description
+ */
+export class ElementA extends LitElement {}
+customElements.define('element-a', ElementA);

--- a/packages/labs/analyzer/test-files/js/jsdoc/package.json
+++ b/packages/labs/analyzer/test-files/js/jsdoc/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@lit-internal/test-jsdoc",
+  "dependencies": {
+    "lit": "^2.0.0"
+  }
+}

--- a/packages/labs/analyzer/test-files/ts/jsdoc/package.json
+++ b/packages/labs/analyzer/test-files/ts/jsdoc/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@lit-internal/test-jsdoc",
+  "dependencies": {
+    "lit": "^2.0.0"
+  }
+}

--- a/packages/labs/analyzer/test-files/ts/jsdoc/src/element-a.ts
+++ b/packages/labs/analyzer/test-files/ts/jsdoc/src/element-a.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {LitElement} from 'lit';
+import {customElement} from 'lit/decorators.js';
+
+/**
+ * A cool custom element.
+ *
+ * @slot basic
+ * @slot with-summary Summary for with-summary
+ * @slot with-summary-dash - Summary for with-summary-dash
+ * @slot with-summary-colon: Summary for with-summary-colon
+ * @slot with-description - Summary for with-description
+ * Description for with-description
+ * More description for with-description
+ *
+ * Even more description for with-description
+ *
+ * @cssPart basic
+ * @cssPart with-summary Summary for :part(with-summary)
+ * @cssPart with-summary-dash - Summary for :part(with-summary-dash)
+ * @cssPart with-summary-colon: Summary for :part(with-summary-colon)
+ * @cssPart with-description - Summary for :part(with-description)
+ * Description for :part(with-description)
+ * More description for :part(with-description)
+ *
+ * Even more description for :part(with-description)
+ *
+ * @cssProperty --basic
+ * @cssProperty --with-summary Summary for --with-summary
+ * @cssProperty --with-summary-dash - Summary for --with-summary-dash
+ * @cssProperty --with-summary-colon: Summary for --with-summary-colon
+ * @cssProperty --with-description - Summary for --with-description
+ * Description for --with-description
+ * More description for --with-description
+ *
+ * Even more description for --with-description
+ *
+ * @cssProp --short-basic
+ * @cssProp --short-with-summary Summary for --short-with-summary
+ * @cssProp --short-with-summary-dash - Summary for --short-with-summary-dash
+ * @cssProp --short-with-summary-colon: Summary for --short-with-summary-colon
+ * @cssProp --short-with-description - Summary for --short-with-description
+ * Description for --short-with-description
+ * More description for --short-with-description
+ *
+ * Even more description for --short-with-description
+ */
+@customElement('element-a')
+export class ElementA extends LitElement {}

--- a/packages/labs/analyzer/test-files/ts/jsdoc/src/element-a.ts
+++ b/packages/labs/analyzer/test-files/ts/jsdoc/src/element-a.ts
@@ -52,3 +52,36 @@ import {customElement} from 'lit/decorators.js';
  */
 @customElement('element-a')
 export class ElementA extends LitElement {}
+
+/**
+ * @description TaggedDescription description. Lorem ipsum dolor sit amet, consectetur
+ * adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
+ * aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris
+ * nisi ut aliquip ex ea commodo consequat.
+ * @summary TaggedDescription summary.
+ * @deprecated TaggedDescription deprecated message.
+ */
+export class TaggedDescription extends LitElement {}
+
+/**
+ * UntaggedDescription description. Lorem ipsum dolor sit amet, consectetur
+ * adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
+ * aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris
+ * nisi ut aliquip ex ea commodo consequat.
+ *
+ * @deprecated UntaggedDescription deprecated message.
+ * @summary UntaggedDescription summary.
+ */
+export class UntaggedDescription extends LitElement {}
+
+/**
+ * UntaggedDescSummary summary.
+ *
+ * UntaggedDescSummary description. Lorem ipsum dolor sit amet, consectetur
+ * adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
+ * aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris
+ * nisi ut aliquip ex ea commodo consequat.
+ *
+ * @deprecated
+ */
+export class UntaggedDescSummary extends LitElement {}

--- a/packages/labs/analyzer/test-files/ts/jsdoc/tsconfig.json
+++ b/packages/labs/analyzer/test-files/ts/jsdoc/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "lib": ["es2020", "DOM"],
+    "module": "ES2020",
+    "rootDir": "./src",
+    "outDir": "./",
+    "moduleResolution": "node",
+    "experimentalDecorators": true,
+    "skipDefaultLibCheck": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": []
+}

--- a/packages/labs/gen-manifest/goldens/test-element-a/custom-elements.json
+++ b/packages/labs/gen-manifest/goldens/test-element-a/custom-elements.json
@@ -19,8 +19,8 @@
         {
           "kind": "class",
           "name": "ElementA",
-          "summary": "TODO",
-          "description": "TODO",
+          "description": "This is a description of my element. It's pretty great. The description has\ntext that spans multiple lines.",
+          "summary": "My awesome element",
           "superclass": {"name": "LitElement", "package": "lit"},
           "mixins": [],
           "members": [],
@@ -179,8 +179,6 @@
         {
           "kind": "class",
           "name": "EventSubclass",
-          "summary": "TODO",
-          "description": "TODO",
           "superclass": {"name": "Event", "package": "global:"},
           "mixins": [],
           "members": [],
@@ -190,8 +188,7 @@
         {
           "kind": "class",
           "name": "ElementEvents",
-          "summary": "TODO",
-          "description": "TODO",
+          "description": "My awesome element",
           "superclass": {"name": "LitElement", "package": "lit"},
           "mixins": [],
           "members": [],
@@ -353,8 +350,7 @@
         {
           "kind": "class",
           "name": "ElementProps",
-          "summary": "TODO",
-          "description": "TODO",
+          "description": "My awesome element",
           "superclass": {"name": "LitElement", "package": "lit"},
           "mixins": [],
           "members": [],
@@ -393,8 +389,7 @@
         {
           "kind": "class",
           "name": "ElementSlots",
-          "summary": "TODO",
-          "description": "TODO",
+          "description": "My awesome element",
           "superclass": {"name": "LitElement", "package": "lit"},
           "mixins": [],
           "members": [],
@@ -433,8 +428,6 @@
         {
           "kind": "class",
           "name": "Bar",
-          "summary": "TODO",
-          "description": "TODO",
           "mixins": [],
           "members": [],
           "source": {"href": "TODO"},
@@ -443,8 +436,6 @@
         {
           "kind": "class",
           "name": "Foo",
-          "summary": "TODO",
-          "description": "TODO",
           "mixins": [],
           "members": [],
           "source": {"href": "TODO"},
@@ -466,8 +457,6 @@
         {
           "kind": "class",
           "name": "SpecialEvent",
-          "summary": "TODO",
-          "description": "TODO",
           "superclass": {"name": "Event", "package": "global:"},
           "mixins": [],
           "members": [],

--- a/packages/labs/gen-manifest/goldens/test-element-a/custom-elements.json
+++ b/packages/labs/gen-manifest/goldens/test-element-a/custom-elements.json
@@ -29,9 +29,18 @@
           "tagName": "element-a",
           "attributes": [],
           "events": [{"name": "a-changed", "type": {"text": "TODO"}}],
-          "slots": [],
-          "cssParts": [],
-          "cssProperties": [],
+          "slots": [
+            {"name": "default", "summary": "The default slot"},
+            {"name": "stuff", "summary": "A slot for stuff"}
+          ],
+          "cssParts": [
+            {"name": "header", "summary": "The header"},
+            {"name": "footer", "summary": "The footer"}
+          ],
+          "cssProperties": [
+            {"name": "--foreground-color", "summary": "The foreground color"},
+            {"name": "--background-color", "summary": "The background color"}
+          ],
           "demos": [],
           "customElement": true
         },

--- a/packages/labs/gen-manifest/goldens/test-element-a/custom-elements.json
+++ b/packages/labs/gen-manifest/goldens/test-element-a/custom-elements.json
@@ -3,6 +3,15 @@
   "modules": [
     {
       "kind": "javascript-module",
+      "path": "detail-type.js",
+      "summary": "TODO",
+      "description": "TODO",
+      "declarations": [],
+      "exports": [],
+      "deprecated": false
+    },
+    {
+      "kind": "javascript-module",
       "path": "element-a.js",
       "summary": "TODO",
       "description": "TODO",
@@ -99,7 +108,311 @@
           }
         }
       ],
-      "exports": [],
+      "exports": [
+        {"kind": "js", "name": "ElementA", "declaration": {"name": "ElementA"}},
+        {
+          "kind": "js",
+          "name": "localTypeVar",
+          "declaration": {"name": "localTypeVar"}
+        },
+        {
+          "kind": "js",
+          "name": "packageTypeVar",
+          "declaration": {"name": "packageTypeVar"}
+        },
+        {
+          "kind": "js",
+          "name": "externalTypeVar",
+          "declaration": {"name": "externalTypeVar"}
+        },
+        {
+          "kind": "js",
+          "name": "globalTypeVar",
+          "declaration": {"name": "globalTypeVar"}
+        },
+        {
+          "kind": "js",
+          "name": "Foo",
+          "declaration": {
+            "name": "Foo",
+            "package": "@lit-internal/test-element-a",
+            "module": "package-stuff.js"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "Baz",
+          "declaration": {
+            "name": "Bar",
+            "package": "@lit-internal/test-element-a",
+            "module": "package-stuff.js"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "local",
+          "declaration": {"name": "localTypeVar"}
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "element-a",
+          "declaration": {"name": "ElementA"}
+        }
+      ],
+      "deprecated": false
+    },
+    {
+      "kind": "javascript-module",
+      "path": "element-events.js",
+      "summary": "TODO",
+      "description": "TODO",
+      "declarations": [
+        {
+          "kind": "class",
+          "name": "EventSubclass",
+          "summary": "TODO",
+          "description": "TODO",
+          "superclass": {"name": "Event", "package": "global:"},
+          "mixins": [],
+          "members": [],
+          "source": {"href": "TODO"},
+          "deprecated": false
+        },
+        {
+          "kind": "class",
+          "name": "ElementEvents",
+          "summary": "TODO",
+          "description": "TODO",
+          "superclass": {"name": "LitElement", "package": "lit"},
+          "mixins": [],
+          "members": [],
+          "source": {"href": "TODO"},
+          "deprecated": false,
+          "tagName": "element-events",
+          "attributes": [],
+          "events": [
+            {
+              "name": "string-custom-event",
+              "type": {
+                "text": "CustomEvent<string>",
+                "references": [
+                  {
+                    "name": "CustomEvent",
+                    "package": "global:",
+                    "start": 0,
+                    "end": 11
+                  }
+                ]
+              }
+            },
+            {
+              "name": "number-custom-event",
+              "type": {
+                "text": "CustomEvent<number>",
+                "references": [
+                  {
+                    "name": "CustomEvent",
+                    "package": "global:",
+                    "start": 0,
+                    "end": 11
+                  }
+                ]
+              }
+            },
+            {
+              "name": "my-detail-custom-event",
+              "type": {
+                "text": "CustomEvent<MyDetail>",
+                "references": [
+                  {
+                    "name": "CustomEvent",
+                    "package": "global:",
+                    "start": 0,
+                    "end": 11
+                  },
+                  {
+                    "name": "MyDetail",
+                    "package": "@lit-internal/test-element-a",
+                    "module": "detail-type.js",
+                    "start": 12,
+                    "end": 20
+                  }
+                ]
+              }
+            },
+            {
+              "name": "event-subclass",
+              "type": {
+                "text": "EventSubclass",
+                "references": [
+                  {
+                    "name": "EventSubclass",
+                    "package": "@lit-internal/test-element-a",
+                    "module": "element-events.js",
+                    "start": 0,
+                    "end": 13
+                  }
+                ]
+              }
+            },
+            {
+              "name": "special-event",
+              "type": {
+                "text": "SpecialEvent",
+                "references": [
+                  {
+                    "name": "SpecialEvent",
+                    "package": "@lit-internal/test-element-a",
+                    "module": "special-event.js",
+                    "start": 0,
+                    "end": 12
+                  }
+                ]
+              }
+            },
+            {
+              "name": "template-result-custom-event",
+              "type": {
+                "text": "CustomEvent<TemplateResult>",
+                "references": [
+                  {
+                    "name": "CustomEvent",
+                    "package": "global:",
+                    "start": 0,
+                    "end": 11
+                  },
+                  {
+                    "name": "TemplateResult",
+                    "package": "lit",
+                    "start": 12,
+                    "end": 26
+                  }
+                ]
+              }
+            }
+          ],
+          "slots": [],
+          "cssParts": [],
+          "cssProperties": [],
+          "demos": [],
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "SpecialEvent",
+          "declaration": {
+            "name": "SpecialEvent",
+            "package": "@lit-internal/test-element-a",
+            "module": "special-event.js"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "MyDetail",
+          "declaration": {
+            "name": "MyDetail",
+            "package": "@lit-internal/test-element-a",
+            "module": "detail-type.js"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "EventSubclass",
+          "declaration": {"name": "EventSubclass"}
+        },
+        {
+          "kind": "js",
+          "name": "ElementEvents",
+          "declaration": {"name": "ElementEvents"}
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "element-events",
+          "declaration": {"name": "ElementEvents"}
+        }
+      ],
+      "deprecated": false
+    },
+    {
+      "kind": "javascript-module",
+      "path": "element-props.js",
+      "summary": "TODO",
+      "description": "TODO",
+      "declarations": [
+        {
+          "kind": "class",
+          "name": "ElementProps",
+          "summary": "TODO",
+          "description": "TODO",
+          "superclass": {"name": "LitElement", "package": "lit"},
+          "mixins": [],
+          "members": [],
+          "source": {"href": "TODO"},
+          "deprecated": false,
+          "tagName": "element-props",
+          "attributes": [],
+          "events": [{"name": "a-changed", "type": {"text": "TODO"}}],
+          "slots": [],
+          "cssParts": [],
+          "cssProperties": [],
+          "demos": [],
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "ElementProps",
+          "declaration": {"name": "ElementProps"}
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "element-props",
+          "declaration": {"name": "ElementProps"}
+        }
+      ],
+      "deprecated": false
+    },
+    {
+      "kind": "javascript-module",
+      "path": "element-slots.js",
+      "summary": "TODO",
+      "description": "TODO",
+      "declarations": [
+        {
+          "kind": "class",
+          "name": "ElementSlots",
+          "summary": "TODO",
+          "description": "TODO",
+          "superclass": {"name": "LitElement", "package": "lit"},
+          "mixins": [],
+          "members": [],
+          "source": {"href": "TODO"},
+          "deprecated": false,
+          "tagName": "element-slots",
+          "attributes": [],
+          "events": [],
+          "slots": [],
+          "cssParts": [],
+          "cssProperties": [],
+          "demos": [],
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "ElementSlots",
+          "declaration": {"name": "ElementSlots"}
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "element-slots",
+          "declaration": {"name": "ElementSlots"}
+        }
+      ],
       "deprecated": false
     },
     {
@@ -129,7 +442,37 @@
           "deprecated": false
         }
       ],
-      "exports": [],
+      "exports": [
+        {"kind": "js", "name": "Bar", "declaration": {"name": "Bar"}},
+        {"kind": "js", "name": "Foo", "declaration": {"name": "Foo"}}
+      ],
+      "deprecated": false
+    },
+    {
+      "kind": "javascript-module",
+      "path": "special-event.js",
+      "summary": "TODO",
+      "description": "TODO",
+      "declarations": [
+        {
+          "kind": "class",
+          "name": "SpecialEvent",
+          "summary": "TODO",
+          "description": "TODO",
+          "superclass": {"name": "Event", "package": "global:"},
+          "mixins": [],
+          "members": [],
+          "source": {"href": "TODO"},
+          "deprecated": false
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "SpecialEvent",
+          "declaration": {"name": "SpecialEvent"}
+        }
+      ],
       "deprecated": false
     }
   ]

--- a/packages/labs/gen-manifest/package.json
+++ b/packages/labs/gen-manifest/package.json
@@ -39,10 +39,11 @@
         "build"
       ],
       "files": [
-        "goldens/**/*"
+        "goldens/**/*",
+        "../test-projects/test-element-a"
       ],
       "#comment": "The quotes around the file regex must be double quotes on windows!",
-      "command": "uvu test \"_test\\.js$\"",
+      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu test \"_test\\.js$\"",
       "output": []
     }
   },

--- a/packages/labs/gen-manifest/src/index.ts
+++ b/packages/labs/gen-manifest/src/index.ts
@@ -19,6 +19,14 @@ import {
 import {FileTree} from '@lit-labs/gen-utils/lib/file-utils.js';
 import type * as cem from 'custom-elements-manifest/schema';
 
+const ifDefined = <O, K extends keyof O>(model: O, name: K) => {
+  const obj: Partial<Pick<O, K>> = {};
+  if (model[name] !== undefined) {
+    obj[name] = model[name];
+  }
+  return obj;
+};
+
 /**
  * Our command for the Lit CLI.
  *
@@ -134,8 +142,8 @@ const convertClassDeclaration = (
   return {
     kind: 'class',
     name: declaration.name!, // TODO(kschaaf) name isn't optional in CEM
-    summary: 'TODO', // TODO
-    description: 'TODO', // TODO
+    ...ifDefined(declaration, 'description'),
+    ...ifDefined(declaration, 'summary'),
     superclass: superClass ? convertReference(superClass) : undefined,
     mixins: [], // TODO
     members: [

--- a/packages/labs/gen-manifest/src/index.ts
+++ b/packages/labs/gen-manifest/src/index.ts
@@ -116,16 +116,10 @@ const convertLitElementDeclaration = (
     attributes: [
       // TODO
     ],
-    events: [...Array.from(declaration.events.values()).map(convertEvent)],
-    slots: [
-      // TODO
-    ],
-    cssParts: [
-      // TODO
-    ],
-    cssProperties: [
-      // TODO
-    ],
+    events: Array.from(declaration.events.values()).map(convertEvent),
+    slots: Array.from(declaration.slots.values()),
+    cssParts: Array.from(declaration.cssParts.values()),
+    cssProperties: Array.from(declaration.cssProperties.values()),
     demos: [
       // TODO
     ],

--- a/packages/labs/gen-manifest/src/index.ts
+++ b/packages/labs/gen-manifest/src/index.ts
@@ -14,6 +14,7 @@ import {
   Reference,
   Type,
   VariableDeclaration,
+  LitElementExport,
 } from '@lit-labs/analyzer';
 import {FileTree} from '@lit-labs/gen-utils/lib/file-utils.js';
 import type * as cem from 'custom-elements-manifest/schema';
@@ -57,7 +58,10 @@ const convertModule = (module: Module): cem.Module => {
     description: 'TODO', // TODO
     declarations: [...module.declarations.map(convertDeclaration)],
     exports: [
-      // TODO
+      ...module.exportNames.map((name) =>
+        convertJavascriptExport(name, module.getExportReference(name))
+      ),
+      ...module.getCustomElementExports().map(convertCustomElementExport),
     ],
     deprecated: false, // TODO
   };
@@ -78,6 +82,29 @@ const convertDeclaration = (declaration: Declaration): cem.Declaration => {
       `Unknown declaration: ${(declaration as Object).constructor.name}`
     );
   }
+};
+
+const convertJavascriptExport = (
+  name: string,
+  reference: Reference
+): cem.JavaScriptExport => {
+  return {
+    kind: 'js',
+    name,
+    declaration: convertReference(reference),
+  };
+};
+
+const convertCustomElementExport = (
+  declaration: LitElementExport
+): cem.CustomElementExport => {
+  return {
+    kind: 'custom-element-definition',
+    name: declaration.tagname,
+    declaration: {
+      name: declaration.name,
+    },
+  };
 };
 
 const convertLitElementDeclaration = (

--- a/packages/labs/test-projects/test-element-a/src/element-a.ts
+++ b/packages/labs/test-projects/test-element-a/src/element-a.ts
@@ -11,12 +11,20 @@ import {Foo, Bar as Baz} from './package-stuff.js';
 /**
  * My awesome element
  * @fires a-changed - An awesome event to fire
+ * @slot default - The default slot
+ * @slot stuff - A slot for stuff
+ * @cssProperty --foreground-color: The foreground color
+ * @cssProp --background-color The background color
+ * @cssPart header The header
+ * @cssPart footer - The footer
  */
 @customElement('element-a')
 export class ElementA extends LitElement {
   static override styles = css`
     :host {
       display: block;
+      background-color: var(--background-color);
+      color: var(-foreground-color);
     }
   `;
 
@@ -24,7 +32,12 @@ export class ElementA extends LitElement {
   foo?: string;
 
   override render() {
-    return html`<h1>${this.foo}</h1>`;
+    return html`
+      <h1 part="header">${this.foo}</h1>
+      <slot></slot>
+      <slot name="stuff"></slot>
+      <footer part="footer">Footer</footer>
+    `;
   }
 }
 

--- a/packages/labs/test-projects/test-element-a/src/element-a.ts
+++ b/packages/labs/test-projects/test-element-a/src/element-a.ts
@@ -10,6 +10,10 @@ import {Foo, Bar as Baz} from './package-stuff.js';
 
 /**
  * My awesome element
+ *
+ * This is a description of my element. It's pretty great. The description has
+ * text that spans multiple lines.
+ *
  * @fires a-changed - An awesome event to fire
  * @slot default - The default slot
  * @slot stuff - A slot for stuff

--- a/packages/labs/test-projects/test-element-a/src/element-a.ts
+++ b/packages/labs/test-projects/test-element-a/src/element-a.ts
@@ -32,3 +32,5 @@ export let localTypeVar: ElementA;
 export let packageTypeVar: Foo<Baz>;
 export let externalTypeVar: LitElement;
 export let globalTypeVar: HTMLElement;
+
+export {Foo, Baz, localTypeVar as local};


### PR DESCRIPTION
* **Adds `exports` to manifest generator** - [5d7d3b4](https://github.com/lit/lit/pull/3464/commits/5d7d3b433b2457532e721e2b50494d6cbc67ab56) - Also fixes a few bugs in analyzer logic around symbol renaming on the import side and export side, and adds tests for all of that which was woefully missing.

* **Add `@slot`, `@cssProp`, and `@cssPart` to manifest generator** - b5c3f5a

* **Fix config to make JS program analysis faster.** - dbe8189 - JS program analysis (specifically the call to `getSemanticDiagnostics()` that we do to make sure the program isn't broken before analyzing the AST) was suuuuper slow, as a result of the `allowJs` setting causing TypeScript to automatically include every `.d.ts` file under `node_modules/@types`, which doesn't happen when `allowJs` is false. Seems unlikely a JS project will install types like this, so for now setting `typeRoots: []`, which dramatically speeds up analysis.

* **Add support for parsing description, summary, & deprecated** - d5f49ca

Addresses parts of #2993