### PR TITLE
[labs/ssr] Render DSD attributes based on `shadowRootOptions`.

### DIFF
--- a/.changeset/early-eggs-doubt.md
+++ b/.changeset/early-eggs-doubt.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/ssr': minor
+---
+
+`ReactiveElement`'s `shadowRootOptions` are now used to configure declarative shadow roots' properties.

--- a/packages/labs/ssr/src/lib/element-renderer.ts
+++ b/packages/labs/ssr/src/lib/element-renderer.ts
@@ -117,6 +117,14 @@ export abstract class ElementRenderer {
   }
 
   /**
+   * Override this getter to configure the element's shadow root, if one is
+   * created with `renderShadow`.
+   */
+  get shadowRootOptions(): ShadowRootInit {
+    return {mode: 'open'};
+  }
+
+  /**
    * Render a single element's ShadowRoot children.
    */
   abstract renderShadow(

--- a/packages/labs/ssr/src/lib/element-renderer.ts
+++ b/packages/labs/ssr/src/lib/element-renderer.ts
@@ -41,6 +41,11 @@ export const getElementRenderer = (
   return new FallbackRenderer(tagName);
 };
 
+export interface ShadowRootOptions {
+  mode: 'open' | 'closed';
+  delegatesFocus?: boolean;
+}
+
 /**
  * An object that renders elements of a certain type.
  */
@@ -120,7 +125,7 @@ export abstract class ElementRenderer {
    * Override this getter to configure the element's shadow root, if one is
    * created with `renderShadow`.
    */
-  get shadowRootOptions(): ShadowRootInit {
+  get shadowRootOptions(): ShadowRootOptions {
     return {mode: 'open'};
   }
 

--- a/packages/labs/ssr/src/lib/lit-element-renderer.ts
+++ b/packages/labs/ssr/src/lib/lit-element-renderer.ts
@@ -29,6 +29,13 @@ export class LitElementRenderer extends ElementRenderer {
     this.element = new (customElements.get(this.tagName)!)() as LitElement;
   }
 
+  override get shadowRootOptions() {
+    return (
+      (this.element.constructor as typeof LitElement).shadowRootOptions ??
+      super.shadowRootOptions
+    );
+  }
+
   connectedCallback() {
     // Call LitElement's `willUpdate` method.
     // Note, this method is required not to use DOM APIs.

--- a/packages/labs/ssr/src/lib/render-lit-html.ts
+++ b/packages/labs/ssr/src/lib/render-lit-html.ts
@@ -753,7 +753,19 @@ function* renderTemplateResult(
           // Only emit a DSR if renderShadow() emitted something (returning
           // undefined allows effectively no-op rendering the element)
           if (shadowContents !== undefined) {
-            yield '<template shadowroot="open">';
+            yield '<template';
+            const shadowRootOptions = instance.shadowRootOptions;
+            if (shadowRootOptions) {
+              yield ` shadowroot="${escapeHtml(
+                String(shadowRootOptions.mode)
+              )}"`;
+              if (shadowRootOptions.delegatesFocus) {
+                yield ' shadowrootdelegatesfocus';
+              }
+            } else {
+              yield ' shadowroot="open"';
+            }
+            yield '>';
             yield* shadowContents;
             yield '</template>';
           }

--- a/packages/labs/ssr/src/lib/render-lit-html.ts
+++ b/packages/labs/ssr/src/lib/render-lit-html.ts
@@ -753,7 +753,8 @@ function* renderTemplateResult(
           // Only emit a DSR if renderShadow() emitted something (returning
           // undefined allows effectively no-op rendering the element)
           if (shadowContents !== undefined) {
-            const {mode, delegatesFocus} = instance.shadowRootOptions;
+            const {mode = 'open', delegatesFocus} =
+              instance.shadowRootOptions ?? {};
             // `delegatesFocus` is intentionally allowed to coerce to boolean to
             // match web platform behavior.
             const delegatesfocusAttr = delegatesFocus

--- a/packages/labs/ssr/src/lib/render-lit-html.ts
+++ b/packages/labs/ssr/src/lib/render-lit-html.ts
@@ -754,6 +754,8 @@ function* renderTemplateResult(
           // undefined allows effectively no-op rendering the element)
           if (shadowContents !== undefined) {
             const {mode, delegatesFocus} = instance.shadowRootOptions;
+            // `delegatesFocus` is intentionally allowed to coerce to boolean to
+            // match web platform behavior.
             const delegatesfocusAttr = delegatesFocus
               ? ' shadowrootdelegatesfocus'
               : '';

--- a/packages/labs/ssr/src/lib/render-lit-html.ts
+++ b/packages/labs/ssr/src/lib/render-lit-html.ts
@@ -753,19 +753,11 @@ function* renderTemplateResult(
           // Only emit a DSR if renderShadow() emitted something (returning
           // undefined allows effectively no-op rendering the element)
           if (shadowContents !== undefined) {
-            yield '<template';
-            const shadowRootOptions = instance.shadowRootOptions;
-            if (shadowRootOptions) {
-              yield ` shadowroot="${escapeHtml(
-                String(shadowRootOptions.mode)
-              )}"`;
-              if (shadowRootOptions.delegatesFocus) {
-                yield ' shadowrootdelegatesfocus';
-              }
-            } else {
-              yield ' shadowroot="open"';
-            }
-            yield '>';
+            const {mode, delegatesFocus} = instance.shadowRootOptions;
+            const delegatesfocusAttr = delegatesFocus
+              ? ' shadowrootdelegatesfocus'
+              : '';
+            yield `<template shadowroot="${mode}"${delegatesfocusAttr}>`;
             yield* shadowContents;
             yield '</template>';
           }

--- a/packages/labs/ssr/src/test/lib/render-lit_test.ts
+++ b/packages/labs/ssr/src/test/lib/render-lit_test.ts
@@ -338,6 +338,33 @@ test('no slot', async () => {
   );
 });
 
+test('shadowroot="open"', async () => {
+  const {render, shadowrootOpen} = await setup();
+  const result = await render(shadowrootOpen);
+  assert.is(
+    result,
+    `<!--lit-part eTOxy3auvsY=--><test-shadowroot-open><template shadowroot="open"><!--lit-part--><!--/lit-part--></template></test-shadowroot-open><!--/lit-part-->`
+  );
+});
+
+test('shadowroot="closed"', async () => {
+  const {render, shadowrootClosed} = await setup();
+  const result = await render(shadowrootClosed);
+  assert.is(
+    result,
+    `<!--lit-part 35tY6VC7KzI=--><test-shadowroot-closed><template shadowroot="closed"><!--lit-part--><!--/lit-part--></template></test-shadowroot-closed><!--/lit-part-->`
+  );
+});
+
+test('shadowrootdelegatesfocus', async () => {
+  const {render, shadowrootdelegatesfocus} = await setup();
+  const result = await render(shadowrootdelegatesfocus);
+  assert.is(
+    result,
+    `<!--lit-part Nim07tlWyJ0=--><test-shadowrootdelegatesfocus><template shadowroot="open" shadowrootdelegatesfocus><!--lit-part--><!--/lit-part--></template></test-shadowrootdelegatesfocus><!--/lit-part-->`
+  );
+});
+
 /* Directives */
 
 test('repeat directive with a template result', async () => {

--- a/packages/labs/ssr/src/test/test-files/render-test-module.ts
+++ b/packages/labs/ssr/src/test/test-files/render-test-module.ts
@@ -234,3 +234,33 @@ export const nestedTemplateResult = html`<div></div>`;
 export const trickyNestedDynamicChildren = html`<test-simple-slot
   >${html`${nestedTemplateResult}${nestedTemplateResult}`}</test-simple-slot
 >`;
+
+@customElement('test-shadowroot-open')
+export class TestShadowrootOpen extends LitElement {
+  static override shadowRootOptions = {
+    ...LitElement.shadowRootOptions,
+    mode: 'open' as const,
+  };
+}
+
+export const shadowrootOpen = html`<test-shadowroot-open></test-shadowroot-open>`;
+
+@customElement('test-shadowroot-closed')
+export class TestShadowrootClosed extends LitElement {
+  static override shadowRootOptions = {
+    ...LitElement.shadowRootOptions,
+    mode: 'closed' as const,
+  };
+}
+
+export const shadowrootClosed = html`<test-shadowroot-closed></test-shadowroot-closed>`;
+
+@customElement('test-shadowrootdelegatesfocus')
+export class TestShadowrootdelegatesfocus extends LitElement {
+  static override shadowRootOptions = {
+    ...LitElement.shadowRootOptions,
+    delegatesFocus: true,
+  };
+}
+
+export const shadowrootdelegatesfocus = html`<test-shadowrootdelegatesfocus></test-shadowrootdelegatesfocus>`;


### PR DESCRIPTION
This PR adds a `shadowRootOptions` getter to `ElementRenderer` and uses it to configure the declarative shadow root attributes when `renderShadow` is defined. Only `mode` and `delegatesFocus` seem to have some amount of agreement around an attribute name at the moment, so `slotAssignment` isn't implemented.

Maybe `shadowRootOptions` on `ElementRenderer` should be renamed to `shadowRootInit` since `ElementRenderer` isn't meant to be specific to Lit?

- [x] Condense new `yield`s into a single `yield` since they can all be computed synchronously.

Fixes #3483.