### PR TITLE
[labs/analyzer] Fix support for static class members.

### DIFF
--- a/.changeset/lazy-rats-hug.md
+++ b/.changeset/lazy-rats-hug.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/analyzer': minor
+---
+
+Fix support for static class members by storing them in separate maps by name.

--- a/packages/labs/analyzer/src/lib/javascript/classes.ts
+++ b/packages/labs/analyzer/src/lib/javascript/classes.ts
@@ -72,22 +72,26 @@ export const getClassMembers = (
   analyzer: AnalyzerInterface
 ) => {
   const fieldMap = new Map<string, ClassField>();
+  const staticFieldMap = new Map<string, ClassField>();
   const methodMap = new Map<string, ClassMethod>();
+  const staticMethodMap = new Map<string, ClassMethod>();
   declaration.members.forEach((node) => {
     if (ts.isMethodDeclaration(node)) {
-      methodMap.set(
+      const info = getMemberInfo(node);
+      (info.static ? staticMethodMap : methodMap).set(
         node.name.getText(),
         new ClassMethod({
-          ...getMemberInfo(node),
+          ...info,
           ...getFunctionLikeInfo(node, analyzer),
           ...parseNodeJSDocInfo(node),
         })
       );
     } else if (ts.isPropertyDeclaration(node)) {
-      fieldMap.set(
+      const info = getMemberInfo(node);
+      (info.static ? staticFieldMap : fieldMap).set(
         node.name.getText(),
         new ClassField({
-          ...getMemberInfo(node),
+          ...info,
           default: node.initializer?.getText(),
           type: getTypeForNode(node, analyzer),
           ...parseNodeJSDocInfo(node),
@@ -97,7 +101,9 @@ export const getClassMembers = (
   });
   return {
     fieldMap,
+    staticFieldMap,
     methodMap,
+    staticMethodMap,
   };
 };
 

--- a/packages/labs/analyzer/src/lib/model.ts
+++ b/packages/labs/analyzer/src/lib/model.ts
@@ -407,7 +407,9 @@ export interface ClassDeclarationInit extends DeclarationInit {
   node: ts.ClassDeclaration;
   getHeritage: () => ClassHeritage;
   fieldMap?: Map<string, ClassField> | undefined;
+  staticFieldMap?: Map<string, ClassField> | undefined;
   methodMap?: Map<string, ClassMethod> | undefined;
+  staticMethodMap?: Map<string, ClassMethod> | undefined;
 }
 
 export class ClassDeclaration extends Declaration {
@@ -415,14 +417,18 @@ export class ClassDeclaration extends Declaration {
   private _getHeritage: () => ClassHeritage;
   private _heritage: ClassHeritage | undefined = undefined;
   readonly _fieldMap: Map<string, ClassField>;
+  readonly _staticFieldMap: Map<string, ClassField>;
   readonly _methodMap: Map<string, ClassMethod>;
+  readonly _staticMethodMap: Map<string, ClassMethod>;
 
   constructor(init: ClassDeclarationInit) {
     super(init);
     this.node = init.node;
     this._getHeritage = init.getHeritage;
     this._fieldMap = init.fieldMap ?? new Map();
+    this._staticFieldMap = init.staticFieldMap ?? new Map();
     this._methodMap = init.methodMap ?? new Map();
+    this._staticMethodMap = init.staticMethodMap ?? new Map();
   }
 
   /**
@@ -438,31 +444,31 @@ export class ClassDeclaration extends Declaration {
    * (excluding any inherited members).
    */
   get fields() {
-    return this._fieldMap.values();
+    return [...this._fieldMap.values(), ...this._staticFieldMap.values()];
   }
 
   /**
    * Returns iterator of the `ClassMethod`s defined on the immediate class
    * (excluding any inherited members).
    */
-  get methods(): IterableIterator<ClassMethod> {
-    return this._methodMap.values();
+  get methods() {
+    return [...this._methodMap.values(), ...this._staticMethodMap.values()];
   }
 
   /**
    * Returns a `ClassField` model the given name defined on the immediate class
    * (excluding any inherited members).
    */
-  getField(name: string): ClassField | undefined {
-    return this._fieldMap.get(name);
+  getField(name: string, isStatic = false): ClassField | undefined {
+    return (isStatic ? this._staticFieldMap : this._fieldMap).get(name);
   }
 
   /**
    * Returns a `ClassMethod` model for the given name defined on the immediate
    * class (excluding any inherited members).
    */
-  getMethod(name: string): ClassMethod | undefined {
-    return this._methodMap.get(name);
+  getMethod(name: string, isStatic = false): ClassMethod | undefined {
+    return (isStatic ? this._staticMethodMap : this._methodMap).get(name);
   }
 
   /**

--- a/packages/labs/analyzer/src/test/lit-element/jsdoc_test.ts
+++ b/packages/labs/analyzer/src/test/lit-element/jsdoc_test.ts
@@ -284,6 +284,18 @@ nisi ut aliquip ex ea commodo consequat.`
     assert.equal(member.deprecated, 'Class field 4 deprecated');
   });
 
+  test('static field1', ({getModule}) => {
+    const element = getModule('element-a').getDeclaration('ElementA');
+    assert.ok(element.isClassDeclaration());
+    const member = element.getField('field1', true);
+    assert.ok(member?.isClassField());
+    assert.equal(member.summary, `Static class field 1 summary`);
+    assert.equal(member.description, `Static class field 1 description`);
+    assert.equal(member.default, undefined);
+    assert.equal(member.privacy, 'protected');
+    assert.equal(member.type?.text, 'string | number');
+  });
+
   // Methods
 
   test('method1', ({getModule}) => {
@@ -329,6 +341,41 @@ nisi ut aliquip ex ea commodo consequat.`
     assert.equal(member.return?.type?.text, 'string');
     assert.equal(member.return?.description, 'Method 2 return description');
     assert.equal(member.deprecated, 'Method 2 deprecated');
+  });
+
+  test('static method1', ({getModule}) => {
+    const element = getModule('element-a').getDeclaration('ElementA');
+    assert.ok(element.isClassDeclaration());
+    const member = element.getMethod('method1', true);
+    assert.ok(member?.isClassMethod());
+    assert.equal(member.summary, `Static method 1 summary`);
+    assert.equal(member.description, `Static method 1 description`);
+    assert.equal(member.parameters?.length, 3);
+    assert.equal(member.parameters?.[0].name, 'a');
+    assert.equal(member.parameters?.[0].description, 'Param a description');
+    assert.equal(member.parameters?.[0].summary, undefined);
+    assert.equal(member.parameters?.[0].type?.text, 'string');
+    assert.equal(member.parameters?.[0].default, undefined);
+    assert.equal(member.parameters?.[0].rest, false);
+    assert.equal(member.parameters?.[1].name, 'b');
+    assert.equal(member.parameters?.[1].description, 'Param b description');
+    assert.equal(member.parameters?.[1].type?.text, 'boolean');
+    assert.equal(member.parameters?.[1].optional, true);
+    assert.equal(member.parameters?.[1].default, 'false');
+    assert.equal(member.parameters?.[1].rest, false);
+    assert.equal(member.parameters?.[2].name, 'c');
+    assert.equal(member.parameters?.[2].description, 'Param c description');
+    assert.equal(member.parameters?.[2].summary, undefined);
+    assert.equal(member.parameters?.[2].type?.text, 'number[]');
+    assert.equal(member.parameters?.[2].optional, false);
+    assert.equal(member.parameters?.[2].default, undefined);
+    assert.equal(member.parameters?.[2].rest, true);
+    assert.equal(member.return?.type?.text, 'string');
+    assert.equal(
+      member.return?.description,
+      'Static method 1 return description'
+    );
+    assert.equal(member.deprecated, 'Static method 1 deprecated');
   });
 
   test.run();

--- a/packages/labs/analyzer/test-files/js/jsdoc/element-a.js
+++ b/packages/labs/analyzer/test-files/js/jsdoc/element-a.js
@@ -90,6 +90,27 @@ export class ElementA extends LitElement {
   method2(a, b = false, ...c) {
     return b ? a : c[0].toFixed();
   }
+
+  /**
+   * @summary Static class field 1 summary
+   * @description Static class field 1 description
+   * @protected
+   * @type {number | string}
+   */
+  static field1;
+
+  /**
+   * @summary Static method 1 summary
+   * @description Static method 1 description
+   * @param {string} a Param a description
+   * @param {boolean} b Param b description
+   * @param {number[]} c Param c description
+   * @returns {string} Static method 1 return description
+   * @deprecated Static method 1 deprecated
+   */
+  static method1(a, b = false, ...c) {
+    return b ? a : c[0].toFixed();
+  }
 }
 customElements.define('element-a', ElementA);
 

--- a/packages/labs/analyzer/test-files/ts/jsdoc/src/element-a.ts
+++ b/packages/labs/analyzer/test-files/ts/jsdoc/src/element-a.ts
@@ -86,6 +86,26 @@ export class ElementA extends LitElement {
   method2(a: string, b = false, ...c: number[]) {
     return b ? a : c[0].toFixed();
   }
+
+  /**
+   * @summary Static class field 1 summary
+   * @description Static class field 1 description
+   * @protected
+   */
+  static field1: number | string;
+
+  /**
+   * @summary Static method 1 summary
+   * @description Static method 1 description
+   * @param a Param a description
+   * @param b Param b description
+   * @param c Param c description
+   * @returns Static method 1 return description
+   * @deprecated Static method 1 deprecated
+   */
+  static method1(a: string, b = false, ...c: number[]) {
+    return b ? a : c[0].toFixed();
+  }
 }
 
 /**


### PR DESCRIPTION
We were previously storing class members (fields & methods) in a map by name (since field-lookup by name is expected to be a key use case), however this ignored the fact that static and non-static members would conflict.

This PR separates the storage into separate maps, and adds an `isStatic` optional argument to `getField()` and `getMethod()`.