### PR TITLE
Remove abstract from members of ElementRendererConstructor type

### DIFF
--- a/.changeset/tough-beans-marry.md
+++ b/.changeset/tough-beans-marry.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/ssr': patch
+---
+
+Remove `abstract` from members of the ElementRendererConstructor type

--- a/packages/labs/ssr/src/lib/element-renderer.ts
+++ b/packages/labs/ssr/src/lib/element-renderer.ts
@@ -10,11 +10,13 @@ import {escapeHtml} from './util/escape-html.js';
 import type {RenderInfo} from './render-value.js';
 import type {RenderResult} from './render-result.js';
 
-export type Constructor<T> = {new (): T};
+type Interface<T> = {
+  [P in keyof T]: T[P];
+};
 
 export type ElementRendererConstructor = (new (
   tagName: string
-) => ElementRenderer) &
+) => Interface<ElementRenderer>) &
   typeof ElementRenderer;
 
 type AttributesMap = Map<string, string>;


### PR DESCRIPTION
This lets you write mixins against ElementRendererConstructor without errors that you're not implementing abstract members.

For example, mixins are useful for modifying existing renderers:

```ts
const excludeElements = (
  renderer: ElementRendererConstructor,
  excludedTagNames: Array<string>
) => {
  return class ExcludeElementRenderer extends renderer {
    static matchesClass(
      ceClass: typeof HTMLElement,
      tagName: string,
      attributes: Map<string, string>
    ) {
      return !excludedTagNames.includes(tagName) && super.matchesClass(ceClass, tagName, attributes);
    }
  };
};
```