### PR TITLE
[reactive-element] Only use symbol keys for properties added as private storage.

### DIFF
--- a/packages/reactive-element/src/decorators/query.ts
+++ b/packages/reactive-element/src/decorators/query.ts
@@ -14,6 +14,8 @@
 import {ReactiveElement} from '../reactive-element.js';
 import {decorateProperty} from './base.js';
 
+const DEV_MODE = true;
+
 /**
  * A property decorator that converts a class property into a getter that
  * executes a querySelector on the element's renderRoot.
@@ -41,7 +43,7 @@ import {decorateProperty} from './base.js';
  */
 export function query(selector: string, cache?: boolean) {
   return decorateProperty({
-    descriptor: (_name: PropertyKey) => {
+    descriptor: (name: PropertyKey) => {
       const descriptor = {
         get(this: ReactiveElement) {
           return this.renderRoot?.querySelector(selector) ?? null;
@@ -50,7 +52,9 @@ export function query(selector: string, cache?: boolean) {
         configurable: true,
       };
       if (cache) {
-        const key = Symbol();
+        const key = DEV_MODE
+          ? Symbol(`${String(name)} (@query() cache)`)
+          : Symbol();
         descriptor.get = function (this: ReactiveElement) {
           if (
             (this as unknown as {[key: symbol]: Element | null})[key] ===

--- a/packages/reactive-element/src/decorators/query.ts
+++ b/packages/reactive-element/src/decorators/query.ts
@@ -41,7 +41,7 @@ import {decorateProperty} from './base.js';
  */
 export function query(selector: string, cache?: boolean) {
   return decorateProperty({
-    descriptor: (name: PropertyKey) => {
+    descriptor: (_name: PropertyKey) => {
       const descriptor = {
         get(this: ReactiveElement) {
           return this.renderRoot?.querySelector(selector) ?? null;
@@ -50,20 +50,16 @@ export function query(selector: string, cache?: boolean) {
         configurable: true,
       };
       if (cache) {
-        const key = typeof name === 'symbol' ? Symbol() : `__${name}`;
+        const key = Symbol();
         descriptor.get = function (this: ReactiveElement) {
           if (
-            (this as unknown as {[key: string]: Element | null})[
-              key as string
-            ] === undefined
+            (this as unknown as {[key: symbol]: Element | null})[key] ===
+            undefined
           ) {
-            (this as unknown as {[key: string]: Element | null})[
-              key as string
-            ] = this.renderRoot?.querySelector(selector) ?? null;
+            (this as unknown as {[key: symbol]: Element | null})[key] =
+              this.renderRoot?.querySelector(selector) ?? null;
           }
-          return (this as unknown as {[key: string]: Element | null})[
-            key as string
-          ];
+          return (this as unknown as {[key: symbol]: Element | null})[key];
         };
       }
       return descriptor;

--- a/packages/reactive-element/src/reactive-element.ts
+++ b/packages/reactive-element/src/reactive-element.ts
@@ -642,7 +642,10 @@ export abstract class ReactiveElement
     // user-defined accessors. Note that if the super has an accessor we will
     // still overwrite it
     if (!options.noAccessor && !this.prototype.hasOwnProperty(name)) {
-      const descriptor = this.getPropertyDescriptor(name, Symbol(), options);
+      const key = DEV_MODE
+        ? Symbol(`${String(name)} (@property() cache)`)
+        : Symbol();
+      const descriptor = this.getPropertyDescriptor(name, key, options);
       if (descriptor !== undefined) {
         Object.defineProperty(this.prototype, name, descriptor);
         if (DEV_MODE) {

--- a/packages/reactive-element/src/reactive-element.ts
+++ b/packages/reactive-element/src/reactive-element.ts
@@ -642,8 +642,7 @@ export abstract class ReactiveElement
     // user-defined accessors. Note that if the super has an accessor we will
     // still overwrite it
     if (!options.noAccessor && !this.prototype.hasOwnProperty(name)) {
-      const key = typeof name === 'symbol' ? Symbol() : `__${name}`;
-      const descriptor = this.getPropertyDescriptor(name, key, options);
+      const descriptor = this.getPropertyDescriptor(name, Symbol(), options);
       if (descriptor !== undefined) {
         Object.defineProperty(this.prototype, name, descriptor);
         if (DEV_MODE) {

--- a/packages/reactive-element/src/test/reactive-element_test.ts
+++ b/packages/reactive-element/src/test/reactive-element_test.ts
@@ -1294,6 +1294,39 @@ suite('ReactiveElement', () => {
     assert.isTrue(el.hasAttribute('bar'));
   });
 
+  test('Internal storage for `@property` does not collide with other properties', async () => {
+    let changed = 0;
+
+    const hasChanged = () => {
+      changed++;
+      return true;
+    };
+
+    class E extends ReactiveElement {
+      static override get properties(): PropertyDeclarations {
+        return {foo: {hasChanged}};
+      }
+
+      foo: number;
+      __foo: number;
+
+      constructor() {
+        super();
+        this.foo = 111;
+        this.__foo = 222;
+      }
+    }
+
+    customElements.define(generateElementName(), E);
+    const el = new E();
+    container.appendChild(el);
+    el.foo = 333;
+    await el.updateComplete;
+    assert.equal(changed, 2);
+    assert.equal(el.foo, 333);
+    assert.equal(el.__foo, 222);
+  });
+
   test('`firstUpdated` called when element first updates', async () => {
     class E extends ReactiveElement {
       static override properties = {foo: {}};

--- a/packages/reactive-element/src/test/reactive-element_test.ts
+++ b/packages/reactive-element/src/test/reactive-element_test.ts
@@ -1286,13 +1286,11 @@ suite('ReactiveElement', () => {
     await el.updateComplete;
     assert.equal(changed, 1);
     assert.equal(el.foo, 20);
-    assert.equal(el.__foo, 20);
     assert.isFalse(el.hasAttribute('foo'));
     el.bar = 'hi';
     await el.updateComplete;
     assert.equal(changed, 2);
     assert.equal(el.bar, 'hi');
-    assert.equal(el.__bar, 'hi');
     assert.isTrue(el.hasAttribute('bar'));
   });
 


### PR DESCRIPTION
Fixes #3690.