### PR TITLE
[infra] Pin polyfill version for tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "@web/test-runner-mocha": "^0.7.5",
         "@web/test-runner-playwright": "^0.9.0",
         "@web/test-runner-saucelabs": "^0.8.0",
-        "@webcomponents/webcomponentsjs": "2.5.0",
+        "@webcomponents/webcomponentsjs": "2.6.0",
         "cross-env": "^7.0.3",
         "eslint": "^8.13.0",
         "eslint-plugin-import": "^2.26.0",
@@ -5769,9 +5769,9 @@
       "integrity": "sha512-ry84Vft6xtRBbd4M/ptRodbOLodV5AD15TYhyRghCRgIcJJKmYmJ2v2BaaWxygENwh6Uq3zTfGPmlckKT/GXsQ=="
     },
     "node_modules/@webcomponents/webcomponentsjs": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.5.0.tgz",
-      "integrity": "sha512-C0l51MWQZ9kLzcxOZtniOMohpIFdCLZum7/TEHv3XWFc1Fvt5HCpbSX84x8ltka/JuNKcuiDnxXFkiB2gaePcg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.6.0.tgz",
+      "integrity": "sha512-Moog+Smx3ORTbWwuPqoclr+uvfLnciVd6wdCaVscHPrxbmQ/IJKm3wbB7hpzJtXWjAq2l/6QMlO85aZiOdtv5Q==",
       "dev": true
     },
     "node_modules/@xmldom/xmldom": {
@@ -25227,7 +25227,7 @@
         "@types/diff": "^5.0.0",
         "@types/fs-extra": "^9.0.1",
         "@types/prettier": "^2.0.1",
-        "@webcomponents/webcomponentsjs": "2.5.0",
+        "@webcomponents/webcomponentsjs": "2.6.0",
         "diff": "^5.0.0",
         "dir-compare": "^4.0.0",
         "prettier": "^2.3.2"
@@ -27233,7 +27233,7 @@
         "@types/diff": "^5.0.0",
         "@types/fs-extra": "^9.0.1",
         "@types/prettier": "^2.0.1",
-        "@webcomponents/webcomponentsjs": "2.5.0",
+        "@webcomponents/webcomponentsjs": "2.6.0",
         "diff": "^5.0.0",
         "dir-compare": "^4.0.0",
         "prettier": "^2.3.2"
@@ -30207,9 +30207,9 @@
       "integrity": "sha512-ry84Vft6xtRBbd4M/ptRodbOLodV5AD15TYhyRghCRgIcJJKmYmJ2v2BaaWxygENwh6Uq3zTfGPmlckKT/GXsQ=="
     },
     "@webcomponents/webcomponentsjs": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.5.0.tgz",
-      "integrity": "sha512-C0l51MWQZ9kLzcxOZtniOMohpIFdCLZum7/TEHv3XWFc1Fvt5HCpbSX84x8ltka/JuNKcuiDnxXFkiB2gaePcg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.6.0.tgz",
+      "integrity": "sha512-Moog+Smx3ORTbWwuPqoclr+uvfLnciVd6wdCaVscHPrxbmQ/IJKm3wbB7hpzJtXWjAq2l/6QMlO85aZiOdtv5Q==",
       "dev": true
     },
     "@xmldom/xmldom": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@web/test-runner-mocha": "^0.7.5",
         "@web/test-runner-playwright": "^0.9.0",
         "@web/test-runner-saucelabs": "^0.8.0",
+        "@webcomponents/webcomponentsjs": "2.5.0",
         "cross-env": "^7.0.3",
         "eslint": "^8.13.0",
         "eslint-plugin-import": "^2.26.0",
@@ -5768,9 +5769,9 @@
       "integrity": "sha512-ry84Vft6xtRBbd4M/ptRodbOLodV5AD15TYhyRghCRgIcJJKmYmJ2v2BaaWxygENwh6Uq3zTfGPmlckKT/GXsQ=="
     },
     "node_modules/@webcomponents/webcomponentsjs": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.7.0.tgz",
-      "integrity": "sha512-j161Z9oiy8k74vchdrQGihfSp7QulrTclCUiPo0D7JF6/RjpXAmB0ThlTAFlSElkgqg0vdFgNAXaX9ZHZy25wQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.5.0.tgz",
+      "integrity": "sha512-C0l51MWQZ9kLzcxOZtniOMohpIFdCLZum7/TEHv3XWFc1Fvt5HCpbSX84x8ltka/JuNKcuiDnxXFkiB2gaePcg==",
       "dev": true
     },
     "node_modules/@xmldom/xmldom": {
@@ -24956,6 +24957,12 @@
         "tslib": "^2.0.3"
       }
     },
