### PR TITLE
[infra] Skip labs/ssr for next release

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,5 +6,16 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "minor",
-  "ignore": ["@lit-labs/ssr"]
+  "ignore": [
+    "@lit-labs/ssr",
+    "@lit-labs/eleventy-plugin-lit",
+    "@lit-labs/testing",
+    "@lit/localize-tools",
+    "@lit-labs/cli",
+    "@lit-labs/cli-localize",
+    "@lit-internal/localize-examples-runtime-js",
+    "@lit-internal/localize-examples-runtime-ts",
+    "@lit-internal/localize-examples-transform-js",
+    "@lit-internal/localize-examples-transform-ts"
+  ]
 }

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,5 +6,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "minor",
-  "ignore": []
+  "ignore": ["@lit-labs/ssr"]
 }

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,7 +42,9 @@ jobs:
         # run, and its output will appear in the raw logs). Unknown why this is the case,
         # see https://github.com/changesets/action/issues/149 for discussion.
         id: cs
-        uses: changesets/action@v1
+        # TODO(augustjk) Revert this to use the official after next release
+        # uses: changesets/action@v1
+        uses: augustjk/changesets-action@test
         with:
           # The `working-directory` option is only available for steps that use
           # `run`. This `cwd` option is the same, but specific to this action.


### PR DESCRIPTION
Adds `@lit-labs/ssr` and packages that depend on it to the ignore list for changeset and use my fork of the changeset action https://github.com/augustjk/changesets-action/tree/test for the next release.

This should be reverted after the next release as packages in the ignore list cannot be selected in the changeset cli to add a new changeset entry.