### PR TITLE
Multihosted Controllers

### DIFF
--- a/.changeset/brown-rivers-perform.md
+++ b/.changeset/brown-rivers-perform.md
@@ -1,0 +1,5 @@
+---
+'@lit/reactive-element': patch
+---
+
+MultiHosted Controller support

--- a/packages/reactive-element/src/reactive-controller.ts
+++ b/packages/reactive-element/src/reactive-controller.ts
@@ -56,7 +56,7 @@ export interface ReactiveController {
    * element hosts, this corresponds to the `connectedCallback()` lifecycle,
    * which is only called when the component is connected to the document.
    */
-  hostConnected?(): void;
+  hostConnected?(host: ReactiveControllerHost): void;
 
   /**
    * Called when the host is disconnected from the component tree. For custom
@@ -64,7 +64,7 @@ export interface ReactiveController {
    * which is called the host or an ancestor component is disconnected from the
    * document.
    */
-  hostDisconnected?(): void;
+  hostDisconnected?(host: ReactiveControllerHost): void;
 
   /**
    * Called during the client-side host update, just before the host calls
@@ -73,12 +73,12 @@ export interface ReactiveController {
    * Code in `update()` can depend on the DOM as it is not called in
    * server-side rendering.
    */
-  hostUpdate?(): void;
+  hostUpdate?(host: ReactiveControllerHost): void;
 
   /**
    * Called after a host update, just before the host calls firstUpdated and
    * updated. It is not called in server-side rendering.
    *
    */
-  hostUpdated?(): void;
+  hostUpdated?(host: ReactiveControllerHost): void;
 }

--- a/packages/reactive-element/src/reactive-element.ts
+++ b/packages/reactive-element/src/reactive-element.ts
@@ -967,7 +967,7 @@ export abstract class ReactiveElement
     // (which is set in connectedCallback) to avoid the need to track a
     // first connected state.
     if (this.renderRoot !== undefined && this.isConnected) {
-      controller.hostConnected?.();
+      controller.hostConnected?.(this);
     }
   }
 
@@ -1043,7 +1043,7 @@ export abstract class ReactiveElement
       ).renderRoot = this.createRenderRoot();
     }
     this.enableUpdating(true);
-    this.__controllers?.forEach((c) => c.hostConnected?.());
+    this.__controllers?.forEach((c) => c.hostConnected?.(this));
   }
 
   /**
@@ -1061,7 +1061,7 @@ export abstract class ReactiveElement
    * @category lifecycle
    */
   disconnectedCallback() {
-    this.__controllers?.forEach((c) => c.hostDisconnected?.());
+    this.__controllers?.forEach((c) => c.hostDisconnected?.(this));
   }
 
   /**
@@ -1327,7 +1327,7 @@ export abstract class ReactiveElement
       shouldUpdate = this.shouldUpdate(changedProperties);
       if (shouldUpdate) {
         this.willUpdate(changedProperties);
-        this.__controllers?.forEach((c) => c.hostUpdate?.());
+        this.__controllers?.forEach((c) => c.hostUpdate?.(this));
         this.update(changedProperties);
       } else {
         this.__markUpdated();
@@ -1372,7 +1372,7 @@ export abstract class ReactiveElement
   // Note, this is an override point for polyfill-support.
   // @internal
   _$didUpdate(changedProperties: PropertyValues) {
-    this.__controllers?.forEach((c) => c.hostUpdated?.());
+    this.__controllers?.forEach((c) => c.hostUpdated?.(this));
     if (!this.hasUpdated) {
       this.hasUpdated = true;
       this.firstUpdated(changedProperties);


### PR DESCRIPTION
This update allows two things:
- writing controllers with multihost capability
- create a controller, add and remove hosts later

E.g.
```ts
/** MyController.ts */

class MyController implements ReactiveController {
  private _hosts: ReactiveControllerHost[];

  addHost(host) {
    host.addController(this);
  }

  hostConnected(host) {
    (this._hosts ??= []).push(host);
  }

  hostDisconnected(host) {
    this._hosts?.splice(this._hosts.indexOf(host) >>> 0, 1);
  }

  updateAll() {
    this._hosts?.forEach((host) => host.requestUpdate());
  }
}

// pre-defined
export const myController = new MyController()
```

And then, in a custom element:


```ts
/** my-element.ts */

import { myController } from './MyController.ts';

@customElement('my-element')
class MyElement extends LitElement {
  constructor() {
    super();
    myController.addHost(this)
  }
}
```