### PR TITLE
Fix change-in-update warning from Tasks

### DIFF
--- a/.changeset/fast-apes-cross.md
+++ b/.changeset/fast-apes-cross.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/task': minor
+---
+
+Tasks now run on hostUpdate() instead of hostUpdated()

--- a/.changeset/fast-apes-cross.md
+++ b/.changeset/fast-apes-cross.md
@@ -2,4 +2,4 @@
 '@lit-labs/task': minor
 ---
 
-Tasks now run on hostUpdate() instead of hostUpdated()
+Fix the change-in-update warning from Tasks by delaying the initial host update

--- a/packages/labs/task/src/task.ts
+++ b/packages/labs/task/src/task.ts
@@ -31,7 +31,7 @@ export const TaskStatus = {
  */
 export const initialState = Symbol();
 
-export type TaskStatus = typeof TaskStatus[keyof typeof TaskStatus];
+export type TaskStatus = (typeof TaskStatus)[keyof typeof TaskStatus];
 
 export type StatusRenderer<R> = {
   initial?: () => unknown;
@@ -159,7 +159,7 @@ export class Task<
     });
   }
 
-  hostUpdated() {
+  hostUpdate() {
     this.performTask();
   }
 

--- a/packages/labs/task/src/task.ts
+++ b/packages/labs/task/src/task.ts
@@ -159,7 +159,7 @@ export class Task<
     });
   }
 
-  hostUpdate() {
+  hostUpdated() {
     this.performTask();
   }
 
@@ -203,8 +203,11 @@ export class Task<
     this.status = TaskStatus.PENDING;
     let result!: R | typeof initialState;
     let error: unknown;
-    // Request an update to report pending state.
-    this._host.requestUpdate();
+
+    // Request an update to report pending state. Do this in a
+    // microtask to avoid the change-in-update warning
+    queueMicrotask(() => this._host.requestUpdate());
+
     const key = ++this._callId;
     try {
       result = await this._task(args!);

--- a/packages/labs/task/src/test/task_test.ts
+++ b/packages/labs/task/src/test/task_test.ts
@@ -10,14 +10,6 @@ import {initialState, Task, TaskStatus, TaskConfig} from '@lit-labs/task';
 import {generateElementName, nextFrame} from './test-helpers.js';
 import {assert} from '@esm-bundle/chai';
 
-// Note, since tests are not built with production support, detect DEV_MODE
-// by checking if warning API is available.
-const DEV_MODE = !!ReactiveElement.enableWarning;
-
-if (DEV_MODE) {
-  ReactiveElement.disableWarning?.('change-in-update');
-}
-
 suite('Task', () => {
   let container: HTMLElement;
 
@@ -92,9 +84,29 @@ suite('Task', () => {
 
   const tasksUpdateComplete = nextFrame;
 
+  let warnMessages: Array<string>;
+  const originalConsoleWarn = console.warn;
+
+  suiteSetup(() => {
+    // Patch console.warn to check warnings
+    console.warn = (...args) => {
+      warnMessages.push(args.join(' '));
+      return originalConsoleWarn.apply(console, args);
+    };
+  });
+
+  suiteTeardown(() => {
+    // Un-patch console.warn
+    console.warn = originalConsoleWarn;
+  });
+
   setup(async () => {
     container = document.createElement('div');
     document.body.appendChild(container);
+    warnMessages = [];
+
+    // Individual tests can enable the warning
+    // ReactiveElement.disableWarning?.('change-in-update');
   });
 
   teardown(() => {
@@ -527,5 +539,22 @@ suite('Task', () => {
     assert.equal(el.task.status, TaskStatus.ERROR);
     assert.equal(numOnErrorInvocations, 1);
     assert.equal(lastOnErrorResult, 'error2');
+  });
+
+  test('no update warning', async () => {
+    ReactiveElement.enableWarning?.('change-in-update');
+    let numInvocations = 0;
+
+    const el = getTestElement({
+      args: () => [1],
+      onComplete: () => {
+        numInvocations++;
+      },
+    });
+    await renderElement(el);
+    el.resolveTask();
+    await tasksUpdateComplete();
+    assert.equal(numInvocations, 1);
+    assert.equal(warnMessages.length, 0);
   });
 });


### PR DESCRIPTION
Fixes #3566 

The fix is to call the initial `host.requestUpdate()` (which is there to get the element to update and see the PENDING state of the task) in a microtask, so that it goes after the change-in-update check.