### PR TITLE
"It can be installed with no configuration"

### DIFF
--- a/packages/labs/router/src/routes.ts
+++ b/packages/labs/router/src/routes.ts
@@ -126,7 +126,7 @@ export class Routes implements ReactiveController {
 
   constructor(
     host: ReactiveControllerHost & HTMLElement,
-    routes: Array<RouteConfig>,
+    routes: Array<RouteConfig> = [],
     options?: {fallback?: BaseRouteConfig}
   ) {
     (this._host = host).addController(this);


### PR DESCRIPTION
The doc says

https://github.com/lit/lit/blob/023cdeb228124d98df4eb1c236a54b2e3db1d88a/packages/labs/router/README.md?plain=1#L53

But TypeScript will complain about not passing a required argument.