### PR TITLE
[labs/virtualizer] Add `/events.js.map` to `.gitignore`.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -315,6 +315,7 @@ packages/labs/virtualizer/test/**/*.js.map
 packages/labs/virtualizer/test/screenshot/cases/*/actual.*.png
 packages/labs/virtualizer/events.d.ts*
 packages/labs/virtualizer/events.js
+packages/labs/virtualizer/events.js.map
 
 packages/labs/vue-utils/development/
 packages/labs/vue-utils/test/

--- a/.prettierignore
+++ b/.prettierignore
@@ -299,6 +299,7 @@ packages/labs/virtualizer/test/**/*.js.map
 packages/labs/virtualizer/test/screenshot/cases/*/actual.*.png
 packages/labs/virtualizer/events.d.ts*
 packages/labs/virtualizer/events.js
+packages/labs/virtualizer/events.js.map
 
 packages/labs/vue-utils/development/
 packages/labs/vue-utils/test/

--- a/packages/labs/virtualizer/.gitignore
+++ b/packages/labs/virtualizer/.gitignore
@@ -24,3 +24,4 @@
 /test/screenshot/cases/*/actual.*.png
 /events.d.ts*
 /events.js
+/events.js.map


### PR DESCRIPTION
This file popped up in the untracked list after building recently.