### PR TITLE
[labs/context] Context root: use event.composedPath()

### DIFF
--- a/.changeset/few-flowers-tease.md
+++ b/.changeset/few-flowers-tease.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/context': minor
+---
+
+Fix bug in ContextRoot when the consumer is the shadowRoot of the provider

--- a/.changeset/few-flowers-tease.md
+++ b/.changeset/few-flowers-tease.md
@@ -2,4 +2,4 @@
 '@lit-labs/context': minor
 ---
 
-Fix bug in ContextRoot when the consumer is the shadowRoot of the provider
+Fix bug in ContextRoot when the consumer is in the shadowRoot of the provider

--- a/.changeset/few-flowers-tease.md
+++ b/.changeset/few-flowers-tease.md
@@ -1,5 +1,5 @@
 ---
-'@lit-labs/context': minor
+'@lit-labs/context': patch
 ---
 
 Fix bug in ContextRoot when the consumer is in the shadowRoot of the provider

--- a/packages/labs/context/src/lib/context-root.ts
+++ b/packages/labs/context/src/lib/context-root.ts
@@ -95,7 +95,7 @@ export class ContextRoot {
     }
 
     // Use composedPath (as opposed to event.target) to cover cases
-    // where the consumer is in the shadowDom of the provider (in which case,
+    // where the consumer is in the shadow DOM of the provider (in which case,
     // event.target === this.host because of event retargeting).
     const element = event.composedPath()[0] as HTMLElement;
     const callback = event.callback;

--- a/packages/labs/context/src/lib/context-root.ts
+++ b/packages/labs/context/src/lib/context-root.ts
@@ -94,7 +94,10 @@ export class ContextRoot {
       return;
     }
 
-    const element = event.target as HTMLElement;
+    // Use composedPath (as opposed to event.target) to cover cases
+    // where the consumer is in the shadowDom of the provider (in which case,
+    // event.target === this.host because of event retargeting).
+    const element = event.composedPath()[0] as HTMLElement;
     const callback = event.callback;
 
     let pendingContextRequests = this.pendingContextRequests.get(event.context);

--- a/packages/labs/context/src/test/late-provider_test.ts
+++ b/packages/labs/context/src/test/late-provider_test.ts
@@ -146,6 +146,38 @@ suiteSkipIE('late context provider', () => {
     assert.strictEqual(consumer.value, 1000);
   });
 
+  test('lazy added provider, with consumer in shadowRoot of provider', async () => {
+    @customElement('lazy-context-provider')
+    class LazyContextProviderElement extends LitElement {
+      protected render() {
+        return html`<context-consumer></context-consumer>`;
+      }
+    }
+    container.innerHTML = `
+      <lazy-context-provider>
+      </lazy-context-provider>
+    `;
+
+    const provider = container.querySelector(
+      'lazy-context-provider'
+    ) as LazyContextProviderElement;
+
+    const consumer = provider.shadowRoot!.querySelector(
+      'context-consumer'
+    ) as ContextConsumerElement;
+
+    await consumer.updateComplete;
+
+    // Add a provider after the elements are setup
+    new ContextProvider(provider, {context: simpleContext, initialValue: 1000});
+
+    await provider.updateComplete;
+    await consumer.updateComplete;
+
+    // `value` should now be provided
+    assert.strictEqual(consumer.value, 1000);
+  });
+
   test('late element with multiple properties', async () => {
     @customElement('context-consumer-2')
     class ContextConsumer2Element extends LitElement {

--- a/packages/labs/context/src/test/late-provider_test.ts
+++ b/packages/labs/context/src/test/late-provider_test.ts
@@ -147,20 +147,20 @@ suiteSkipIE('late context provider', () => {
   });
 
   test('lazy added provider, with consumer in shadowRoot of provider', async () => {
-    @customElement('lazy-context-provider')
-    class LazyContextProviderElement extends LitElement {
+    @customElement('lazy-context-provider-consumer')
+    class LazyContextProviderConsumerElement extends LitElement {
       protected render() {
         return html`<context-consumer></context-consumer>`;
       }
     }
     container.innerHTML = `
-      <lazy-context-provider>
-      </lazy-context-provider>
+      <lazy-context-provider-consumer>
+      </lazy-context-provider-consumer>
     `;
 
     const provider = container.querySelector(
-      'lazy-context-provider'
-    ) as LazyContextProviderElement;
+      'lazy-context-provider-consumer'
+    ) as LazyContextProviderConsumerElement;
 
     const consumer = provider.shadowRoot!.querySelector(
       'context-consumer'

--- a/packages/labs/context/src/test/late-provider_test.ts
+++ b/packages/labs/context/src/test/late-provider_test.ts
@@ -162,6 +162,8 @@ suiteSkipIE('late context provider', () => {
       'lazy-context-provider-consumer'
     ) as LazyContextProviderConsumerElement;
 
+    await provider.updateComplete;
+
     const consumer = provider.shadowRoot!.querySelector(
       'context-consumer'
     ) as ContextConsumerElement;


### PR DESCRIPTION
use `event.composedPath()` instead of `event.target` because of event retargeting in shadowDom.