### PR TITLE
fix for globalThis on iOS 11

### DIFF
--- a/packages/lit-element/src/lit-element.ts
+++ b/packages/lit-element/src/lit-element.ts
@@ -54,6 +54,8 @@ export * from 'lit-html';
 import {LitUnstable} from 'lit-html';
 import {ReactiveUnstable} from '@lit/reactive-element';
 
+typeof window === 'undefined' || (window['globalThis'] = window); // fix for iOS 11
+
 /**
  * Contains types that are part of the unstable debug API.
  *


### PR DESCRIPTION
`globalThis` is not defined on older ipads, this PR fixes it