### PR TITLE
[labs/virtualizer] Trigger reflow after padding is set

### DIFF
--- a/.changeset/slimy-mails-clean.md
+++ b/.changeset/slimy-mails-clean.md
@@ -1,0 +1,5 @@
+---
+"@lit-labs/virtualizer": patch
+---
+
+Trigger reflow after padding is set

--- a/packages/labs/virtualizer/src/layouts/shared/SizeGapPaddingBaseLayout.ts
+++ b/packages/labs/virtualizer/src/layouts/shared/SizeGapPaddingBaseLayout.ts
@@ -174,17 +174,21 @@ export abstract class SizeGapPaddingBaseLayout<
       .map((v) => paddingValueToNumber(v as PaddingValue));
     if (values.length === 1) {
       padding.top = padding.right = padding.bottom = padding.left = values[0];
+      this._triggerReflow();
     } else if (values.length === 2) {
       padding.top = padding.bottom = values[0];
       padding.right = padding.left = values[1];
+      this._triggerReflow();
     } else if (values.length === 3) {
       padding.top = values[0];
       padding.right = padding.left = values[1];
       padding.bottom = values[2];
+      this._triggerReflow();
     } else if (values.length === 4) {
       ['top', 'right', 'bottom', 'left'].forEach(
         (side, idx) => (padding[side as side] = values[idx])
       );
+      this._triggerReflow();
     }
   }
 }


### PR DESCRIPTION
fixes #3285

Ensure that the layout for the Virtualizer is updated when a new `padding` value is provided.