### PR TITLE
[infra] Don't run sauce SSR tests in parallel

### DIFF
--- a/.github/workflows/sauce-ie11.yaml
+++ b/.github/workflows/sauce-ie11.yaml
@@ -46,6 +46,8 @@ jobs:
         env:
           SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
           SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
+          # Sauce does not like multiple instances to be launched simultaneously
+          WIREIT_PARALLEL: 1
         run: |
           cd packages/labs/ssr
           npm run test:integration

--- a/.github/workflows/sauce.yaml
+++ b/.github/workflows/sauce.yaml
@@ -46,6 +46,8 @@ jobs:
         env:
           SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
           SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
+          # Sauce does not like multiple instances to be launched simultaneously
+          WIREIT_PARALLEL: 1
         run: |
           cd packages/labs/ssr
           npm run test:integration


### PR DESCRIPTION
To alleviate ETXTBSY errors or timeouts due to multiple sauce tests being run simultaneously.