### PR TITLE
Accept requestUpdate to be passed in @event binding

### DIFF
--- a/packages/reactive-element/src/reactive-element.ts
+++ b/packages/reactive-element/src/reactive-element.ts
@@ -1176,13 +1176,13 @@ export abstract class ReactiveElement
    * @category updates
    */
   requestUpdate(
-    name?: PropertyKey,
+    name?: PropertyKey | Event,
     oldValue?: unknown,
     options?: PropertyDeclaration
   ): void {
     let shouldRequestUpdate = true;
     // If we have a property key, perform property update steps.
-    if (name !== undefined) {
+    if (name !== undefined && !(name instanceof Event)) {
       options =
         options ||
         (this.constructor as typeof ReactiveElement).getPropertyOptions(name);

--- a/packages/reactive-element/src/test/reactive-element_test.ts
+++ b/packages/reactive-element/src/test/reactive-element_test.ts
@@ -3278,4 +3278,11 @@ suite('ReactiveElement', () => {
       // Suppress no-unused-vars warnings
     }
   });
+
+  test('requestUpdate can be used as a template @event binding', () => {
+    class E extends ReactiveElement {}
+    customElements.define(generateElementName(), E);
+    const el = new E();
+    el.requestUpdate(new CustomEvent('custom-event'));
+  });
 });


### PR DESCRIPTION
This change will permit to pass `requestUpdate` in a @event binding

```html
<button @click=${this.requestUpdate}></button>
```

(Previously, 
```html
<button @click=${() => this.requestUpdate()}></button>
```
)