### PR TITLE
[infra] Bump wireit version from 0.9.3 to 0.9.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "rollup-plugin-terser": "^7.0.2",
         "typescript": "~4.7.4",
         "uvu": "^0.5.6",
-        "wireit": "^0.9.3"
+        "wireit": "^0.9.5"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -24036,9 +24036,9 @@
       }
     },
     "node_modules/wireit": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.9.4.tgz",
-      "integrity": "sha512-QGDxePp956+tBXFAKt/1+cBwfUdCQ23+AcGnjmdTN/9GfkNqiHwfq6n7HyoYEx08tmN6K/faEozkLcMIllhVVg==",
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.9.5.tgz",
+      "integrity": "sha512-dKKNAwLxQjbPPMrltPxMUFKvLy2z6hlVjvR/qitvPm8GEQyb/1QYBG7ObvOQLsi95uAXpkWLJXBYkCKeVcMVgA==",
       "dev": true,
       "dependencies": {
         "braces": "^3.0.2",
@@ -44274,9 +44274,9 @@
       }
     },
     "wireit": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.9.4.tgz",
-      "integrity": "sha512-QGDxePp956+tBXFAKt/1+cBwfUdCQ23+AcGnjmdTN/9GfkNqiHwfq6n7HyoYEx08tmN6K/faEozkLcMIllhVVg==",
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.9.5.tgz",
+      "integrity": "sha512-dKKNAwLxQjbPPMrltPxMUFKvLy2z6hlVjvR/qitvPm8GEQyb/1QYBG7ObvOQLsi95uAXpkWLJXBYkCKeVcMVgA==",
       "dev": true,
       "requires": {
         "braces": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -214,7 +214,7 @@
     "rollup-plugin-terser": "^7.0.2",
     "typescript": "~4.7.4",
     "uvu": "^0.5.6",
-    "wireit": "^0.9.3"
+    "wireit": "^0.9.5"
   },
   "lint-staged": {
     "**/*.{cjs,html,js,json,md,ts}": "prettier --write",


### PR DESCRIPTION
Relevant changelog entries from https://github.com/google/wireit/blob/main/CHANGELOG.md

## [0.9.5] - 2023-02-06

### Changed

- Better attribute socket errors, and don't crash when a socket is closed
  unexpectedly.

### Fixed

- Fixed infinite loops that could occur in watch mode when a script failed, but
  still emitted output that was configured as the input files for another
  script.

- Don't clear the console or emit "no-op" style log messages in watch mode for
  iterations that don't do anything useful.

## [0.9.4] - 2023-01-30

### Changed

- It is now allowed to define a wireit script without a corresponding entry in
  the `scripts` section. Such scripts cannot be directly invoked with `npm run
  <script>` or similar, but they can still be used as dependencies by other
  wireit scripts.