### PR TITLE
[reactive-element] Fix Node build auto-shimming of `HTMLElement` to respect existing global shim

### DIFF
--- a/.changeset/thick-wasps-love.md
+++ b/.changeset/thick-wasps-love.md
@@ -1,0 +1,6 @@
+---
+'@lit/lit-starter-js': patch
+'@lit/lit-starter-ts': patch
+---
+
+Update dependency `@rollup/plugin-replace`

--- a/.changeset/tidy-lamps-rest.md
+++ b/.changeset/tidy-lamps-rest.md
@@ -3,4 +3,4 @@
 '@lit/reactive-element': patch
 ---
 
-Fix built-in shimming of `HTMLElement` for Node build of `reactive-element` to respect existing existing `HTMLElement` in global
+Fix built-in shimming of `HTMLElement` for Node build of `reactive-element` to respect existing `HTMLElement` in global

--- a/.changeset/tidy-lamps-rest.md
+++ b/.changeset/tidy-lamps-rest.md
@@ -1,0 +1,6 @@
+---
+'lit': patch
+'@lit/reactive-element': patch
+---
+
+Fix built-in shimming of `HTMLElement` for Node build of `reactive-element` to respect existing existing `HTMLElement` in global

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@rollup/plugin-commonjs": "^22.0.0",
         "@rollup/plugin-inject": "^5.0.2",
         "@rollup/plugin-node-resolve": "^13.2.1",
-        "@rollup/plugin-replace": "^4.0.0",
+        "@rollup/plugin-replace": "^5.0.2",
         "@rollup/plugin-virtual": "^2.1.0",
         "@types/chai": "^4.3.1",
         "@types/mocha": "^9.1.1",
@@ -3525,16 +3525,64 @@
       }
     },
     "node_modules/@rollup/plugin-replace": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-4.0.0.tgz",
-      "integrity": "sha512-+rumQFiaNac9y64OHtkHGmdjm7us9bo1PlbgQfdihQtuNxzjpaB064HbRnewUOggLQxVCCyINfStkgmBeQpv1g==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-5.0.2.tgz",
+      "integrity": "sha512-M9YXNekv/C/iHHK+cvORzfRYfPbq0RDD8r0G+bMiTXjNGKulPnCT9O3Ss46WfhI6ZOCgApOP7xAdmCQJ+U2LAA==",
       "dev": true,
       "dependencies": {
-        "@rollup/pluginutils": "^3.1.0",
-        "magic-string": "^0.25.7"
+        "@rollup/pluginutils": "^5.0.1",
+        "magic-string": "^0.27.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "rollup": "^1.20.0 || ^2.0.0"
+        "rollup": "^1.20.0||^2.0.0||^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-replace/node_modules/@rollup/pluginutils": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.2.tgz",
+      "integrity": "sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-replace/node_modules/@types/estree": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
+      "integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==",
+      "dev": true
+    },
+    "node_modules/@rollup/plugin-replace/node_modules/magic-string": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
+      "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.13"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@rollup/plugin-typescript": {
@@ -24485,7 +24533,7 @@
         "@custom-elements-manifest/analyzer": "^0.6.3",
         "@open-wc/testing": "^3.1.5",
         "@rollup/plugin-node-resolve": "^13.3.0",
-        "@rollup/plugin-replace": "^4.0.0",
+        "@rollup/plugin-replace": "^5.0.2",
         "@web/dev-server": "^0.1.31",
         "@web/dev-server-legacy": "^1.0.0",
         "@web/test-runner": "^0.13.27",
@@ -24513,7 +24561,7 @@
         "@custom-elements-manifest/analyzer": "^0.6.3",
         "@open-wc/testing": "^3.1.5",
         "@rollup/plugin-node-resolve": "^13.3.0",
-        "@rollup/plugin-replace": "^4.0.0",
+        "@rollup/plugin-replace": "^5.0.2",
         "@typescript-eslint/eslint-plugin": "^5.25.0",
         "@typescript-eslint/parser": "^5.25.0",
         "@web/dev-server": "^0.1.31",
@@ -26914,7 +26962,7 @@
         "@custom-elements-manifest/analyzer": "^0.6.3",
         "@open-wc/testing": "^3.1.5",
         "@rollup/plugin-node-resolve": "^13.3.0",
