### PR TITLE
[chore] Update github actions

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -12,9 +12,9 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: 16
           cache: 'npm'

--- a/.github/workflows/release-image.yaml
+++ b/.github/workflows/release-image.yaml
@@ -15,9 +15,9 @@ jobs:
     name: Generate Release Image
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: 16
           cache: 'npm'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,12 +20,14 @@ jobs:
           git config --global user.email "lit-robot@google.com"
 
       - name: Setup Node.js 16
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
 
       - name: Checkout Lit Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: lit
           # This makes Actions fetch all Git history so that Changesets can
@@ -58,7 +60,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.LIT_ROBOT_NPM_PUBLISH_ACCESS_TOKEN }}
 
       - name: Checkout dist repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         # GitHub Actions outputs are strings and the string 'false' converts to
         # `true` because it isn't the empty string.
         if: steps.cs.outputs.published == 'true'

--- a/.github/workflows/sauce-ie11.yaml
+++ b/.github/workflows/sauce-ie11.yaml
@@ -24,9 +24,9 @@ jobs:
       BROWSERS: preset:sauce-ie11
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: 16
           cache: 'npm'

--- a/.github/workflows/sauce.yaml
+++ b/.github/workflows/sauce.yaml
@@ -24,9 +24,9 @@ jobs:
       BROWSERS: preset:sauce
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: 16
           cache: 'npm'

--- a/.github/workflows/starter-kits.yaml
+++ b/.github/workflows/starter-kits.yaml
@@ -19,14 +19,14 @@ jobs:
           git config --global user.email "lit-robot@google.com"
 
       - name: Checkout Lit Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: lit
           # Fetch all history, otherwise we can't fetch from this repo.
           fetch-depth: 0
 
       - name: Checkout lit-element-starter-ts repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: lit/lit-element-starter-ts
           ref: main
@@ -61,7 +61,7 @@ jobs:
           echo "Done."
 
       - name: Checkout lit-element-starter-js repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: lit/lit-element-starter-js
           ref: main

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,13 +16,14 @@ jobs:
     if: ${{ github.actor != 'lit-robot' }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: 16
+          cache: 'npm'
           cache-dependency-path: package-lock.json
 
       - name: NPM install
@@ -46,9 +47,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: 16
           cache: 'npm'
@@ -75,9 +76,9 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: 16
           cache: 'npm'


### PR DESCRIPTION
Updates `actions/checkout` and `actions/setup-node` to v3. Per their changelog, the only breaking part is the default node version used for the workflow being bumped to node16 instead of node12.

This should fix warnings like below that we get in workflows.

![image](https://user-images.githubusercontent.com/40413829/224814686-7eab7ab9-3984-46b9-b1d8-a2c5fcc60681.png)
