### PR TITLE
[labs/virtualizer] Accept assigned slots as parent elements

### DIFF
--- a/packages/labs/virtualizer/src/Virtualizer.ts
+++ b/packages/labs/virtualizer/src/Virtualizer.ts
@@ -872,6 +872,9 @@ function getMarginValue(value: string): number {
 
 // TODO (graynorton): Deal with iframes?
 function getParentElement(el: Element) {
+  if (el.assignedSlot !== null) {
+    return el.assignedSlot;
+  }
   if (el.parentElement !== null) {
     return el.parentElement;
   }


### PR DESCRIPTION
Adds `assignedSlot` to the `getParentElement` workflow to ensure that shadow root content that has scrolling parents are included in the listening process.

fixes #3493 