-        "@rollup/plugin-replace": "^4.0.0",
+        "@rollup/plugin-replace": "5.0.2",
         "@web/dev-server": "^0.1.31",
         "@web/dev-server-legacy": "^1.0.0",
         "@web/test-runner": "^0.13.27",
@@ -26938,7 +26986,7 @@
         "@custom-elements-manifest/analyzer": "^0.6.3",
         "@open-wc/testing": "^3.1.5",
         "@rollup/plugin-node-resolve": "^13.3.0",
-        "@rollup/plugin-replace": "^4.0.0",
+        "@rollup/plugin-replace": "5.0.2",
         "@typescript-eslint/eslint-plugin": "^5.25.0",
         "@typescript-eslint/parser": "^5.25.0",
         "@web/dev-server": "^0.1.31",
@@ -27783,13 +27831,41 @@
       }
     },
     "@rollup/plugin-replace": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-4.0.0.tgz",
-      "integrity": "sha512-+rumQFiaNac9y64OHtkHGmdjm7us9bo1PlbgQfdihQtuNxzjpaB064HbRnewUOggLQxVCCyINfStkgmBeQpv1g==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-5.0.2.tgz",
+      "integrity": "sha512-M9YXNekv/C/iHHK+cvORzfRYfPbq0RDD8r0G+bMiTXjNGKulPnCT9O3Ss46WfhI6ZOCgApOP7xAdmCQJ+U2LAA==",
       "dev": true,
       "requires": {
-        "@rollup/pluginutils": "^3.1.0",
-        "magic-string": "^0.25.7"
+        "@rollup/pluginutils": "^5.0.1",
+        "magic-string": "^0.27.0"
+      },
+      "dependencies": {
+        "@rollup/pluginutils": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.2.tgz",
+          "integrity": "sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==",
+          "dev": true,
+          "requires": {
+            "@types/estree": "^1.0.0",
+            "estree-walker": "^2.0.2",
+            "picomatch": "^2.3.1"
+          }
+        },
+        "@types/estree": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
+          "integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==",
+          "dev": true
+        },
+        "magic-string": {
+          "version": "0.27.0",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
+          "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/sourcemap-codec": "^1.4.13"
+          }
+        }
       }
     },
     "@rollup/plugin-typescript": {

--- a/package.json
+++ b/package.json
@@ -185,7 +185,7 @@
     "@rollup/plugin-commonjs": "^22.0.0",
     "@rollup/plugin-inject": "^5.0.2",
     "@rollup/plugin-node-resolve": "^13.2.1",
-    "@rollup/plugin-replace": "^4.0.0",
+    "@rollup/plugin-replace": "^5.0.2",
     "@rollup/plugin-virtual": "^2.1.0",
     "@types/chai": "^4.3.1",
     "@types/mocha": "^9.1.1",

--- a/packages/lit-starter-js/package.json
+++ b/packages/lit-starter-js/package.json
@@ -48,7 +48,7 @@
     "@custom-elements-manifest/analyzer": "^0.6.3",
     "@open-wc/testing": "^3.1.5",
     "@rollup/plugin-node-resolve": "^13.3.0",
-    "@rollup/plugin-replace": "^4.0.0",
+    "@rollup/plugin-replace": "^5.0.2",
     "@web/dev-server": "^0.1.31",
     "@web/dev-server-legacy": "^1.0.0",
     "@web/test-runner": "^0.13.27",

--- a/packages/lit-starter-ts/package.json
+++ b/packages/lit-starter-ts/package.json
@@ -49,7 +49,7 @@
     "@custom-elements-manifest/analyzer": "^0.6.3",
     "@open-wc/testing": "^3.1.5",
     "@rollup/plugin-node-resolve": "^13.3.0",
-    "@rollup/plugin-replace": "^4.0.0",
+    "@rollup/plugin-replace": "^5.0.2",
     "@typescript-eslint/eslint-plugin": "^5.25.0",
     "@typescript-eslint/parser": "^5.25.0",
     "@web/dev-server": "^0.1.31",

--- a/packages/reactive-element/package.json
+++ b/packages/reactive-element/package.json
@@ -166,7 +166,9 @@
     "test:dev": "wireit",
     "test:prod": "wireit",
     "test:node": "wireit",
-    "test:node-dev": "wireit"
+    "test:node-dev": "wireit",
+    "test:node-dom-shim": "wireit",
+    "test:node-dom-shim-dev": "wireit"
   },
   "wireit": {
     "build": {
@@ -268,6 +270,8 @@
         "test:prod",
         "test:node",
         "test:node-dev",
+        "test:node-dom-shim",
+        "test:node-dom-shim-dev",
         "check-version"
       ]
     },
