### PR TITLE
docs: Use backticks to escape tags

### DIFF
--- a/packages/reactive-element/src/reactive-element.ts
+++ b/packages/reactive-element/src/reactive-element.ts
@@ -568,10 +568,10 @@ export abstract class ReactiveElement
    * Element styles are implemented with `<style>` tags when the browser doesn't
    * support adopted StyleSheets. To use such `<style>` tags with the style-src
    * CSP directive, the style-src value must either include 'unsafe-inline' or
-   * 'nonce-<base64-value>' with <base64-value> replaced be a server-generated
+   * `nonce-<base64-value>` with `<base64-value>` replaced be a server-generated
    * nonce.
    *
-   * To provide a nonce to use on generated <style> elements, set
+   * To provide a nonce to use on generated `<style>` elements, set
    * `window.litNonce` to a server-generated nonce in your page's HTML, before
    * loading application code:
    *


### PR DESCRIPTION
For downstream friendliness 😊 

I'm documenting a lit project using docusaurus and [docusaurus-plugin-typedoc](https://www.npmjs.com/package/docusaurus-plugin-typedoc).

Unescaped tags in markdown can cause issues with the parsing of the markdown:

<details>

<summary>Error with LitElement</summary>

```console
SyntaxError: site/docs/api/classes/OEmbedElement.md: Expected corresponding JSX closing tag for <base64-value>. (2022:8)
  2020 | CSP directive, the style-src value must either include 'unsafe-inline' or
  2021 | 'nonce-`}<base64-value>{`' with `}<base64-value>{` replaced be a server-generated
> 2022 | nonce.`}</p>
       |         ^
  2023 | <p>{`To provide a nonce to use on generated `}<style>{` elements, set
  2024 | `}<inlineCode parentName="p">{`window.litNonce`}</inlineCode>{` to a server-generated nonce in your page's HTML, before
  2025 | loading application code:`}</p>
SyntaxError: site/docs/api/index.md: Expected corresponding JSX closing tag for <MDXLayout>. (68:165)
  66 | <h3 {...{"id":"static-site"}}>{`Static Site`}</h3>
  67 | <p>{`This project includes a simple website generated with the `}<a parentName="p" {...{"href":"11ty.dev"}}>{`eleventy`}</a>{` static site generator and the templates and pages in `}<inlineCode parentName="p">{`/docs-src`}</inlineCode>{`. The site is generated to `}<inlineCode parentName="p">{`/docs`}</inlineCode>{` and intended to be checked in so that GitHub pages can serve the site `}<a parentName="p" {...{"href":"https://help.github.com/en/github/working-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site"}}>{`from `}<inlineCode parentName="a">{`/docs`}</inlineCode>{` on the master branch`}</a>{`.`}</p>
> 68 | <p>{`To enable the site go to the GitHub settings and change the GitHub Pages `}{`"`}{`Source`}{`"`}{` setting to `}{`"`}{`master branch /docs folder`}{`"`}{`.`}</p></p>
     |                                                                                                                                                                      ^
  69 | <p>{`To build the site, run:`}</p>
  70 | <pre><code parentName="pre" {...{"className":"language-bash"}}>{`npm run docs
  71 | `}</code></pre>
client (webpack 5.75.0) compiled with 2 errors
```

</details>

Similar PR: https://github.com/Chevrotain/chevrotain/pull/1726
Background: https://github.com/tgreyuk/typedoc-plugin-markdown/issues/276