### PR TITLE
Feat: Avoid Script Injection Risks on Github Action Workflows

### DIFF
--- a/.github/workflows/release-image.yaml
+++ b/.github/workflows/release-image.yaml
@@ -33,11 +33,11 @@ jobs:
         run: npm run build
 
       - name: Create release image
+        env:
+          BODY: ${{ github.event.pull_request.body }}
         run: |
           # Store the PR body contents containing the changelog in 'release.md'
-          cat <<'EOF' > release.md
-          ${{ github.event.pull_request.body }}
-          EOF
+          echo "$BODY" > release.md
           # Only render the pull request content including and after the "#
           # Releases" heading.
           node_modules/.bin/release-image -m <(sed -n '/# Releases/,$p' release.md)


### PR DESCRIPTION
Closes #3668 

Here is one of the solutions, suggested by the [GIthub Security Guides](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections).