### PR TITLE
[localize] Fix XLIFF serialization regression

### DIFF
--- a/.changeset/flat-readers-brush.md
+++ b/.changeset/flat-readers-brush.md
@@ -1,0 +1,5 @@
+---
+'@lit/localize-tools': patch
+---
+
+Fix regression in Localize XLIFF serialization. When updating an existing XLIFF file, placeholders would appear in the wrong places.

--- a/packages/localize-tools/src/formatters/xliff.ts
+++ b/packages/localize-tools/src/formatters/xliff.ts
@@ -412,7 +412,9 @@ export class XliffFormatter implements Formatter {
    */
   private clearElement(element: Element) {
     const children = element.childNodes;
-    for (let i = 0; i < children.length; i++) {
+    // Iterate backwards so we don't have to worry about the index changing each
+    // time we remove.
+    for (let i = children.length - 1; i >= 0; i--) {
       element.removeChild(children.item(i));
     }
   }

--- a/packages/localize-tools/testdata/extract-xliff-merge/goldens/foo.ts
+++ b/packages/localize-tools/testdata/extract-xliff-merge/goldens/foo.ts
@@ -4,9 +4,10 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {msg} from '@lit/localize';
+import {msg, str} from '@lit/localize';
 
-msg('I am translated', {desc: 'Description of translated'});
+const who = 'World';
+msg(str`I am translated. Hello ${who}.`, {desc: 'Description of translated'});
 msg('I am not translated', {desc: 'Description of not translated'});
 msg('I am translated with a note', {desc: 'Happy note'});
 msg('My note needs to be migrated', {desc: 'Existing note'});

--- a/packages/localize-tools/testdata/extract-xliff-merge/goldens/xliff/es-419.xlf
+++ b/packages/localize-tools/testdata/extract-xliff-merge/goldens/xliff/es-419.xlf
@@ -3,9 +3,9 @@
   <!-- Comment by translation tool -->
   <file target-language="es-419" source-language="en" original="other-original" datatype="plaintext" date="2002-01-25T21:06:00Z">
   <body>
-    <trans-unit id="s677cb50a446c46f4" approved="yes">
-      <source>I am translated</source>
-      <target state="translated">Estoy traducido</target>
+    <trans-unit id="sa6552c557bbace72" approved="yes">
+      <source>I am translated. Hello <ph id="0">${who}</ph>.</source>
+      <target state="translated">Estoy traducido. Hola <ph id="0">${who}</ph>.</target>
   <note from="lit-localize">Description of translated</note>
     </trans-unit>
     <trans-unit id="s18fa8e4d6470399d">

--- a/packages/localize-tools/testdata/extract-xliff-merge/input/foo.ts
+++ b/packages/localize-tools/testdata/extract-xliff-merge/input/foo.ts
@@ -4,9 +4,10 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {msg} from '@lit/localize';
+import {msg, str} from '@lit/localize';
 
-msg('I am translated', {desc: 'Description of translated'});
+const who = 'World';
+msg(str`I am translated. Hello ${who}.`, {desc: 'Description of translated'});
 msg('I am not translated', {desc: 'Description of not translated'});
 msg('I am translated with a note', {desc: 'Happy note'});
 msg('My note needs to be migrated', {desc: 'Existing note'});

--- a/packages/localize-tools/testdata/extract-xliff-merge/input/xliff/es-419.xlf
+++ b/packages/localize-tools/testdata/extract-xliff-merge/input/xliff/es-419.xlf
@@ -3,9 +3,9 @@
   <!-- Comment by translation tool -->
   <file target-language="es-419" source-language="en" original="other-original" datatype="plaintext" date="2002-01-25T21:06:00Z">
   <body>
-    <trans-unit id="s677cb50a446c46f4" approved="yes">
-      <source>I was translated</source>
-      <target state="translated">Estoy traducido</target>
+    <trans-unit id="sa6552c557bbace72" approved="yes">
+      <source>I was translated. Hello <ph id="0">${who}</ph>.</source>
+      <target state="translated">Estoy traducido. Hola <ph id="0">${who}</ph>.</target>
     </trans-unit>
     <trans-unit id="s18fa8e4d6470399d">
       <source foo:attribute="bar">I am translated with a note</source>


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/lit/lit/pull/3514 where we were not correctly updating XLIFF messages that contained placeholders, because of an index-invalidation bug in the way we were deleting the contents of existing nodes.

Fixes https://github.com/lit/lit/issues/3569