### PR TITLE
[labs/virtualizer] handle uninitialized layout in _childrenSizeChanged

### DIFF
--- a/.changeset/hip-badgers-burn.md
+++ b/.changeset/hip-badgers-burn.md
@@ -1,0 +1,5 @@
+---
+"@lit-labs/virtualizer": patch
+---
+
+[@lit-labs/virtualizer]: handle uninitialized layout in _childrenSizeChanged

--- a/.changeset/hip-badgers-burn.md
+++ b/.changeset/hip-badgers-burn.md
@@ -1,5 +1,5 @@
 ---
-"@lit-labs/virtualizer": patch
+'@lit-labs/virtualizer': patch
 ---
 
-[@lit-labs/virtualizer]: handle uninitialized layout in _childrenSizeChanged
+[@lit-labs/virtualizer]: handle uninitialized layout in \_childrenSizeChanged

--- a/packages/labs/virtualizer/src/Virtualizer.ts
+++ b/packages/labs/virtualizer/src/Virtualizer.ts
@@ -874,7 +874,7 @@ export class Virtualizer {
   // the virtualizer update cycle.
   private _childrenSizeChanged(changes: ResizeObserverEntry[]) {
     // Only measure if the layout requires it
-    if (this._layout?.measureChildren) {
+    if (this._layout!.measureChildren) {
       for (const change of changes) {
         this._toBeMeasured.set(
           change.target as HTMLElement,

--- a/packages/labs/virtualizer/src/Virtualizer.ts
+++ b/packages/labs/virtualizer/src/Virtualizer.ts
@@ -874,7 +874,7 @@ export class Virtualizer {
   // the virtualizer update cycle.
   private _childrenSizeChanged(changes: ResizeObserverEntry[]) {
     // Only measure if the layout requires it
-    if (this._layout!.measureChildren) {
+    if (this._layout?.measureChildren) {
       for (const change of changes) {
         this._toBeMeasured.set(
           change.target as HTMLElement,

--- a/packages/labs/virtualizer/src/test/scenarios/immediate-sizing.test.ts
+++ b/packages/labs/virtualizer/src/test/scenarios/immediate-sizing.test.ts
@@ -47,7 +47,7 @@ describe("Don't behave badly when sizing element before initialization is comple
   ignoreBenignErrors(beforeEach, afterEach);
 
   it('should render the element without error', async () => {
-    const example: ImmediateSizing = await fixture(
+    await fixture(
       testingHtml`
         <immediate-sizing .items=${['item 1', 'item 2']}></immediate-sizing>
       `

--- a/packages/labs/virtualizer/src/test/scenarios/immediate-sizing.test.ts
+++ b/packages/labs/virtualizer/src/test/scenarios/immediate-sizing.test.ts
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {ignoreBenignErrors} from '../helpers.js';
+import {html, css, LitElement} from 'lit';
+import {ref} from 'lit/directives/ref.js';
+import {customElement, property} from 'lit/decorators.js';
+import {virtualize} from '../../virtualize.js';
+import {html as testingHtml, fixture} from '@open-wc/testing';
+
+@customElement('immediate-sizing')
+class ImmediateSizing extends LitElement {
+  static styles = css`
+    .list {
+      width: 100px;
+      height: 100;
+    }
+    .item {
+      height: 50px;
+      margin: 0;
+      padding: 0;
+    }
+    .sized {
+      width: 10px;
+    }
+  `;
+
+  @property({type: Array, attribute: false})
+  public items: Array<string> = [];
+
+  render() {
+    return html` <div class="list">
+      ${virtualize({
+        scroller: true,
+        items: this.items,
+        renderItem: (item) => html`<div class="item">[${item}]</div>`,
+      })}
+      <div ${ref((el?: Element) => el?.classList.toggle('sized'))}></div>
+    </div>`;
+  }
+}
+
+describe("Don't behave badly when sizing element before initialization is complete ", () => {
+  ignoreBenignErrors(beforeEach, afterEach);
+
+  it('should render the element without error', async () => {
+    const example: ImmediateSizing = await fixture(
+      testingHtml`
+        <immediate-sizing .items=${['item 1', 'item 2']}></immediate-sizing>
+      `
+    );
+  });
+});

--- a/packages/labs/virtualizer/src/test/scenarios/immediate-sizing.test.ts
+++ b/packages/labs/virtualizer/src/test/scenarios/immediate-sizing.test.ts
@@ -47,7 +47,7 @@ describe("Don't behave badly when sizing element before initialization is comple
   ignoreBenignErrors(beforeEach, afterEach);
 
   it('should render the element without error', async () => {
-    await fixture(
+    await fixture<ImmediateSizing>(
       testingHtml`
         <immediate-sizing .items=${['item 1', 'item 2']}></immediate-sizing>
       `


### PR DESCRIPTION
Handle uninitialized layout in `_childrenSizeChanged`.

 Because the ResizeObserver starts listening very early it is possible that the layout has not been imported and initialized when a children has updated.

Fixes #3726 