### PR TITLE
[context] Add type parameter for key to createContext()

### DIFF
--- a/.changeset/happy-apricots-pay.md
+++ b/.changeset/happy-apricots-pay.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/context': patch
+---
+
+Add type parameter for key to createContext()

--- a/packages/labs/context/src/lib/create-context.ts
+++ b/packages/labs/context/src/lib/create-context.ts
@@ -49,8 +49,8 @@ export type ContextType<Key extends Context<unknown, unknown>> =
  *
  * @param key a context key value
  * @template ValueType the type of value that can be provided by this context.
- * @returns the context key value with the correct type
+ * @returns the context key value cast to `Context<K, ValueType>`
  */
-export function createContext<ValueType>(key: unknown) {
-  return key as Context<typeof key, ValueType>;
+export function createContext<ValueType, K = unknown>(key: K) {
+  return key as Context<K, ValueType>;
 }


### PR DESCRIPTION
Small change to get more accurate types. Should be non breaking as the second type parameter has a default and doesn't have to be specified.

cc @benjamind 