### PR TITLE
[labs/analyzer] Parse ctor-defined fields as ClassField instead of ReactiveProperty

### DIFF
--- a/.changeset/poor-hornets-act.md
+++ b/.changeset/poor-hornets-act.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/analyzer': minor
+---
+
+Moved analysis of class fields that only have constructor initializers from ReactiveProperty to ClassField analysis, and removed type field from ReactiveProperty model, since this is already covered by ClassField.

--- a/packages/labs/analyzer/src/lib/lit-element/lit-element.ts
+++ b/packages/labs/analyzer/src/lib/lit-element/lit-element.ts
@@ -33,7 +33,7 @@ export const getLitElementDeclaration = (
     // TODO(kschaaf): support anonymous class expressions when assigned to a const
     name: declaration.name?.text ?? '',
     node: declaration,
-    reactiveProperties: getProperties(declaration, analyzer),
+    reactiveProperties: getProperties(declaration),
     ...getJSDocData(declaration, analyzer),
     getHeritage: () => getHeritage(declaration, analyzer),
     ...getClassMembers(declaration, analyzer),

--- a/packages/labs/analyzer/src/lib/lit-element/properties.ts
+++ b/packages/labs/analyzer/src/lib/lit-element/properties.ts
@@ -12,16 +12,12 @@
 
 import ts from 'typescript';
 import {LitClassDeclaration} from './lit-element.js';
-import {ReactiveProperty, AnalyzerInterface} from '../model.js';
-import {getTypeForNode} from '../types.js';
+import {ReactiveProperty} from '../model.js';
 import {getPropertyDecorator, getPropertyOptions} from './decorators.js';
 import {DiagnosticsError} from '../errors.js';
 import {hasStaticModifier} from '../utils.js';
 
-export const getProperties = (
-  classDeclaration: LitClassDeclaration,
-  analyzer: AnalyzerInterface
-) => {
+export const getProperties = (classDeclaration: LitClassDeclaration) => {
   const reactiveProperties = new Map<string, ReactiveProperty>();
   const undecoratedProperties = new Map<string, ts.Node>();
 
@@ -45,7 +41,6 @@ export const getProperties = (
       const options = getPropertyOptions(propertyDecorator);
       reactiveProperties.set(name, {
         name,
-        type: getTypeForNode(prop, analyzer),
         attribute: getPropertyAttribute(options, name),
         typeOption: getPropertyType(options),
         reflect: getPropertyReflect(options),
@@ -68,13 +63,7 @@ export const getProperties = (
 
   // Handle static properties block (initializer or getter).
   if (staticProperties !== undefined) {
-    addPropertiesFromStaticBlock(
-      classDeclaration,
-      staticProperties,
-      undecoratedProperties,
-      reactiveProperties,
-      analyzer
-    );
+    addPropertiesFromStaticBlock(staticProperties, reactiveProperties);
   }
 
   return reactiveProperties;
@@ -85,18 +74,9 @@ export const getProperties = (
  * options to the provided `reactiveProperties` map.
  */
 const addPropertiesFromStaticBlock = (
-  classDeclaration: LitClassDeclaration,
   properties: ts.PropertyDeclaration | ts.GetAccessorDeclaration,
-  undecoratedProperties: Map<string, ts.Node>,
-  reactiveProperties: Map<string, ReactiveProperty>,
-  analyzer: AnalyzerInterface
+  reactiveProperties: Map<string, ReactiveProperty>
 ) => {
-  // Add any constructor initializers to the undecorated properties node map
-  // from which we can infer types from. This is the primary path that JS source
-  // can get their inferred types (in TS, types will come from the undecorated
-  // fields passed in, since you need to declare the field to assign it in the
-  // constructor).
-  addConstructorInitializers(classDeclaration, undecoratedProperties);
   // Find the object literal from the initializer or getter return value
   const object = getStaticPropertiesObjectLiteral(properties);
   // Loop over each key/value in the object and add them to the map
@@ -108,13 +88,8 @@ const addPropertiesFromStaticBlock = (
     ) {
       const name = prop.name.text;
       const options = prop.initializer;
-      const nodeForType = undecoratedProperties.get(name);
       reactiveProperties.set(name, {
         name,
-        type:
-          nodeForType !== undefined
-            ? getTypeForNode(nodeForType, analyzer)
-            : undefined,
         attribute: getPropertyAttribute(options, name),
         typeOption: getPropertyType(options),
         reflect: getPropertyReflect(options),
@@ -173,40 +148,6 @@ const getStaticPropertiesObjectLiteral = (
     );
   }
   return object;
-};
-
-/**
- * Adds any field initializers in the given class's constructor to the provided
- * map. This will be used for inferring the type of fields in JS programs.
- */
-const addConstructorInitializers = (
-  classDeclaration: ts.ClassDeclaration,
-  undecoratedProperties: Map<string, ts.Node>
-) => {
-  const ctor = classDeclaration.forEachChild((node) =>
-    ts.isConstructorDeclaration(node) ? node : undefined
-  );
-  if (ctor !== undefined) {
-    ctor.body?.statements.forEach((stmt) => {
-      // Look for initializers in the form of `this.foo = xxxx`
-      if (
-        ts.isExpressionStatement(stmt) &&
-        ts.isBinaryExpression(stmt.expression) &&
-        ts.isPropertyAccessExpression(stmt.expression.left) &&
-        stmt.expression.left.expression.kind === ts.SyntaxKind.ThisKeyword &&
-        ts.isIdentifier(stmt.expression.left.name) &&
-        !undecoratedProperties.has(stmt.expression.left.name.text)
-      ) {
-        // Add the initializer expression to the map
-        undecoratedProperties.set(
-          // Property name
-          stmt.expression.left.name.text,
-          // Expression from which we can infer a type
-          stmt.expression.right
-        );
-      }
-    });
-  }
 };
 
 /**

--- a/packages/labs/analyzer/src/lib/model.ts
+++ b/packages/labs/analyzer/src/lib/model.ts
@@ -615,7 +615,9 @@ export interface Parameter extends PropertyLike {
   rest?: boolean | undefined;
 }
 
-export interface ReactiveProperty extends PropertyLike {
+export interface ReactiveProperty {
+  name: string;
+
   reflect: boolean;
 
   // TODO(justinfagnani): should we convert into attribute name?

--- a/packages/labs/analyzer/src/test/lit-element/lit-element_test.ts
+++ b/packages/labs/analyzer/src/test/lit-element/lit-element_test.ts
@@ -54,23 +54,24 @@ for (const lang of languages) {
     assert.ok(aProp);
     assert.equal(aProp.name, 'a', 'property name');
     assert.equal(aProp.attribute, 'a', 'attribute name');
-    assert.equal(aProp.type?.text, 'string');
-    // TODO (justinfagnani) better assertion
-    assert.ok(aProp.type);
+    assert.equal(decl.getField('a')?.type?.text, 'string');
     assert.equal(aProp.reflect, false);
 
     const bProp = decl.reactiveProperties.get('b');
     assert.ok(bProp);
     assert.equal(bProp.name, 'b');
     assert.equal(bProp.attribute, 'bbb');
-    assert.equal(bProp.type?.text, 'number');
+    assert.equal(decl.getField('b')?.type?.text, 'number');
     assert.equal(bProp.typeOption, 'Number');
 
     const cProp = decl.reactiveProperties.get('c');
     assert.ok(cProp);
     assert.equal(cProp.name, 'c');
     assert.equal(cProp.attribute, 'c');
-    assert.equal(cProp.type?.text, lang === 'ts' ? 'any' : undefined);
+    assert.equal(
+      decl.getField('c')?.type?.text,
+      lang === 'ts' ? 'any' : undefined
+    );
   });
 
   test('Analyzer finds LitElement properties from static getter', ({
@@ -88,7 +89,7 @@ for (const lang of languages) {
     assert.ok(fooProp);
     assert.equal(fooProp.name, 'foo', 'property name');
     assert.equal(fooProp.attribute, 'foo', 'attribute name');
-    assert.equal(fooProp.type?.text, 'string');
+    assert.equal(decl.getField('foo')?.type?.text, 'string');
     assert.equal(fooProp.reflect, false);
 
     const bProp = decl.reactiveProperties.get('bar');
@@ -97,7 +98,7 @@ for (const lang of languages) {
     assert.equal(bProp.attribute, 'bar');
 
     // This is inferred
-    assert.equal(bProp.type?.text, 'number');
+    assert.equal(decl.getField('bar')?.type?.text, 'number');
     assert.equal(bProp.typeOption, 'Number');
   });
 

--- a/packages/labs/analyzer/src/test/lit-element/properties_test.ts
+++ b/packages/labs/analyzer/src/test/lit-element/properties_test.ts
@@ -40,9 +40,11 @@ for (const lang of languages) {
     assert.ok(property);
     assert.equal(property.name, 'noOptionsString');
     assert.equal(property.attribute, 'nooptionsstring');
-    assert.equal(property.type?.text, 'string');
-    assert.equal(property.type?.references.length, 0);
-    assert.ok(property.type);
+    assert.equal(element.getField('noOptionsString')?.type?.text, 'string');
+    assert.equal(
+      element.getField('noOptionsString')?.type?.references.length,
+      0
+    );
     assert.equal(property.reflect, false);
     assert.equal(property.converter, undefined);
   });
@@ -51,34 +53,36 @@ for (const lang of languages) {
     const property = element.reactiveProperties.get('noOptionsNumber')!;
     assert.equal(property.name, 'noOptionsNumber');
     assert.equal(property.attribute, 'nooptionsnumber');
-    assert.equal(property.type?.text, 'number');
-    assert.equal(property.type?.references.length, 0);
-    assert.ok(property.type);
+    assert.equal(element.getField('noOptionsNumber')?.type?.text, 'number');
+    assert.equal(
+      element.getField('noOptionsNumber')?.type?.references.length,
+      0
+    );
   });
 
   test('string property with type', ({element}) => {
-    const property = element.reactiveProperties.get('typeString')!;
+    const property = element.getField('typeString')!;
     assert.equal(property.type?.text, 'string');
     assert.equal(property.type?.references.length, 0);
     assert.ok(property.type);
   });
 
   test('number property with type', ({element}) => {
-    const property = element.reactiveProperties.get('typeNumber')!;
+    const property = element.getField('typeNumber')!;
     assert.equal(property.type?.text, 'number');
     assert.equal(property.type?.references.length, 0);
     assert.ok(property.type);
   });
 
   test('boolean property with type', ({element}) => {
-    const property = element.reactiveProperties.get('typeBoolean')!;
+    const property = element.getField('typeBoolean')!;
     assert.equal(property.type?.text, 'boolean');
     assert.equal(property.type?.references.length, 0);
     assert.ok(property.type);
   });
 
   test('property typed with local class', ({element}) => {
-    const property = element.reactiveProperties.get('localClass')!;
+    const property = element.getField('localClass')!;
     assert.equal(property.type?.text, 'LocalClass');
     assert.equal(property.type?.references.length, 1);
     assert.equal(property.type?.references[0].name, 'LocalClass');
@@ -90,7 +94,7 @@ for (const lang of languages) {
   });
 
   test('property typed with imported class', ({element}) => {
-    const property = element.reactiveProperties.get('importedClass')!;
+    const property = element.getField('importedClass')!;
     assert.equal(property.type?.text, 'ImportedClass');
     assert.equal(property.type?.references.length, 1);
     assert.equal(property.type?.references[0].name, 'ImportedClass');
@@ -102,7 +106,7 @@ for (const lang of languages) {
   });
 
   test('property typed with global class', ({element}) => {
-    const property = element.reactiveProperties.get('globalClass')!;
+    const property = element.getField('globalClass')!;
     assert.equal(property.type?.text, 'HTMLElement');
     assert.equal(property.type?.references.length, 1);
     assert.equal(property.type?.references[0].name, 'HTMLElement');
@@ -117,7 +121,7 @@ for (const lang of languages) {
     if (lang === 'js') {
       return;
     }
-    const property = element.reactiveProperties.get('union')!;
+    const property = element.getField('union')!;
     assert.equal(property.type?.references.length, 3);
     // The order is not necessarily reliable. It changed between TypeScript
     // versions once.
@@ -185,8 +189,8 @@ for (const lang of languages) {
 
   test('property defined in static properties block', ({element}) => {
     const property = element.reactiveProperties.get('staticProp')!;
-    assert.equal(property.type?.text, 'number');
-    assert.equal(property.type?.references.length, 0);
+    assert.equal(element.getField('staticProp')?.type?.text, 'number');
+    assert.equal(element.getField('staticProp')?.type?.references.length, 0);
     assert.equal(property.typeOption, 'Number');
     assert.equal(property.attribute, 'static-prop');
   });


### PR DESCRIPTION
The `ReactiveProperty` model holds metadata specific to Lit's reactive properties (either via `@property()` decorator or `static properties` block). From early on, it also held `type` information. However, now that we have a `ClassField` model with `type` information, that is redundant, so this removes `type` from `ReactiveProperty`.

In addition, when we added JavaScript support to the analyzer (prior to adding `ClassField`), in order to fill in the `type` information on `ReactiveProperty`, we added code to find the associated initializer in the `constructor` and analyze the `type` info from that. This PR also moves that logic to the `ClassField` analysis, so that we also create class fields based on constructor-initialized fields.