### PR TITLE
disabled shadydom in node dev build

### DIFF
--- a/.changeset/friendly-papayas-glow.md
+++ b/.changeset/friendly-papayas-glow.md
@@ -1,0 +1,6 @@
+---
+'lit': patch
+'lit-html': patch
+---
+
+disable shadydom in node dev environments

--- a/.changeset/friendly-papayas-glow.md
+++ b/.changeset/friendly-papayas-glow.md
@@ -3,4 +3,4 @@
 'lit-html': patch
 ---
 
-disable shadydom in node dev environments
+Disable ShadyDOM noPatch in Node dev build. This fixes the issue of throwing due to undefined `window`.

--- a/packages/lit-html/package.json
+++ b/packages/lit-html/package.json
@@ -287,7 +287,8 @@
     "test": "wireit",
     "test:dev": "wireit",
     "test:prod": "wireit",
-    "test:node": "wireit"
+    "test:node": "wireit",
+    "test:node-dev": "wireit"
   },
   "files": [
     "/async-directive.{d.ts,d.ts.map,js,js.map}",
@@ -408,6 +409,7 @@
         "test:dev",
         "test:prod",
         "test:node",
+        "test:node-dev",
         "check-version"
       ]
     },
@@ -433,6 +435,15 @@
     },
     "test:node": {
       "command": "node development/test/node-imports.js",
+      "dependencies": [
+        "build:ts",
+        "build:rollup"
+      ],
+      "files": [],
+      "output": []
+    },
+    "test:node-dev": {
+      "command": "node --conditions=development development/test/node-imports.js",
       "dependencies": [
         "build:ts",
         "build:rollup"

--- a/packages/lit/package.json
+++ b/packages/lit/package.json
@@ -183,7 +183,8 @@
     "test": "wireit",
     "test:dev": "wireit",
     "test:prod": "wireit",
-    "test:node": "wireit"
+    "test:node": "wireit",
+    "test:node-dev": "wireit"
   },
   "wireit": {
     "build": {
@@ -274,7 +275,8 @@
       "dependencies": [
         "test:dev",
         "test:prod",
-        "test:node"
+        "test:node",
+        "test:node-dev"
       ]
     },
     "test:dev": {
@@ -302,6 +304,15 @@
     },
     "test:node": {
       "command": "node development/test/node-imports.js",
+      "dependencies": [
+        "build:ts",
+        "build:rollup"
+      ],
+      "files": [],
+      "output": []
+    },
+    "test:node-dev": {
+      "command": "node --conditions=development development/test/node-imports.js",
       "dependencies": [
         "build:ts",
         "build:rollup"

--- a/packages/reactive-element/package.json
+++ b/packages/reactive-element/package.json
@@ -165,7 +165,8 @@
     "test": "wireit",
     "test:dev": "wireit",
     "test:prod": "wireit",
-    "test:node": "wireit"
+    "test:node": "wireit",
+    "test:node-dev": "wireit"
   },
   "wireit": {
     "build": {
@@ -263,6 +264,7 @@
         "test:dev",
         "test:prod",
         "test:node",
+        "test:node-dev",
         "check-version"
       ]
     },
@@ -289,6 +291,15 @@
     },
     "test:node": {
       "command": "node development/test/node-imports.js",
+      "dependencies": [
+        "build:ts",
+        "build:rollup"
+      ],
+      "files": [],
+      "output": []
+    },
+    "test:node-dev": {
+      "command": "node --conditions=development development/test/node-imports.js",
       "dependencies": [
         "build:ts",
         "build:rollup"

--- a/rollup-common.js
+++ b/rollup-common.js
@@ -494,6 +494,8 @@ export function litProdConfig({
                   // i.e. using globalThis instead of window, and shimming APIs
                   // needed for Lit bootup.
                   'const NODE_MODE = false': 'const NODE_MODE = true',
+                  'const ENABLE_SHADYDOM_NOPATCH = true':
+                    'const ENABLE_SHADYDOM_NOPATCH = false',
                 },
               }),
               sourcemaps(),


### PR DESCRIPTION
In a next.js environent this line was throwing because `window` is undefined. This module was imported transitively via a component importing the ref directive, which in turn imports async-directive, which in turn imports the file where the fix was added.

Related #3156 

I notice [there are tests](https://github.com/lit/lit/pull/3156/files#diff-1b9f30d8d53005f52e428cbb9c40a8b467742740f50445af9050f67c11944c43R23) for `lit-html` in that PR which import the ref directive, so i'm not sure how they pass (or conversely how it is not working for me)