### PR TITLE
Revert "[infra] Skip labs/ssr for next release"

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,16 +6,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "minor",
-  "ignore": [
-    "@lit-labs/ssr",
-    "@lit-labs/eleventy-plugin-lit",
-    "@lit-labs/testing",
-    "@lit/localize-tools",
-    "@lit-labs/cli",
-    "@lit-labs/cli-localize",
-    "@lit-internal/localize-examples-runtime-js",
-    "@lit-internal/localize-examples-runtime-ts",
-    "@lit-internal/localize-examples-transform-js",
-    "@lit-internal/localize-examples-transform-ts"
-  ]
+  "ignore": []
 }

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,9 +42,7 @@ jobs:
         # run, and its output will appear in the raw logs). Unknown why this is the case,
         # see https://github.com/changesets/action/issues/149 for discussion.
         id: cs
-        # TODO(augustjk) Revert this to use the official after next release
-        # uses: changesets/action@v1
-        uses: augustjk/changesets-action@test
+        uses: changesets/action@v1
         with:
           # The `working-directory` option is only available for steps that use
           # `run`. This `cwd` option is the same, but specific to this action.


### PR DESCRIPTION
Reverts lit/lit#3530

The commits in the original PR were intended as a temporary workaround to make releasing a single package through the changesets action possible.  Reverting these changes to resume standard behavior.

thanks again @augustjk 🤘