@@ -313,6 +317,24 @@
     },
     "test:node-dev": {
       "command": "node --conditions=development development/test/node-imports.js",
+      "dependencies": [
+        "build:ts",
+        "build:rollup"
+      ],
+      "files": [],
+      "output": []
+    },
+    "test:node-dom-shim": {
+      "command": "node development/test/node-dom-shim.js",
+      "dependencies": [
+        "build:ts",
+        "build:rollup"
+      ],
+      "files": [],
+      "output": []
+    },
+    "test:node-dom-shim-dev": {
+      "command": "node --conditions=development development/test/node-dom-shim.js",
       "dependencies": [
         "build:ts",
         "build:rollup"

--- a/packages/reactive-element/src/test/node-dom-shim.ts
+++ b/packages/reactive-element/src/test/node-dom-shim.ts
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+// This file will be loaded by Node from the node:test-dom-shim script to verify
+// `ReactiveElement` will prefer extending existing `HTMLElement` from the
+// global rather than the built-in shim
+
+import './node-shim-html-element.js';
+import {ReactiveElement} from '@lit/reactive-element';
+import {HTMLElement} from '@lit-labs/ssr-dom-shim';
+
+import assert from 'node:assert/strict';
+assert.strictEqual(
+  Object.getPrototypeOf(ReactiveElement),
+  globalThis.HTMLElement,
+  'Expected ReactiveElement to extend existing globalThis.HTMLElement'
+);
+assert.notStrictEqual(
+  Object.getPrototypeOf(ReactiveElement),
+  HTMLElement,
+  'Expected ReactiveElement to not extend HTMLElement from ssr-dom-shim'
+);

--- a/packages/reactive-element/src/test/node-imports.ts
+++ b/packages/reactive-element/src/test/node-imports.ts
@@ -43,3 +43,11 @@ export class MyElement extends ReactiveElement {
 
 export class MyOtherElement extends ReactiveElement {}
 customElements.define('my-other-element', MyOtherElement);
+
+import assert from 'node:assert/strict';
+import {HTMLElement} from '@lit-labs/ssr-dom-shim';
+assert.strictEqual(
+  Object.getPrototypeOf(ReactiveElement),
+  HTMLElement,
+  'Expected ReactiveElement to extend HTMLElement from ssr-dom-shim'
+);

--- a/packages/reactive-element/src/test/node-shim-html-element.ts
+++ b/packages/reactive-element/src/test/node-shim-html-element.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+// This file is used as a side-effectful import in `node-dom-shim.js` to
+// simulate loading a separate DOM shim that adds `HTMLElement` to the global
+
+class FakeHTMLElement {}
+globalThis.HTMLElement = FakeHTMLElement as typeof HTMLElement;

--- a/rollup-common.js
+++ b/rollup-common.js
@@ -275,6 +275,7 @@ const injectNodeDomShimIntoReactiveElement = [
     include: ['**/packages/lit-html/development/experimental-hydrate.js'],
   }),
   replace({
+    preventAssignment: true,
     values: {
       'extends HTMLElement': 'extends (globalThis.HTMLElement ?? HTMLElement)',
     },


### PR DESCRIPTION
Fixes #3559 

The replace of `extends HTMLElement` with `extends (globalThis.HTMLElement ?? HTMLElement)` was not happening due to the `includes` option for `@rollup/plugin-replace` not working properly. Updating the version fixes this.

Note: To keep a single version of the plugin in the monorepo, the version was also updated for the starter kits.

Now the outputs look like:

Dev Node build:
```js
class ReactiveElement
 extends (globalThis.HTMLElement ?? HTMLElement) {
```

Prod Node build:
```js
class v extends(globalThis.HTMLElement??i)
```

I added another test in the vein of the node-import tests. It feels like there are a lot of scripts for the node tests now but unsure if there's a better way to do this.