### PR TITLE
[labs/context] Make `@provide` and `@consume` support optional and private properties.

### DIFF
--- a/.changeset/eighty-bananas-drive.md
+++ b/.changeset/eighty-bananas-drive.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/context': patch
+---
+
+Make @provide work with optional fields

--- a/.changeset/eighty-bananas-drive.md
+++ b/.changeset/eighty-bananas-drive.md
@@ -2,4 +2,6 @@
 '@lit-labs/context': patch
 ---
 
-Make @provide work with optional fields
+Improve type checking of @provide and @consume. We now support optional properties, and public properties should be fully type checked.
+
+This also adds support for using @provide and @consume with protected and private fields, but be aware that do to limitations in TypeScript's experimental decorators, the connection between the context and the property can not be type checked. We'll be able to fix this when standard decorators are released (current ETA TypeScript 5.2 in August 2023).

--- a/.changeset/eighty-bananas-drive.md
+++ b/.changeset/eighty-bananas-drive.md
@@ -2,6 +2,6 @@
 '@lit-labs/context': patch
 ---
 
-Improve type checking of @provide and @consume. We now support optional properties, and public properties should be fully type checked.
+Improve type checking of `@provide` and `@consume`. We now support optional properties, and public properties should be fully type checked.
 
-This also adds support for using @provide and @consume with protected and private fields, but be aware that do to limitations in TypeScript's experimental decorators, the connection between the context and the property can not be type checked. We'll be able to fix this when standard decorators are released (current ETA TypeScript 5.2 in August 2023).
+This also adds support for using `@provide` and `@consume` with protected and private fields, but be aware that due to limitations in TypeScript's experimental decorators, the connection between the context and the property can not be type checked. We'll be able to fix this when standard decorators are released (current ETA TypeScript 5.2 in August 2023), see https://github.com/lit/lit/issues/3926 for more.

--- a/packages/labs/context/README.md
+++ b/packages/labs/context/README.md
@@ -157,6 +157,12 @@ This solution has a small overhead, in that if a provider is not within the DOM 
 
 Note that ContextRoot uses [WeakRefs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakRef) which are not supported in IE11.
 
+### Protected / Private Properties
+
+You can use the `@consume` and `@provide` decorators on TypeScript `protected` and `private` properties, but we aware that there is no type checking between the type of the context and the type of the property. This is because the TypeScript compiler does not make type information for protected or private properties available to decorators.
+
+We expect to be able to fix this when we switch to standard decorators.
+
 ## Contributing
 
 Please see [CONTRIBUTING.md](../../../CONTRIBUTING.md).

