### PR TITLE
Ignore `/examples/` when lint-staged runs eslint.

### DIFF
--- a/package.json
+++ b/package.json
@@ -226,6 +226,6 @@
   },
   "lint-staged": {
     "**/*.{cjs,html,js,json,md,ts}": "prettier --write",
-    "**/*.{js,ts}": "eslint --ignore-pattern=examples/ --fix"
+    "{*.{js,ts},!(examples)/**/*.{js,ts}}": "eslint --fix"
   }
 }


### PR DESCRIPTION
eslint doesn't apply `--ignore-pattern` to any full paths passed to it but lint-staged *only* passes full paths. This replaces the eslint `--ignore-pattern` option with a more specific lint-staged glob.