### PR TITLE
[labs/virtualizer] Added missing events.js.map sourcemap file to package.json

### DIFF
--- a/.changeset/thirty-knives-hunt.md
+++ b/.changeset/thirty-knives-hunt.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/virtualizer': patch
+---
+
+Added missing "events.js.map" sourcemap file.

--- a/packages/labs/virtualizer/package.json
+++ b/packages/labs/virtualizer/package.json
@@ -103,7 +103,7 @@
     "/layouts/shared/*.{d.ts,d.ts.map,js,js.map}",
     "/polyfillLoaders/*.{d.ts,d.ts.map,js,js.map}",
     "/polyfills/resize-observer-polyfill/ResizeObserver.{d.ts,js}",
-    "/events.{js,d.ts,d.ts.map}",
+    "/events.{js,d.ts,d.ts.map,js.map}",
     "/lit-virtualizer.{d.ts,d.ts.map,js,js.map}",
     "/virtualize.{d.ts,d.ts.map,js,js.map}",
     "/Virtualizer.{d.ts,d.ts.map,js,js.map}",


### PR DESCRIPTION
Fixes missing sourcemap file in package.json.