### PR TITLE
[labs/context] Fix getter for @provide() decorated fields

### DIFF
--- a/.changeset/lazy-beers-sin.md
+++ b/.changeset/lazy-beers-sin.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/context': patch
+---
+
+Fix getter for @provide() decorated fields

--- a/packages/labs/context/src/lib/decorators/provide.ts
+++ b/packages/labs/context/src/lib/decorators/provide.ts
@@ -63,13 +63,17 @@ export function provide<ValueType>({
       // notify the controller of an updated value
       const descriptor = Object.getOwnPropertyDescriptor(ctor.prototype, name);
       const oldSetter = descriptor?.set;
+      const oldGetter = descriptor?.get;
       const newDescriptor = {
         ...descriptor,
-        set: function (value: ValueType) {
+        set(value: ValueType) {
           controllerMap.get(this)?.setValue(value);
-          if (oldSetter) {
-            oldSetter.call(this, value);
-          }
+          oldSetter?.call(this, value);
+        },
+        get() {
+          return oldGetter !== undefined
+            ? oldGetter.call(this)
+            : controllerMap.get(this)?.value;
         },
       };
       Object.defineProperty(ctor.prototype, name, newDescriptor);


### PR DESCRIPTION
Previously there was no getter, so `@provide()` would always result in reading `undefined` from a decorated field. This adds a getter that delegate to an inner getter or the current value of the ContextProvider controller.