### PR TITLE
[labs/virtualizer] RangeChangedEvent and VisibilityChangedEvent no longer bubble up

### DIFF
--- a/.changeset/wild-turtles-rush.md
+++ b/.changeset/wild-turtles-rush.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/virtualizer': minor
+---
+
+RangeChangedEvent and VisibilityChangedEvent both no longer bubble up. Listeners for these events must be placed on the lit-virtualizer or virtualize directive's host element.

--- a/packages/labs/virtualizer/src/events.ts
+++ b/packages/labs/virtualizer/src/events.ts
@@ -11,7 +11,7 @@ export class RangeChangedEvent extends Event {
   last: number;
 
   constructor(range: Range) {
-    super(RangeChangedEvent.eventName, {bubbles: true});
+    super(RangeChangedEvent.eventName, {bubbles: false});
     this.first = range.first;
     this.last = range.last;
   }
@@ -24,7 +24,7 @@ export class VisibilityChangedEvent extends Event {
   last: number;
 
   constructor(range: Range) {
-    super(VisibilityChangedEvent.eventName, {bubbles: true});
+    super(VisibilityChangedEvent.eventName, {bubbles: false});
     this.first = range.first;
     this.last = range.last;
   }

--- a/packages/labs/virtualizer/src/test/layouts/flow.test.ts
+++ b/packages/labs/virtualizer/src/test/layouts/flow.test.ts
@@ -56,7 +56,7 @@ describe('flow layout', () => {
     )) as LitVirtualizer;
     expect(virtualizer).to.be.instanceof(LitVirtualizer);
     await until(() => getVisibleItems(virtualizer).length === 4);
-    return {container, virtualizer};
+    return virtualizer;
   }
 
   function getVisibleItems(virtualizer: LitVirtualizer) {
@@ -67,14 +67,14 @@ describe('flow layout', () => {
 
   describe('item resizing', () => {
     it('emits VisibilityChanged event due to item resizing', async () => {
-      const {container, virtualizer} = await createVirtualizer({
+      const virtualizer = await createVirtualizer({
         items: array(1000),
       });
       const visibilityChangedEvents: VisibilityChangedEvent[] = [];
 
       await until(() => getVisibleItems(virtualizer).length == 4);
 
-      container.addEventListener('visibilityChanged', (e) => {
+      virtualizer.addEventListener('visibilityChanged', (e) => {
         visibilityChangedEvents.push(e as VisibilityChangedEvent);
       });
 
@@ -105,7 +105,7 @@ describe('flow layout', () => {
 
   describe('element(<index>).scrollIntoView', () => {
     it('shows the correct items when scrolling to start position', async () => {
-      const {virtualizer} = await createVirtualizer({items: array(1000)});
+      const virtualizer = await createVirtualizer({items: array(1000)});
 
       virtualizer.element(5)!.scrollIntoView({block: 'start'});
 
@@ -120,7 +120,7 @@ describe('flow layout', () => {
     });
 
     it('shows leading items when scrolling to last item in start position', async () => {
-      const {virtualizer} = await createVirtualizer({items: array(1000)});
+      const virtualizer = await createVirtualizer({items: array(1000)});
 
       virtualizer.element(999)!.scrollIntoView({block: 'start'});
 
@@ -135,7 +135,7 @@ describe('flow layout', () => {
     });
 
     it('shows the correct items when scrolling to center position', async () => {
-      const {virtualizer} = await createVirtualizer({items: array(1000)});
+      const virtualizer = await createVirtualizer({items: array(1000)});
 
       virtualizer.element(200)!.scrollIntoView({block: 'center'});
 
@@ -151,7 +151,7 @@ describe('flow layout', () => {
     });
 
     it('shows trailing items when scrolling to first item in end position', async () => {
-      const {virtualizer} = await createVirtualizer({items: array(1000)});
+      const virtualizer = await createVirtualizer({items: array(1000)});
       virtualizer.element(0)!.scrollIntoView({block: 'end'});
 
       await until(() =>
@@ -165,7 +165,7 @@ describe('flow layout', () => {
     });
 
     it('shows the correct items when scrolling to nearest position', async () => {
-      const {virtualizer} = await createVirtualizer({items: array(1000)});
+      const virtualizer = await createVirtualizer({items: array(1000)});
 
       // The nearest position for item 500 will be at the end.
       virtualizer.element(500)!.scrollIntoView({block: 'nearest'});
@@ -208,7 +208,7 @@ describe('flow layout', () => {
 
   describe('scrollToIndex', () => {
     it('shows the correct items when scrolling to start position', async () => {
-      const {virtualizer} = await createVirtualizer({items: array(1000)});
+      const virtualizer = await createVirtualizer({items: array(1000)});
 
       virtualizer.scrollToIndex(5, 'start');
 
@@ -223,7 +223,7 @@ describe('flow layout', () => {
     });
 
     it('shows leading items when scrolling to last item in start position', async () => {
-      const {virtualizer} = await createVirtualizer({items: array(1000)});
+      const virtualizer = await createVirtualizer({items: array(1000)});
 
       virtualizer.scrollToIndex(999, 'start');
 
@@ -238,7 +238,7 @@ describe('flow layout', () => {
     });
 
     it('shows the correct items when scrolling to center position', async () => {
-      const {virtualizer} = await createVirtualizer({items: array(1000)});
+      const virtualizer = await createVirtualizer({items: array(1000)});
 
       virtualizer.scrollToIndex(200, 'center');
 
@@ -254,7 +254,7 @@ describe('flow layout', () => {
     });
 
     it('shows trailing items when scrolling to first item in end position', async () => {
-      const {virtualizer} = await createVirtualizer({items: array(1000)});
+      const virtualizer = await createVirtualizer({items: array(1000)});
       virtualizer.scrollToIndex(0, 'end');
 
       await until(() =>
@@ -268,7 +268,7 @@ describe('flow layout', () => {
     });
 
     it('shows the correct items when scrolling to nearest position', async () => {
-      const {virtualizer} = await createVirtualizer({items: array(1000)});
+      const virtualizer = await createVirtualizer({items: array(1000)});
 
       // The nearest position for item 500 will be at the end.
       virtualizer.scrollToIndex(500, 'nearest');

--- a/packages/labs/virtualizer/src/test/scenarios/visibility-changed-events.test.ts
+++ b/packages/labs/virtualizer/src/test/scenarios/visibility-changed-events.test.ts
@@ -70,15 +70,13 @@ describe('VisibilityChanged event', () => {
 
     first(getVisibleItems(virtualizer)).style.height = '10px';
 
-    await until(() => containerEvents.length === 1);
-
-    expect(last(containerEvents).first).to.equal(0);
-    expect(last(containerEvents).last).to.equal(4);
-
     await until(() => virtualizerEvents.length === 1);
 
     expect(last(virtualizerEvents).first).to.equal(0);
     expect(last(virtualizerEvents).last).to.equal(4);
+
+    // The visibilitychanged event should not bubble up to its containing element.
+    expect(containerEvents.length).to.equal(0);
   });
 
   it('should fire when item moves out of view', async () => {
@@ -99,14 +97,12 @@ describe('VisibilityChanged event', () => {
 
     first(getVisibleItems(virtualizer)).style.height = '100px';
 
-    await until(() => containerEvents.length === 1);
-
-    expect(last(containerEvents).first).to.equal(0);
-    expect(last(containerEvents).last).to.equal(2);
-
     await until(() => virtualizerEvents.length === 1);
 
     expect(last(virtualizerEvents).first).to.equal(0);
     expect(last(virtualizerEvents).last).to.equal(2);
+
+    // The visibilitychanged event should not bubble up to its containing element.
+    expect(containerEvents.length).to.equal(0);
   });
 });

--- a/packages/labs/virtualizer/src/virtualize.ts
+++ b/packages/labs/virtualizer/src/virtualize.ts
@@ -138,7 +138,6 @@ class VirtualizeDirective<T = unknown> extends AsyncDirective {
     const hostElement = part.parentNode as HTMLElement;
     if (hostElement && hostElement.nodeType === 1) {
       hostElement.addEventListener('rangeChanged', (e: RangeChangedEvent) => {
-        e.stopPropagation();
         this._first = e.first;
         this._last = e.last;
         this.setValue(this.render());


### PR DESCRIPTION
This PR solves the event behavior differences between RangeChangedEvent and VisibilityChangedEvent per #3051 

Both event types are ensured not to bubble up and must be listened for now on the `<lit-virtualizer>` itself or the host element in the case of `virtualize()` directive.