### PR TITLE
add router general page navigation

### DIFF
--- a/packages/labs/router/src/test/router_test.ts
+++ b/packages/labs/router/src/test/router_test.ts
@@ -70,6 +70,13 @@ const canTest =
       '#test1'
     ) as HTMLAnchorElement;
     test1Link.click();
+    await new Promise<void>((res) => {
+      const listener = () => {
+        contentWindow!.removeEventListener('popstate', listener);
+        res();
+      };
+      contentWindow!.addEventListener('popstate', listener);
+    });
     await el.updateComplete;
     assert.include(
       stripExpressionComments(el.shadowRoot!.innerHTML),
@@ -124,6 +131,13 @@ const canTest =
     ) as HTMLAnchorElement;
     child1Link.click();
     await child1.updateComplete;
+    await new Promise<void>((res) => {
+      const listener = () => {
+        contentWindow!.removeEventListener('popstate', listener);
+        res();
+      };
+      contentWindow!.addEventListener('popstate', listener);
+    });
     assert.include(
       stripExpressionComments(child1.shadowRoot!.innerHTML),
       '<h3>Child 1: abc</h3>'
@@ -136,6 +150,13 @@ const canTest =
       '#child2'
     ) as HTMLAnchorElement;
     child2Link.click();
+    await new Promise<void>((res) => {
+      const listener = () => {
+        contentWindow!.removeEventListener('popstate', listener);
+        res();
+      };
+      contentWindow!.addEventListener('popstate', listener);
+    });
     await el.updateComplete;
     const child2 = el.shadowRoot!.querySelector('child-2') as Child2;
     await child2.updateComplete;

--- a/packages/labs/router/src/test/router_test_code.ts
+++ b/packages/labs/router/src/test/router_test_code.ts
@@ -6,7 +6,7 @@
 
 import {LitElement, html} from 'lit';
 import {customElement} from 'lit/decorators.js';
-import {Router} from '@lit-labs/router/router.js';
+import {Router, onLinkClick} from '@lit-labs/router/router.js';
 import {Routes} from '@lit-labs/router/routes.js';
 
 @customElement('router-test-1')
@@ -60,9 +60,9 @@ export class Test1 extends LitElement {
   override render() {
     return html`
       <h1>Test</h1>
-      <a id="test1" href="/test1/abc">Test 1</a>
-      <a id="child1" href="/child1/abc">Child 1</a>
-      <a id="child2" href="/child2/xyz">Child 2</a>
+      <a id="test1" href="/test1/abc" @click=${onLinkClick}>Test 1</a>
+      <a id="child1" href="/child1/abc" @click=${onLinkClick}>Child 1</a>
+      <a id="child2" href="/child2/xyz" @click=${onLinkClick}>Child 2</a>
       ${this._router.outlet()}
     `;
   }
@@ -76,7 +76,9 @@ export class Child1 extends LitElement {
 
   override render() {
     return html`
-      <a id="abc" href="${this._routes.link('abc')}">ABC</a>
+      <a id="abc" href="${this._routes.link('abc')}" @click=${onLinkClick}
+        >ABC</a
+      >
       ${this._routes.outlet()}
     `;
   }


### PR DESCRIPTION
all forward navigation are now handled on the popstate event, exactly as the backward ones.
when a controlled link is clicked it creates two history entries with the same url, so we go back to the second-last to fire the popstate event.