### PR TITLE
[infra] Skip benchmarks workflow for forks

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -6,7 +6,7 @@ jobs:
   benchmarks:
     # Don't run on forks. Benchmarks can't run on forks because secrets aren't
     # available, which are needed for posting result comments.
-    if: github.repository == 'lit/lit'
+    if: github.event.pull_request.head.repo.id == github.event.pull_request.base.repo.id
 
     name: benchmarks
 


### PR DESCRIPTION
Update the condition check to be the same as we use for the Sauce workflows so it'll only run if the head and base repo of the PR are the same, i.e. the lit/lit repo.