+    "packages/lit-element/node_modules/@webcomponents/webcomponentsjs": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.7.0.tgz",
+      "integrity": "sha512-j161Z9oiy8k74vchdrQGihfSp7QulrTclCUiPo0D7JF6/RjpXAmB0ThlTAFlSElkgqg0vdFgNAXaX9ZHZy25wQ==",
+      "dev": true
+    },
     "packages/lit-html": {
       "version": "2.6.1",
       "license": "BSD-3-Clause",
@@ -24970,6 +24977,12 @@
         "@webcomponents/template": "^1.4.4",
         "@webcomponents/webcomponentsjs": "^2.6.0"
       }
+    },
+    "packages/lit-html/node_modules/@webcomponents/webcomponentsjs": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.7.0.tgz",
+      "integrity": "sha512-j161Z9oiy8k74vchdrQGihfSp7QulrTclCUiPo0D7JF6/RjpXAmB0ThlTAFlSElkgqg0vdFgNAXaX9ZHZy25wQ==",
+      "dev": true
     },
     "packages/lit-starter-js": {
       "name": "@lit/lit-starter-js",
@@ -24999,6 +25012,12 @@
         "rollup-plugin-summary": "^1.4.3",
         "rollup-plugin-terser": "^7.0.2"
       }
+    },
+    "packages/lit-starter-js/node_modules/@webcomponents/webcomponentsjs": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.7.0.tgz",
+      "integrity": "sha512-j161Z9oiy8k74vchdrQGihfSp7QulrTclCUiPo0D7JF6/RjpXAmB0ThlTAFlSElkgqg0vdFgNAXaX9ZHZy25wQ==",
+      "dev": true
     },
     "packages/lit-starter-ts": {
       "name": "@lit/lit-starter-ts",
@@ -25030,6 +25049,18 @@
         "rollup-plugin-terser": "^7.0.2",
         "typescript": "~4.7.4"
       }
+    },
+    "packages/lit-starter-ts/node_modules/@webcomponents/webcomponentsjs": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.7.0.tgz",
+      "integrity": "sha512-j161Z9oiy8k74vchdrQGihfSp7QulrTclCUiPo0D7JF6/RjpXAmB0ThlTAFlSElkgqg0vdFgNAXaX9ZHZy25wQ==",
+      "dev": true
+    },
+    "packages/lit/node_modules/@webcomponents/webcomponentsjs": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.7.0.tgz",
+      "integrity": "sha512-j161Z9oiy8k74vchdrQGihfSp7QulrTclCUiPo0D7JF6/RjpXAmB0ThlTAFlSElkgqg0vdFgNAXaX9ZHZy25wQ==",
+      "dev": true
     },
     "packages/localize": {
       "name": "@lit/localize",
@@ -25183,6 +25214,12 @@
         "@webcomponents/webcomponentsjs": "^2.6.0"
       }
     },
+    "packages/reactive-element/node_modules/@webcomponents/webcomponentsjs": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.7.0.tgz",
+      "integrity": "sha512-j161Z9oiy8k74vchdrQGihfSp7QulrTclCUiPo0D7JF6/RjpXAmB0ThlTAFlSElkgqg0vdFgNAXaX9ZHZy25wQ==",
+      "dev": true
+    },
     "packages/tests": {
       "name": "@lit-internal/tests",
       "version": "0.0.0",
@@ -25195,12 +25232,6 @@
         "dir-compare": "^4.0.0",
         "prettier": "^2.3.2"
       }