--- a/packages/labs/context/README.md
+++ b/packages/labs/context/README.md
@@ -159,9 +159,9 @@ Note that ContextRoot uses [WeakRefs](https://developer.mozilla.org/en-US/docs/W
 
 ### Protected / Private Properties
 
-You can use the `@consume` and `@provide` decorators on TypeScript `protected` and `private` properties, but we aware that there is no type checking between the type of the context and the type of the property. This is because the TypeScript compiler does not make type information for protected or private properties available to decorators.
+You can use the `@consume` and `@provide` decorators on TypeScript `protected` and `private` properties, but be aware that there is no type checking between the type of the context and the type of the property. This is because the TypeScript compiler does not make type information for protected or private properties available to decorators. Standard `#private` properties are not supported at all.
 
-We expect to be able to fix this when we switch to standard decorators.
+We expect to fix all of this when we switch to standard decorators. See [#3926](https://github.com/lit/lit/issues/3926).
 
 ## Contributing
 

--- a/packages/labs/context/src/lib/decorators/consume.ts
+++ b/packages/labs/context/src/lib/decorators/consume.ts
@@ -68,23 +68,20 @@ type ConsumerDecorator<ValueType> = {
   <K extends PropertyKey, Proto extends ReactiveElement>(
     protoOrDescriptor: Proto,
     name?: K
-    // Note TypeScript requires the return type to be `void|any`
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ): FieldMustMatchProvidedType<Proto, K, ValueType, void | any>;
+  ): FieldMustMatchProvidedType<Proto, K, ValueType>;
 };
 
-type FieldMustMatchProvidedType<
-  Obj,
-  Key extends PropertyKey,
-  ProvidedType,
-  ReturnValue
-> =
+// Note TypeScript requires the return type of a decorator to be `void | any`
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type DecoratorReturn = void | any;
+
+type FieldMustMatchProvidedType<Obj, Key extends PropertyKey, ProvidedType> =
   // First we check whether the object has the property as a required field
   Obj extends Record<Key, infer ConsumingType>
     ? // Ok, it does, just check whether it's ok to assign the
       // provided type to the consuming field
       [ProvidedType] extends [ConsumingType]
-      ? ReturnValue
+      ? DecoratorReturn
       : {
           message: 'provided type not assignable to consuming field';
           provided: ProvidedType;
@@ -95,7 +92,7 @@ type FieldMustMatchProvidedType<
     ? // Check assignability again. Note that we have to include undefined
       // here on the consuming type because it's optional.
       [ProvidedType] extends [ConsumingType | undefined]
-      ? ReturnValue
+      ? DecoratorReturn
       : {
           message: 'provided type not assignable to consuming field';
           provided: ProvidedType;
@@ -105,4 +102,4 @@ type FieldMustMatchProvidedType<
       // manually, i.e. not as a decorator (maybe don't do that! but if you do,
       // you're on your own for your type checking, sorry), or the field is
       // private, in which case we can't check it.
-      ReturnValue;
+      DecoratorReturn;

--- a/packages/labs/context/src/lib/decorators/consume.ts
+++ b/packages/labs/context/src/lib/decorators/consume.ts
@@ -42,18 +42,12 @@ import {Context} from '../create-context.js';
  * @category Decorator
  */
 export function consume<ValueType>({
-  context: context,
+  context,
   subscribe,
 }: {
   context: Context<unknown, ValueType>;
   subscribe?: boolean;
-}): <K extends PropertyKey>(
-  // Partial<> allows for providing the value to an optional field
-  protoOrDescriptor: ReactiveElement & Partial<Record<K, ValueType>>,
-  name?: K
-  // Note TypeScript requires the return type to be `void|any`
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-) => void | any {
+}): ConsumerDecorator<ValueType> {
   return decorateProperty({
     finisher: (ctor: typeof ReactiveElement, name: PropertyKey) => {
       ctor.addInitializer((element: ReactiveElement): void => {
@@ -69,3 +63,46 @@ export function consume<ValueType>({
     },
   });
 }
+
+type ConsumerDecorator<ValueType> = {
+  <K extends PropertyKey, Proto extends ReactiveElement>(
+    protoOrDescriptor: Proto,
+    name?: K
+    // Note TypeScript requires the return type to be `void|any`
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ): FieldMustMatchProvidedType<Proto, K, ValueType, void | any>;
+};
+
+type FieldMustMatchProvidedType<
+  Obj,
+  Key extends PropertyKey,
+  ProvidedType,
+  ReturnValue
+> =
+  // First we check whether the object has the property as a required field
+  Obj extends Record<Key, infer ConsumingType>
+    ? // Ok, it does, just check whether it's ok to assign the
+      // provided type to the consuming field
+      [ProvidedType] extends [ConsumingType]
+      ? ReturnValue
+      : {
+          message: 'provided type not assignable to consuming field';
+          provided: ProvidedType;
+          consuming: ConsumingType;
+        }
+    : // Next we check whether the object has the property as an optional field
+    Obj extends Partial<Record<Key, infer ConsumingType>>
+    ? // Check assignability again. Note that we have to include undefined
+      // here on the consuming type because it's optional.
+      [ProvidedType] extends [ConsumingType | undefined]
+      ? ReturnValue
+      : {
+          message: 'provided type not assignable to consuming field';
+          provided: ProvidedType;
+          consuming: ConsumingType | undefined;
+        }
+    : // Ok, the field isn't present, so either someone's using consume
+      // manually, i.e. not as a decorator (maybe don't do that! but if you do,
+      // you're on your own for your type checking, sorry), or the field is
+      // private, in which case we can't check it.
+      ReturnValue;

--- a/packages/labs/context/src/lib/decorators/provide.ts
+++ b/packages/labs/context/src/lib/decorators/provide.ts
@@ -48,7 +48,7 @@ export function provide<ValueType>({
 }: {
   context: Context<unknown, ValueType>;
 }): <K extends PropertyKey>(
-  protoOrDescriptor: ReactiveElement & Record<K, ValueType>,
+  protoOrDescriptor: ReactiveElement & Partial<Record<K, ValueType>>,
   name?: K
   // Note TypeScript requires the return type to be `void|any`
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/labs/context/src/lib/decorators/provide.ts
+++ b/packages/labs/context/src/lib/decorators/provide.ts
@@ -48,7 +48,7 @@ export function provide<ValueType>({
 }: {
   context: Context<unknown, ValueType>;
 }): <K extends PropertyKey>(
-  protoOrDescriptor: ReactiveElement & Partial<Record<K, ValueType>>,
+  protoOrDescriptor: ReactiveElement & LooseRecord<K, ValueType>,
   name?: K
   // Note TypeScript requires the return type to be `void|any`
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -76,3 +76,10 @@ export function provide<ValueType>({
     },
   });
 }
+
+/**
+ * Allows optional fields when the context type permits `undefined`.
+ */
+type LooseRecord<K extends string | number | symbol, V> = V extends undefined
+  ? Partial<Record<K, V>>
+  : Record<K, V>;

--- a/packages/labs/context/src/lib/decorators/provide.ts
+++ b/packages/labs/context/src/lib/decorators/provide.ts
@@ -76,23 +76,20 @@ type ProvideDecorator<ContextType> = {
   <K extends PropertyKey, Proto extends ReactiveElement>(
     protoOrDescriptor: Proto,
     name?: K
-    // Note TypeScript requires the return type to be `void|any`
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ): FieldMustMatchContextType<Proto, K, ContextType, void | any>;
+  ): FieldMustMatchContextType<Proto, K, ContextType>;
 };
 
-type FieldMustMatchContextType<
-  Obj,
-  Key extends PropertyKey,
-  ContextType,
-  ReturnValue
-> =
+// Note TypeScript requires the return type of a decorator to be `void | any`
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type DecoratorReturn = void | any;
+
+type FieldMustMatchContextType<Obj, Key extends PropertyKey, ContextType> =
   // First we check whether the object has the property as a required field
   Obj extends Record<Key, infer ProvidingType>
     ? // Ok, it does, just check whether it's ok to assign the
       // provided type to the consuming field
       [ProvidingType] extends [ContextType]
-      ? ReturnValue
+      ? DecoratorReturn
       : {
           message: 'providing field not assignable to context';
           context: ContextType;
@@ -103,7 +100,7 @@ type FieldMustMatchContextType<
     ? // Check assignability again. Note that we have to include undefined
       // here on the consuming type because it's optional.
       [Providing | undefined] extends [ContextType]
-      ? ReturnValue
+      ? DecoratorReturn
       : {
           message: 'providing field not assignable to context';
           context: ContextType;
@@ -113,4 +110,4 @@ type FieldMustMatchContextType<
       // manually, i.e. not as a decorator (maybe don't do that! but if you do,
       // you're on your own for your type checking, sorry), or the field is
       // private, in which case we can't check it.
-      ReturnValue;
+      DecoratorReturn;

--- a/packages/labs/context/src/lib/decorators/provide.ts
+++ b/packages/labs/context/src/lib/decorators/provide.ts
@@ -98,7 +98,7 @@ type FieldMustMatchContextType<Obj, Key extends PropertyKey, ContextType> =
     : // Next we check whether the object has the property as an optional field
     Obj extends Partial<Record<Key, infer Providing>>
     ? // Check assignability again. Note that we have to include undefined
-      // here on the consuming type because it's optional.
+      // here on the providing type because it's optional.
       [Providing | undefined] extends [ContextType]
       ? DecoratorReturn
       : {
@@ -106,7 +106,7 @@ type FieldMustMatchContextType<Obj, Key extends PropertyKey, ContextType> =
           context: ContextType;
           consuming: Providing | undefined;
         }
-    : // Ok, the field isn't present, so either someone's using consume
+    : // Ok, the field isn't present, so either someone's using provide
       // manually, i.e. not as a decorator (maybe don't do that! but if you do,
       // you're on your own for your type checking, sorry), or the field is
       // private, in which case we can't check it.

--- a/packages/labs/context/src/test/context-provider_test.ts
+++ b/packages/labs/context/src/test/context-provider_test.ts
@@ -31,7 +31,7 @@ customElements.define('context-consumer', ContextConsumerElement);
 class ContextProviderElement extends LitElement {
   @provide({context: simpleContext})
   @property({type: Number, reflect: true})
-  public value = 0;
+  public value?: number;
 
   protected render(): TemplateResult {
     return html`

--- a/packages/labs/context/src/test/context-provider_test.ts
+++ b/packages/labs/context/src/test/context-provider_test.ts
@@ -102,8 +102,6 @@ suite('@consume', () => {
     assert.strictEqual(consumer.optionalValue, undefined);
     assert.strictEqual(consumer.consumeOptionalWithDefault, undefined);
     provider.optionalValue = 500;
-    await provider.updateComplete;
-    await consumer.updateComplete;
     assert.strictEqual(consumer.optionalValue, 500);
     assert.strictEqual(consumer.consumeOptionalWithDefault, 500);
   });

--- a/packages/labs/context/src/test/context-provider_test.ts
+++ b/packages/labs/context/src/test/context-provider_test.ts
@@ -31,7 +31,7 @@ customElements.define('context-consumer', ContextConsumerElement);
 class ContextProviderElement extends LitElement {
   @provide({context: simpleContext})
   @property({type: Number, reflect: true})
-  public value?: number;
+  public value = 0;
 
   protected render(): TemplateResult {
     return html`

--- a/packages/labs/context/src/test/context-provider_test.ts
+++ b/packages/labs/context/src/test/context-provider_test.ts
@@ -7,10 +7,11 @@
 import {LitElement, html, TemplateResult} from 'lit';
 import {property} from 'lit/decorators/property.js';
 
-import {Context, consume, provide} from '@lit-labs/context';
+import {createContext, consume, provide} from '@lit-labs/context';
 import {assert} from '@esm-bundle/chai';
 
-const simpleContext = 'simple-context' as Context<'simple-context', number>;
+const simpleContext = createContext<number>('simple-context');
+const optionalContext = createContext<number | undefined>('optional-context');
 
 class ContextConsumerElement extends LitElement {
   @consume({context: simpleContext, subscribe: true})
@@ -22,6 +23,14 @@ class ContextConsumerElement extends LitElement {
   @property({type: Number})
   public value2?: string;
 
+  @consume({context: optionalContext, subscribe: true})
+  @property({type: Number})
+  public optionalValue?: number;
+
+  @consume({context: optionalContext, subscribe: true})
+  @property({type: Number})
+  public consumeOptionalWithDefault: number | undefined = 0;
+
   protected render(): TemplateResult {
     return html`Value <span id="value">${this.value}</span>`;
   }
@@ -32,6 +41,10 @@ class ContextProviderElement extends LitElement {
   @provide({context: simpleContext})
   @property({type: Number, reflect: true})
   public value = 0;
+
+  @provide({context: optionalContext})
+  @property({type: Number})
+  public optionalValue?: number;
 
   protected render(): TemplateResult {
     return html`
@@ -83,6 +96,16 @@ suite('@consume', () => {
     provider.value = 500;
     await consumer.updateComplete;
     assert.strictEqual(consumer.value, 500);
+  });
+
+  test('consuming and providing with optional fields', async () => {
+    assert.strictEqual(consumer.optionalValue, undefined);
+    assert.strictEqual(consumer.consumeOptionalWithDefault, undefined);
+    provider.optionalValue = 500;
+    await provider.updateComplete;
+    await consumer.updateComplete;
+    assert.strictEqual(consumer.optionalValue, 500);
+    assert.strictEqual(consumer.consumeOptionalWithDefault, 500);
   });
 });
 

--- a/packages/labs/context/src/test/type_check_test.ts
+++ b/packages/labs/context/src/test/type_check_test.ts
@@ -87,6 +87,9 @@ suite('compilation tests', () => {
       @provide({context: numberContext}) provideNumberWithOptionalUndefined?:
         | number
         | undefined;
+
+      // @ts-expect-error experimental decorators unsupported on #private fields
+      @provide({context: numberContext}) #provideToPrivate = 0;
     }
     markAsUsed(TestElement);
   });
@@ -101,6 +104,8 @@ suite('compilation tests', () => {
       // @ts-expect-error number consuming number or undefined
       @consume({context: numberOrUndefinedContext})
       consumeUndefinedWithDefined = 0;
+      // @ts-expect-error experimental decorators unsupported on #private fields
+      @consume({context: numberContext}) #consumeWithPrivate = 0;
     }
     markAsUsed(TestElement);
   });

--- a/packages/labs/context/src/test/type_check_test.ts
+++ b/packages/labs/context/src/test/type_check_test.ts
@@ -88,6 +88,7 @@ suite('compilation tests', () => {
         | number
         | undefined;
 
+      // We'd like this to work. See https://github.com/lit/lit/issues/3926
       // @ts-expect-error experimental decorators unsupported on #private fields
       @provide({context: numberContext}) #provideToPrivate = 0;
     }
@@ -104,6 +105,7 @@ suite('compilation tests', () => {
       // @ts-expect-error number consuming number or undefined
       @consume({context: numberOrUndefinedContext})
       consumeUndefinedWithDefined = 0;
+      // We'd like this to work. See https://github.com/lit/lit/issues/3926
       // @ts-expect-error experimental decorators unsupported on #private fields
       @consume({context: numberContext}) #consumeWithPrivate = 0;
     }

--- a/packages/labs/context/src/test/type_check_test.ts
+++ b/packages/labs/context/src/test/type_check_test.ts
@@ -31,6 +31,19 @@ suite('compilation tests', () => {
       provideUndefinedWithOptional?: number;
       @provide({context: numberOrUndefinedContext})
       provideUndefinedWithOptionalUndefined?: number | undefined;
+      @provide({context: numberContext})
+      private providePrivate = 0;
+      @provide({context: numberContext})
+      private providePrivateOptional?: number;
+      @provide({context: numberContext})
+      protected provideProtected = 0;
+      @provide({context: numberContext})
+      protected provideProtectedOptional?: number;
+      constructor() {
+        super();
+        markAsUsed(this.providePrivate);
+        markAsUsed(this.providePrivateOptional);
+      }
     }
     markAsUsed(TestElement);
   });
@@ -92,32 +105,17 @@ suite('compilation tests', () => {
     markAsUsed(TestElement);
   });
 
-  test(`things we wish would type check, but don't currently`, () => {
-    class TestElement extends ReactiveElement {
-      // @ts-expect-error don't support providing private fields
-      @provide({context: numberContext})
-      private providePrivate = 0;
-      // @ts-expect-error don't support providing private fields
-      @provide({context: numberContext})
-      private providePrivateOptional?: number;
-      // @ts-expect-error don't support providing protected fields
-      @provide({context: numberContext})
-      protected provideProtected = 0;
-      // @ts-expect-error don't support providing protected fields
-      @provide({context: numberContext})
-      protected provideProtectedOptional?: number;
-
-      constructor() {
-        super();
-        markAsUsed(this.providePrivate);
-        markAsUsed(this.providePrivateOptional);
-      }
-    }
-    markAsUsed(TestElement);
-  });
-
   test(`things we wish wouldn't type check, but do currently`, () => {
     class TestElement extends ReactiveElement {
+      @provide({context: numberContext})
+      private provideNumberWithPrivateString = '';
+      @provide({context: numberContext})
+      private provideNumberWithPrivateOptionalString?: string;
+      @provide({context: numberContext})
+      protected provideNumberWithProtectedString = '';
+      @provide({context: numberContext})
+      protected provideNumberWithProtectedOptionalString?: string;
+
       @consume({context: numberContext})
       private consumeNumberWithPrivateString = '';
       @consume({context: numberContext})
@@ -129,6 +127,8 @@ suite('compilation tests', () => {
 
       constructor() {
         super();
+        markAsUsed(this.provideNumberWithPrivateString);
+        markAsUsed(this.provideNumberWithPrivateOptionalString);
         markAsUsed(this.consumeNumberWithPrivateString);
         markAsUsed(this.consumeNumberWithPrivateOptionalString);
       }

--- a/packages/labs/context/src/test/type_check_test.ts
+++ b/packages/labs/context/src/test/type_check_test.ts
@@ -1,0 +1,138 @@
+import {ReactiveElement} from 'lit';
+
+import {createContext, consume, provide} from '@lit-labs/context';
+
+const numberContext = createContext<number>('number');
+const numberOrUndefinedContext = createContext<number | undefined>(
+  'numberOrUndefined'
+);
+
+// to silence linters
+function markAsUsed(val: unknown) {
+  if (false as boolean) {
+    console.log(val);
+  }
+}
+
+suite('compilation tests', () => {
+  // this code doesn't need to run, it's tested by tsc
+  if (true as boolean) {
+    return;
+  }
+
+  test('correct uses of @provide should type check', () => {
+    class TestElement extends ReactiveElement {
+      @provide({context: numberContext}) simpleProvide = 0;
+      @provide({context: numberOrUndefinedContext})
+      provideUndefinedWithDefined = 0;
+      @provide({context: numberOrUndefinedContext})
+      provideUndefinedWithUndefined: number | undefined;
+      @provide({context: numberOrUndefinedContext})
+      provideUndefinedWithOptional?: number;
+      @provide({context: numberOrUndefinedContext})
+      provideUndefinedWithOptionalUndefined?: number | undefined;
+    }
+    markAsUsed(TestElement);
+  });
+
+  test('correct uses of @consume should type check', () => {
+    class TestElement extends ReactiveElement {
+      @consume({context: numberContext}) simpleConsume = 0;
+      @consume({context: numberOrUndefinedContext})
+      consumeUndefinedWithUndefined: number | undefined;
+      @consume({context: numberOrUndefinedContext})
+      consumeUndefinedWithOptional?: number;
+      @consume({context: numberOrUndefinedContext})
+      consumeUndefinedWithOptionalUndefined?: number | undefined;
+      @consume({context: numberContext}) private consumePrivate = 0;
+      @consume({context: numberContext})
+      private consumePrivateOptional?: number;
+      @consume({context: numberContext})
+      protected consumeProtected = 0;
+      @consume({context: numberContext})
+      protected consumeProtectedOptional?: number;
+      constructor() {
+        super();
+        markAsUsed(this.consumePrivate);
+        markAsUsed(this.consumePrivateOptional);
+      }
+    }
+    markAsUsed(TestElement);
+  });
+
+  test('incorrect uses of @provide should produce type errors', () => {
+    class TestElement extends ReactiveElement {
+      // @ts-expect-error string providing number
+      @provide({context: numberContext}) provideStringWithNumber = '0';
+      // @ts-expect-error number or undefined providing number
+      @provide({context: numberContext}) provideNumberWithUndefined:
+        | number
+        | undefined = 0;
+      // @ts-expect-error optional number providing into number
+      @provide({context: numberContext}) provideNumberWithOptional?: number;
+      // @ts-expect-error optional number providing into number
+      @provide({context: numberContext}) provideNumberWithOptionalUndefined?:
+        | number
+        | undefined;
+    }
+    markAsUsed(TestElement);
+  });
+
+  test('incorrect uses of @consume should produce type errors', () => {
+    class TestElement extends ReactiveElement {
+      // @ts-expect-error string consuming number
+      @consume({context: numberContext}) consumeNumberWithString = '0';
+      // @ts-expect-error string consuming number
+      @consume({context: numberContext})
+      consumeNumberWithOptionalString?: string;
+      // @ts-expect-error number consuming number or undefined
+      @consume({context: numberOrUndefinedContext})
+      consumeUndefinedWithDefined = 0;
+    }
+    markAsUsed(TestElement);
+  });
+
+  test(`things we wish would type check, but don't currently`, () => {
+    class TestElement extends ReactiveElement {
+      // @ts-expect-error don't support providing private fields
+      @provide({context: numberContext})
+      private providePrivate = 0;
+      // @ts-expect-error don't support providing private fields
+      @provide({context: numberContext})
+      private providePrivateOptional?: number;
+      // @ts-expect-error don't support providing protected fields
+      @provide({context: numberContext})
+      protected provideProtected = 0;
+      // @ts-expect-error don't support providing protected fields
+      @provide({context: numberContext})
+      protected provideProtectedOptional?: number;
+
+      constructor() {
+        super();
+        markAsUsed(this.providePrivate);
+        markAsUsed(this.providePrivateOptional);
+      }
+    }
+    markAsUsed(TestElement);
+  });
+
+  test(`things we wish wouldn't type check, but do currently`, () => {
+    class TestElement extends ReactiveElement {
+      @consume({context: numberContext})
+      private consumeNumberWithPrivateString = '';
+      @consume({context: numberContext})
+      private consumeNumberWithPrivateOptionalString?: string;
+      @consume({context: numberContext})
+      protected consumeNumberWithProtectedString = '';
+      @consume({context: numberContext})
+      protected consumeNumberWithProtectedOptionalString?: string;
+
+      constructor() {
+        super();
+        markAsUsed(this.consumeNumberWithPrivateString);
+        markAsUsed(this.consumeNumberWithPrivateOptionalString);
+      }
+    }
+    markAsUsed(TestElement);
+  });
+});


### PR DESCRIPTION
Fixes #3732 

As far as I can tell, the change just works. All tests still pass.