### PR TITLE
[localize] Fix handling of nested HTML

### DIFF
--- a/.changeset/mighty-hornets-explain.md
+++ b/.changeset/mighty-hornets-explain.md
@@ -1,0 +1,5 @@
+---
+'@lit/localize-tools': patch
+---
+
+Fix incorrect extraction of html embedded within html

--- a/packages/localize-tools/src/tests/transform.unit.test.ts
+++ b/packages/localize-tools/src/tests/transform.unit.test.ts
@@ -274,32 +274,31 @@ test('multiple expression-placeholders and order switching', () => {
   );
 });
 
-// TODO(aomarks) Uncomment with fix for #2426
-// test('msg(html(html))', () => {
-//   checkTransform(
-//     'msg(html`Hello <b>${html`<i>World</i>`}</b>!`, {id: "foo"});',
-//     'html`Hello <b><i>World</i></b>!`;'
-//   );
-// });
+test('msg(html(html))', () => {
+  checkTransform(
+    'msg(html`Hello <b>${html`<i>World</i>`}</b>!`, {id: "foo"});',
+    'html`Hello <b><i>World</i></b>!`;'
+  );
+});
 
-// test('msg(html(html)) translated', () => {
-//   checkTransform(
-//     'msg(html`Hello <b>${html`<i>World</i>`}</b>!`, {id: "foo"});',
-//     'html`Hola <b><i>World</i></b>!`;',
-//     {
-//       messages: [
-//         {
-//           name: 'foo',
-//           contents: [
-//             'Hola ',
-//             {untranslatable: '<b>${html`<i>World</i>`}</b>', index: 0},
-//             '!',
-//           ],
-//         },
-//       ],
-//     }
-//   );
-// });
+test('msg(html(html)) translated', () => {
+  checkTransform(
+    'msg(html`Hello <b>${html`<i>World</i>`}</b>!`, {id: "foo"});',
+    'html`Hola <b><i>World</i></b>!`;',
+    {
+      messages: [
+        {
+          name: 'foo',
+          contents: [
+            'Hola ',
+            {untranslatable: '<b>${html`<i>World</i>`}</b>', index: 0},
+            '!',
+          ],
+        },
+      ],
+    }
+  );
+});
 
 test('msg(string(msg(string)))', () => {
   checkTransform(

--- a/packages/localize-tools/testdata/extract-xliff-fresh/goldens/data/xliff/es-419.xlf
+++ b/packages/localize-tools/testdata/extract-xliff-fresh/goldens/data/xliff/es-419.xlf
@@ -5,6 +5,9 @@
 <trans-unit id="h02c268d9b1fcb031">
   <source>&lt;Hello<x id="0" equiv-text="&lt;b&gt;"/>&lt;World &amp; Friends&gt;<x id="1" equiv-text="&lt;/b&gt;"/>!&gt;</source>
 </trans-unit>
+<trans-unit id="h82ccc38d4d46eaa9">
+  <source>Hello <x id="0" equiv-text="&lt;b&gt;${html `&lt;i&gt;World&lt;/i&gt;`}&lt;/b&gt;"/>!</source>
+</trans-unit>
 <trans-unit id="he7b474847636149b">
   <source>Hello <x id="0" equiv-text="&lt;b&gt;${name}"/>!<x id="1" equiv-text="&lt;/b&gt;"/></source>
   <note from="lit-localize">Description of Hello $(name)</note>

--- a/packages/localize-tools/testdata/extract-xliff-fresh/goldens/data/xliff/zh_CN.xlf
+++ b/packages/localize-tools/testdata/extract-xliff-fresh/goldens/data/xliff/zh_CN.xlf
@@ -5,6 +5,9 @@
 <trans-unit id="h02c268d9b1fcb031">
   <source>&lt;Hello<x id="0" equiv-text="&lt;b&gt;"/>&lt;World &amp; Friends&gt;<x id="1" equiv-text="&lt;/b&gt;"/>!&gt;</source>
 </trans-unit>
+<trans-unit id="h82ccc38d4d46eaa9">
+  <source>Hello <x id="0" equiv-text="&lt;b&gt;${html `&lt;i&gt;World&lt;/i&gt;`}&lt;/b&gt;"/>!</source>
+</trans-unit>
 <trans-unit id="he7b474847636149b">
   <source>Hello <x id="0" equiv-text="&lt;b&gt;${name}"/>!<x id="1" equiv-text="&lt;/b&gt;"/></source>
   <note from="lit-localize">Description of Hello $(name)</note>

--- a/packages/localize-tools/testdata/extract-xliff-fresh/goldens/foo.ts
+++ b/packages/localize-tools/testdata/extract-xliff-fresh/goldens/foo.ts
@@ -14,3 +14,6 @@ msg(html`Hello <b>${name}!</b>`, {desc: 'Description of Hello $(name)'});
 
 // Escaped markup characters should remain escaped
 msg(html`&lt;Hello<b>&lt;World &amp; Friends&gt;</b>!&gt;`);
+
+// A localized Lit template that contains a nested Lit template.
+msg(html`Hello <b>${html`<i>World</i>`}</b>!`);

--- a/packages/localize-tools/testdata/extract-xliff-fresh/input/foo.ts
+++ b/packages/localize-tools/testdata/extract-xliff-fresh/input/foo.ts
@@ -14,3 +14,6 @@ msg(html`Hello <b>${name}!</b>`, {desc: 'Description of Hello $(name)'});
 
 // Escaped markup characters should remain escaped
 msg(html`&lt;Hello<b>&lt;World &amp; Friends&gt;</b>!&gt;`);
+
+// A localized Lit template that contains a nested Lit template.
+msg(html`Hello <b>${html`<i>World</i>`}</b>!`);


### PR DESCRIPTION
Fixes handling of nested html-tagged template expressions in lit localize analysis.

For example, the following example was analyzed incorrectly:

```ts
msg(html`Hello <b>${html`<i>World</i>`}</b>!`);
```

We combine runs of HTML markup and expressions so that we have fewer placeholders during translation, so we pass the template through an HTML parser, nested expressions and all. The problem was that if the nested expressions contained HTML, those would get parsed as part of the outer message, which would corrupt the analyzed template. The fix was to replace nested expressions with placeholders (the index) during HTML parsing (because we don't need the HTML parser to see the contents of expressions at all) and then substitute the original expression back after HTML parsing.

Fixes https://github.com/lit/lit/issues/2426