### PR TITLE
[lit-html, reactive-element] Add development node builds

### DIFF
--- a/.changeset/light-dryers-talk.md
+++ b/.changeset/light-dryers-talk.md
@@ -1,0 +1,7 @@
+---
+'lit-html': minor
+'@lit/reactive-element': minor
+'lit': patch
+---
+
+`lit-html` and `reactive-element` now include development Node builds with unminified code and dev warnings.

--- a/packages/lit-html/package.json
+++ b/packages/lit-html/package.json
@@ -15,175 +15,262 @@
   "exports": {
     ".": {
       "types": "./development/lit-html.d.ts",
-      "node": "./node/lit-html.js",
+      "node": {
+        "development": "./node/development/lit-html.js",
+        "default": "./node/lit-html.js"
+      },
       "development": "./development/lit-html.js",
       "default": "./lit-html.js"
     },
     "./async-directive.js": {
       "types": "./development/async-directive.d.ts",
-      "node": "./node/async-directive.js",
+      "node": {
+        "development": "./node/development/async-directive.js",
+        "default": "./node/async-directive.js"
+      },
       "development": "./development/async-directive.js",
       "default": "./async-directive.js"
     },
     "./directive-helpers.js": {
       "types": "./development/directive-helpers.d.ts",
-      "node": "./node/directive-helpers.js",
+      "node": {
+        "development": "./node/development/directive-helpers.js",
+        "default": "./node/directive-helpers.js"
+      },
       "development": "./development/directive-helpers.js",
       "default": "./directive-helpers.js"
     },
     "./directive.js": {
       "types": "./development/directive.d.ts",
-      "node": "./node/directive.js",
+      "node": {
+        "development": "./node/development/directive.js",
+        "default": "./node/directive.js"
+      },
       "development": "./development/directive.js",
       "default": "./directive.js"
     },
     "./directives/async-append.js": {
       "types": "./development/directives/async-append.d.ts",
-      "node": "./node/directives/async-append.js",
+      "node": {
+        "development": "./node/development/directives/async-append.js",
+        "default": "./node/directives/async-append.js"
+      },
       "development": "./development/directives/async-append.js",
       "default": "./directives/async-append.js"
     },
     "./directives/async-replace.js": {
       "types": "./development/directives/async-replace.d.ts",
-      "node": "./node/directives/async-replace.js",
+      "node": {
+        "development": "./node/development/directives/async-replace.js",
+        "default": "./node/directives/async-replace.js"
+      },
       "development": "./development/directives/async-replace.js",
       "default": "./directives/async-replace.js"
     },
     "./directives/cache.js": {
       "types": "./development/directives/cache.d.ts",
-      "node": "./node/directives/cache.js",
+      "node": {
+        "development": "./node/development/directives/cache.js",
+        "default": "./node/directives/cache.js"
+      },
       "development": "./development/directives/cache.js",
       "default": "./directives/cache.js"
     },
     "./directives/choose.js": {
       "types": "./development/directives/choose.d.ts",
-      "node": "./node/directives/choose.js",
+      "node": {
+        "development": "./node/development/directives/choose.js",
+        "default": "./node/directives/choose.js"
+      },
       "development": "./development/directives/choose.js",
       "default": "./directives/choose.js"
     },
     "./directives/class-map.js": {
       "types": "./development/directives/class-map.d.ts",
-      "node": "./node/directives/class-map.js",
+      "node": {
+        "development": "./node/development/directives/class-map.js",
+        "default": "./node/directives/class-map.js"
+      },
       "development": "./development/directives/class-map.js",
       "default": "./directives/class-map.js"
     },
     "./directives/guard.js": {
       "types": "./development/directives/guard.d.ts",
-      "node": "./node/directives/guard.js",
+      "node": {
+        "development": "./node/development/directives/guard.js",
+        "default": "./node/directives/guard.js"
+      },
       "development": "./development/directives/guard.js",
       "default": "./directives/guard.js"
     },
     "./directives/if-defined.js": {
       "types": "./development/directives/if-defined.d.ts",
-      "node": "./node/directives/if-defined.js",
+      "node": {
+        "development": "./node/development/directives/if-defined.js",
+        "default": "./node/directives/if-defined.js"
+      },
       "development": "./development/directives/if-defined.js",
       "default": "./directives/if-defined.js"
     },
     "./directives/join.js": {
       "types": "./development/directives/join.d.ts",
-      "node": "./node/directives/join.js",
+      "node": {
+        "development": "./node/development/directives/join.js",
+        "default": "./node/directives/join.js"
+      },
       "development": "./development/directives/join.js",
       "default": "./directives/join.js"
     },
     "./directives/keyed.js": {
       "types": "./development/directives/keyed.d.ts",
-      "node": "./node/directives/keyed.js",
+      "node": {
+        "development": "./node/development/directives/keyed.js",
+        "default": "./node/directives/keyed.js"
+      },
       "development": "./development/directives/keyed.js",
       "default": "./directives/keyed.js"
     },
     "./directives/live.js": {
       "types": "./development/directives/live.d.ts",
-      "node": "./node/directives/live.js",
+      "node": {
+        "development": "./node/development/directives/live.js",
+        "default": "./node/directives/live.js"
+      },
       "development": "./development/directives/live.js",
       "default": "./directives/live.js"
     },
     "./directives/map.js": {
       "types": "./development/directives/map.d.ts",
-      "node": "./node/directives/map.js",
+      "node": {
+        "development": "./node/development/directives/map.js",
+        "default": "./node/directives/map.js"
+      },
       "development": "./development/directives/map.js",
       "default": "./directives/map.js"
     },
     "./directives/range.js": {
       "types": "./development/directives/range.d.ts",
-      "node": "./node/directives/range.js",
+      "node": {
+        "development": "./node/development/directives/range.js",
+        "default": "./node/directives/range.js"
+      },
       "development": "./development/directives/range.js",
       "default": "./directives/range.js"
     },
     "./directives/ref.js": {
       "types": "./development/directives/ref.d.ts",
-      "node": "./node/directives/ref.js",
+      "node": {
+        "development": "./node/development/directives/ref.js",
+        "default": "./node/directives/ref.js"
+      },
       "development": "./development/directives/ref.js",
       "default": "./directives/ref.js"
     },
     "./directives/repeat.js": {
       "types": "./development/directives/repeat.d.ts",
-      "node": "./node/directives/repeat.js",
+      "node": {
+        "development": "./node/development/directives/repeat.js",
+        "default": "./node/directives/repeat.js"
+      },
       "development": "./development/directives/repeat.js",
       "default": "./directives/repeat.js"
     },
     "./directives/style-map.js": {
       "types": "./development/directives/style-map.d.ts",
-      "node": "./node/directives/style-map.js",
+      "node": {
+        "development": "./node/development/directives/style-map.js",
+        "default": "./node/directives/style-map.js"
+      },
       "development": "./development/directives/style-map.js",
       "default": "./directives/style-map.js"
     },
     "./directives/template-content.js": {
       "types": "./development/directives/template-content.d.ts",
-      "node": "./node/directives/template-content.js",
+      "node": {
+        "development": "./node/development/directives/template-content.js",
+        "default": "./node/directives/template-content.js"
+      },
       "development": "./development/directives/template-content.js",
       "default": "./directives/template-content.js"
     },
     "./directives/unsafe-html.js": {
       "types": "./development/directives/unsafe-html.d.ts",
-      "node": "./node/directives/unsafe-html.js",
+      "node": {
+        "development": "./node/development/directives/unsafe-html.js",
+        "default": "./node/directives/unsafe-html.js"
+      },
       "development": "./development/directives/unsafe-html.js",
       "default": "./directives/unsafe-html.js"
     },
     "./directives/unsafe-svg.js": {
       "types": "./development/directives/unsafe-svg.d.ts",
-      "node": "./node/directives/unsafe-svg.js",
+      "node": {
+        "development": "./node/development/directives/unsafe-svg.js",
+        "default": "./node/directives/unsafe-svg.js"
+      },
       "development": "./development/directives/unsafe-svg.js",
       "default": "./directives/unsafe-svg.js"
     },
     "./directives/until.js": {
       "types": "./development/directives/until.d.ts",
-      "node": "./node/directives/until.js",
+      "node": {
+        "development": "./node/development/directives/until.js",
+        "default": "./node/directives/until.js"
+      },
       "development": "./development/directives/until.js",
       "default": "./directives/until.js"
     },
     "./directives/when.js": {
       "types": "./development/directives/when.d.ts",
-      "node": "./node/directives/when.js",
+      "node": {
+        "development": "./node/development/directives/when.js",
+        "default": "./node/directives/when.js"
+      },
       "development": "./development/directives/when.js",
       "default": "./directives/when.js"
     },
     "./experimental-hydrate.js": {
       "types": "./development/experimental-hydrate.d.ts",
-      "node": "./node/experimental-hydrate.js",
+      "node": {
+        "development": "./node/development/experimental-hydrate.js",
+        "default": "./node/experimental-hydrate.js"
+      },
       "development": "./development/experimental-hydrate.js",
       "default": "./experimental-hydrate.js"
     },
     "./polyfill-support.js": {
       "types": "./development/polyfill-support.d.ts",
-      "node": "./node/polyfill-support.js",
+      "node": {
+        "development": "./node/development/polyfill-support.js",
+        "default": "./node/polyfill-support.js"
+      },
       "development": "./development/polyfill-support.js",
       "default": "./polyfill-support.js"
     },
     "./private-ssr-support.js": {
       "types": "./development/private-ssr-support.d.ts",
-      "node": "./node/private-ssr-support.js",
+      "node": {
+        "development": "./node/development/private-ssr-support.js",
+        "default": "./node/private-ssr-support.js"
+      },
       "development": "./development/private-ssr-support.js",
       "default": "./private-ssr-support.js"
     },
     "./static.js": {
       "types": "./development/static.d.ts",
-      "node": "./node/static.js",
+      "node": {
+        "development": "./node/development/static.js",
+        "default": "./node/static.js"
+      },
       "development": "./development/static.js",
       "default": "./static.js"
     },
     "./is-server.js": {
       "types": "./development/is-server.d.ts",
-      "node": "./node/is-server.js",
+      "node": {
+        "development": "./node/development/is-server.js",
+        "default": "./node/is-server.js"
+      },
       "development": "./development/is-server.js",
       "default": "./is-server.js"
     }

--- a/packages/reactive-element/package.json
+++ b/packages/reactive-element/package.json
@@ -19,91 +19,136 @@
   "exports": {
     ".": {
       "types": "./development/reactive-element.d.ts",
-      "node": "./node/reactive-element.js",
+      "node": {
+        "development": "./node/development/reactive-element.js",
+        "default": "./node/reactive-element.js"
+      },
       "development": "./development/reactive-element.js",
       "default": "./reactive-element.js"
     },
     "./css-tag.js": {
       "types": "./development/css-tag.d.ts",
-      "node": "./node/css-tag.js",
+      "node": {
+        "development": "./node/development/css-tag.js",
+        "default": "./node/css-tag.js"
+      },
       "development": "./development/css-tag.js",
       "default": "./css-tag.js"
     },
     "./decorators.js": {
       "types": "./development/decorators.d.ts",
-      "node": "./node/decorators.js",
+      "node": {
+        "development": "./node/development/decorators.js",
+        "default": "./node/decorators.js"
+      },
       "development": "./development/decorators.js",
       "default": "./decorators.js"
     },
     "./decorators/base.js": {
       "types": "./development/decorators/base.d.ts",
-      "node": "./node/decorators/base.js",
+      "node": {
+        "development": "./node/development/decorators/base.js",
+        "default": "./node/decorators/base.js"
+      },
       "development": "./development/decorators/base.js",
       "default": "./decorators/base.js"
     },
     "./decorators/custom-element.js": {
       "types": "./development/decorators/custom-element.d.ts",
-      "node": "./node/decorators/custom-element.js",
+      "node": {
+        "development": "./node/development/decorators/custom-element.js",
+        "default": "./node/decorators/custom-element.js"
+      },
       "development": "./development/decorators/custom-element.js",
       "default": "./decorators/custom-element.js"
     },
     "./decorators/event-options.js": {
       "types": "./development/decorators/event-options.d.ts",
-      "node": "./node/decorators/event-options.js",
+      "node": {
+        "development": "./node/development/decorators/event-options.js",
+        "default": "./node/decorators/event-options.js"
+      },
       "development": "./development/decorators/event-options.js",
       "default": "./decorators/event-options.js"
     },
     "./decorators/property.js": {
       "types": "./development/decorators/property.d.ts",
-      "node": "./node/decorators/property.js",
+      "node": {
+        "development": "./node/development/decorators/property.js",
+        "default": "./node/decorators/property.js"
+      },
       "development": "./development/decorators/property.js",
       "default": "./decorators/property.js"
     },
     "./decorators/query-all.js": {
       "types": "./development/decorators/query-all.d.ts",
-      "node": "./node/decorators/query-all.js",
+      "node": {
+        "development": "./node/development/decorators/query-all.js",
+        "default": "./node/decorators/query-all.js"
+      },
       "development": "./development/decorators/query-all.js",
       "default": "./decorators/query-all.js"
     },
     "./decorators/query-assigned-elements.js": {
       "types": "./development/decorators/query-assigned-elements.d.ts",
-      "node": "./node/decorators/query-assigned-elements.js",
+      "node": {
+        "development": "./node/development/decorators/query-assigned-elements.js",
+        "default": "./node/decorators/query-assigned-elements.js"
+      },
       "development": "./development/decorators/query-assigned-elements.js",
       "default": "./decorators/query-assigned-elements.js"
     },
     "./decorators/query-assigned-nodes.js": {
       "types": "./development/decorators/query-assigned-nodes.d.ts",
-      "node": "./node/decorators/query-assigned-nodes.js",
+      "node": {
+        "development": "./node/development/decorators/query-assigned-nodes.js",
+        "default": "./node/decorators/query-assigned-nodes.js"
+      },
       "development": "./development/decorators/query-assigned-nodes.js",
       "default": "./decorators/query-assigned-nodes.js"
     },
     "./decorators/query-async.js": {
       "types": "./development/decorators/query-async.d.ts",
-      "node": "./node/decorators/query-async.js",
+      "node": {
+        "development": "./node/development/decorators/query-async.js",
+        "default": "./node/decorators/query-async.js"
+      },
       "development": "./development/decorators/query-async.js",
       "default": "./decorators/query-async.js"
     },
     "./decorators/query.js": {
       "types": "./development/decorators/query.d.ts",
-      "node": "./node/decorators/query.js",
+      "node": {
+        "development": "./node/development/decorators/query.js",
+        "default": "./node/decorators/query.js"
+      },
       "development": "./development/decorators/query.js",
       "default": "./decorators/query.js"
     },
     "./decorators/state.js": {
       "types": "./development/decorators/state.d.ts",
-      "node": "./node/decorators/state.js",
+      "node": {
+        "development": "./node/development/decorators/state.js",
+        "default": "./node/decorators/state.js"
+      },
       "development": "./development/decorators/state.js",
       "default": "./decorators/state.js"
     },
     "./polyfill-support.js": {
       "types": "./development/polyfill-support.d.ts",
-      "node": "./node/polyfill-support.js",
+      "node": {
+        "development": "./node/development/polyfill-support.js",
+        "default": "./node/polyfill-support.js"
+      },
       "development": "./development/polyfill-support.js",
       "default": "./polyfill-support.js"
     },
     "./reactive-controller.js": {
       "types": "./development/reactive-controller.d.ts",
-      "node": "./node/reactive-controller.js",
+      "node": {
+        "development": "./node/development/reactive-controller.js",
+        "default": "./node/reactive-controller.js"
+      },
       "development": "./development/reactive-controller.js",
       "default": "./reactive-controller.js"
     }

--- a/rollup-common.js
+++ b/rollup-common.js
@@ -454,7 +454,7 @@ export function litProdConfig({
                 },
               }),
               sourcemaps(),
-              // We want the Node build to be minified because:
+              // We want the production Node build to be minified because:
               //
               // 1. It should be very slightly faster, even in Node where bytes
               //    are not as important as in the browser.
@@ -467,6 +467,36 @@ export function litProdConfig({
               //    otherwise have different names. The default export that
               //    lit-element will use is minified.
               terser(terserOptions),
+              summary({
+                showBrotliSize: true,
+                showGzippedSize: true,
+              }),
+              ...(CHECKSIZE ? [skipBundleOutput] : []),
+            ],
+          },
+          {
+            // Also create a development Node build that does not minify to be
+            // used during devlopment so it can work along side the unminified
+            // dev build of lit-element
+            input: entryPoints.map((name) => `development/${name}.js`),
+            output: {
+              dir: `${outputDir}/node/development`,
+              format: 'esm',
+              preserveModules: true,
+              sourcemap: !CHECKSIZE,
+            },
+            external,
+            plugins: [
+              replace({
+                preventAssignment: true,
+                values: {
+                  // Setting NODE_MODE to true enables node-specific behaviors,
+                  // i.e. using globalThis instead of window, and shimming APIs
+                  // needed for Lit bootup.
+                  'const NODE_MODE = false': 'const NODE_MODE = true',
+                },
+              }),
+              sourcemaps(),
               summary({
                 showBrotliSize: true,
                 showGzippedSize: true,


### PR DESCRIPTION
While working on SSR integration, it was found that dev mode was using the unminified development build of `lit-element` but using the minified Node build of `reactive-element` causing error due to the mismatching method names.

This is solved by adding a development Node build which is unminified and will be used in these cases.