-    },
-    "packages/tests/node_modules/@webcomponents/webcomponentsjs": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.5.0.tgz",
-      "integrity": "sha512-C0l51MWQZ9kLzcxOZtniOMohpIFdCLZum7/TEHv3XWFc1Fvt5HCpbSX84x8ltka/JuNKcuiDnxXFkiB2gaePcg==",
-      "dev": true
     },
     "packages/ts-transformers": {
       "name": "@lit/ts-transformers",
@@ -27206,14 +27237,6 @@
         "diff": "^5.0.0",
         "dir-compare": "^4.0.0",
         "prettier": "^2.3.2"
-      },
-      "dependencies": {
-        "@webcomponents/webcomponentsjs": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.5.0.tgz",
-          "integrity": "sha512-C0l51MWQZ9kLzcxOZtniOMohpIFdCLZum7/TEHv3XWFc1Fvt5HCpbSX84x8ltka/JuNKcuiDnxXFkiB2gaePcg==",
-          "dev": true
-        }
       }
     },
     "@lit-labs/analyzer": {
@@ -27508,6 +27531,14 @@
         "rollup": "^2.73.0",
         "rollup-plugin-summary": "^1.4.3",
         "rollup-plugin-terser": "^7.0.2"
+      },
+      "dependencies": {
+        "@webcomponents/webcomponentsjs": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.7.0.tgz",
+          "integrity": "sha512-j161Z9oiy8k74vchdrQGihfSp7QulrTclCUiPo0D7JF6/RjpXAmB0ThlTAFlSElkgqg0vdFgNAXaX9ZHZy25wQ==",
+          "dev": true
+        }
       }
     },
     "@lit/lit-starter-ts": {
@@ -27535,6 +27566,14 @@
         "rollup-plugin-summary": "^1.4.3",
         "rollup-plugin-terser": "^7.0.2",
         "typescript": "~4.7.4"
+      },
+      "dependencies": {
+        "@webcomponents/webcomponentsjs": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.7.0.tgz",
+          "integrity": "sha512-j161Z9oiy8k74vchdrQGihfSp7QulrTclCUiPo0D7JF6/RjpXAmB0ThlTAFlSElkgqg0vdFgNAXaX9ZHZy25wQ==",
+          "dev": true
+        }
       }
     },
     "@lit/localize": {
@@ -27607,6 +27646,14 @@
         "@webcomponents/shadycss": "^1.8.0",
         "@webcomponents/template": "^1.4.4",
         "@webcomponents/webcomponentsjs": "^2.6.0"
+      },
+      "dependencies": {
+        "@webcomponents/webcomponentsjs": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.7.0.tgz",
+          "integrity": "sha512-j161Z9oiy8k74vchdrQGihfSp7QulrTclCUiPo0D7JF6/RjpXAmB0ThlTAFlSElkgqg0vdFgNAXaX9ZHZy25wQ==",
+          "dev": true
+        }
       }
     },
     "@lit/ts-transformers": {
@@ -30160,9 +30207,9 @@
       "integrity": "sha512-ry84Vft6xtRBbd4M/ptRodbOLodV5AD15TYhyRghCRgIcJJKmYmJ2v2BaaWxygENwh6Uq3zTfGPmlckKT/GXsQ=="
     },
     "@webcomponents/webcomponentsjs": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.7.0.tgz",
-      "integrity": "sha512-j161Z9oiy8k74vchdrQGihfSp7QulrTclCUiPo0D7JF6/RjpXAmB0ThlTAFlSElkgqg0vdFgNAXaX9ZHZy25wQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.5.0.tgz",
+      "integrity": "sha512-C0l51MWQZ9kLzcxOZtniOMohpIFdCLZum7/TEHv3XWFc1Fvt5HCpbSX84x8ltka/JuNKcuiDnxXFkiB2gaePcg==",
       "dev": true
     },
     "@xmldom/xmldom": {
@@ -37378,6 +37425,14 @@
         "lit-element": "^3.2.0",
         "lit-html": "^2.6.0",
         "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "@webcomponents/webcomponentsjs": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.7.0.tgz",
+          "integrity": "sha512-j161Z9oiy8k74vchdrQGihfSp7QulrTclCUiPo0D7JF6/RjpXAmB0ThlTAFlSElkgqg0vdFgNAXaX9ZHZy25wQ==",
+          "dev": true
+        }
       }
     },
     "lit-analyzer": {
@@ -37567,6 +37622,14 @@
         "@webcomponents/webcomponentsjs": "^2.6.0",
         "lit-html": "^2.2.0",
         "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "@webcomponents/webcomponentsjs": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.7.0.tgz",
+          "integrity": "sha512-j161Z9oiy8k74vchdrQGihfSp7QulrTclCUiPo0D7JF6/RjpXAmB0ThlTAFlSElkgqg0vdFgNAXaX9ZHZy25wQ==",
+          "dev": true
+        }
       }
     },
     "lit-html": {
@@ -37579,6 +37642,14 @@
         "@webcomponents/shadycss": "^1.8.0",
         "@webcomponents/template": "^1.4.4",
         "@webcomponents/webcomponentsjs": "^2.6.0"
+      },
+      "dependencies": {
+        "@webcomponents/webcomponentsjs": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.7.0.tgz",
+          "integrity": "sha512-j161Z9oiy8k74vchdrQGihfSp7QulrTclCUiPo0D7JF6/RjpXAmB0ThlTAFlSElkgqg0vdFgNAXaX9ZHZy25wQ==",
+          "dev": true
+        }
       }
     },
     "load-json-file": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25190,11 +25190,17 @@
         "@types/diff": "^5.0.0",
         "@types/fs-extra": "^9.0.1",
         "@types/prettier": "^2.0.1",
