### PR TITLE
[infra] Reorder release workflow actions for npm caching

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,13 +19,6 @@ jobs:
           git config --global user.name "Lit Robot"
           git config --global user.email "lit-robot@google.com"
 
-      - name: Setup Node.js 16
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16
-          cache: 'npm'
-          cache-dependency-path: package-lock.json
-
       - name: Checkout Lit Repo
         uses: actions/checkout@v3
         with:
@@ -33,6 +26,13 @@ jobs:
           # This makes Actions fetch all Git history so that Changesets can
           # generate changelogs with the correct commits
           fetch-depth: 0
+
+      - name: Setup Node.js 16
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: 'npm'
+          cache-dependency-path: lit/package-lock.json
 
       - name: Install Dependencies
         working-directory: lit


### PR DESCRIPTION
Release workflow was broken by https://github.com/lit/lit/pull/3724 as it added the `cache` option to the setup-node action but the `package-lock.json` file wasn't available because the repo hadn't been checked out yet.

This fixes the ordering and accounts for the checkout happening in a nested `lit/` directory.