-        "@webcomponents/webcomponentsjs": "^2.6.0",
+        "@webcomponents/webcomponentsjs": "2.5.0",
         "diff": "^5.0.0",
         "dir-compare": "^4.0.0",
         "prettier": "^2.3.2"
       }
+    },
+    "packages/tests/node_modules/@webcomponents/webcomponentsjs": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.5.0.tgz",
+      "integrity": "sha512-C0l51MWQZ9kLzcxOZtniOMohpIFdCLZum7/TEHv3XWFc1Fvt5HCpbSX84x8ltka/JuNKcuiDnxXFkiB2gaePcg==",
+      "dev": true
     },
     "packages/ts-transformers": {
       "name": "@lit/ts-transformers",
@@ -27196,10 +27202,18 @@
         "@types/diff": "^5.0.0",
         "@types/fs-extra": "^9.0.1",
         "@types/prettier": "^2.0.1",
-        "@webcomponents/webcomponentsjs": "^2.6.0",
+        "@webcomponents/webcomponentsjs": "2.5.0",
         "diff": "^5.0.0",
         "dir-compare": "^4.0.0",
         "prettier": "^2.3.2"
+      },
+      "dependencies": {
+        "@webcomponents/webcomponentsjs": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.5.0.tgz",
+          "integrity": "sha512-C0l51MWQZ9kLzcxOZtniOMohpIFdCLZum7/TEHv3XWFc1Fvt5HCpbSX84x8ltka/JuNKcuiDnxXFkiB2gaePcg==",
+          "dev": true
+        }
       }
     },
     "@lit-labs/analyzer": {

--- a/package.json
+++ b/package.json
@@ -198,6 +198,7 @@
     "@web/test-runner-mocha": "^0.7.5",
     "@web/test-runner-playwright": "^0.9.0",
     "@web/test-runner-saucelabs": "^0.8.0",
+    "@webcomponents/webcomponentsjs": "2.5.0",
     "cross-env": "^7.0.3",
     "eslint": "^8.13.0",
     "eslint-plugin-import": "^2.26.0",

--- a/package.json
+++ b/package.json
@@ -198,7 +198,7 @@
     "@web/test-runner-mocha": "^0.7.5",
     "@web/test-runner-playwright": "^0.9.0",
     "@web/test-runner-saucelabs": "^0.8.0",
-    "@webcomponents/webcomponentsjs": "2.5.0",
+    "@webcomponents/webcomponentsjs": "2.6.0",
     "cross-env": "^7.0.3",
     "eslint": "^8.13.0",
     "eslint-plugin-import": "^2.26.0",

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -11,7 +11,7 @@
     "@types/diff": "^5.0.0",
     "@types/fs-extra": "^9.0.1",
     "@types/prettier": "^2.0.1",
-    "@webcomponents/webcomponentsjs": "2.5.0",
+    "@webcomponents/webcomponentsjs": "2.6.0",
     "diff": "^5.0.0",
     "dir-compare": "^4.0.0",
     "prettier": "^2.3.2"

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -8,10 +8,10 @@
     "test": "wireit"
   },
   "devDependencies": {
-    "@types/prettier": "^2.0.1",
     "@types/diff": "^5.0.0",
     "@types/fs-extra": "^9.0.1",
-    "@webcomponents/webcomponentsjs": "^2.6.0",
+    "@types/prettier": "^2.0.1",
+    "@webcomponents/webcomponentsjs": "2.5.0",
     "diff": "^5.0.0",
     "dir-compare": "^4.0.0",
     "prettier": "^2.3.2"

--- a/packages/tests/src/web-test-runner.config.ts
+++ b/packages/tests/src/web-test-runner.config.ts
@@ -199,7 +199,7 @@ const config: TestRunnerConfig = {
         webcomponents: false,
         custom: [
           {
-            name: 'webcomponents-2.5.0',
+            name: 'webcomponents-2.6.0',
             path: require.resolve(
               '@webcomponents/webcomponentsjs/webcomponents-bundle.js'
             ),


### PR DESCRIPTION
IE sauce tests have been failing since the polyfill version was updated. This PR pins the version to the one listed in our WTR config file here: https://github.com/lit/lit/blob/1726e236d4d842b56ec1c26b276a9081961a152c/packages/tests/src/web-test-runner.config.ts#L202

We may want to investigate why the test fails with the newer version though.