### PR TITLE
[lit-element] Remove lit-element@2.x back-compat exports

### DIFF
--- a/.changeset/healthy-planes-smash.md
+++ b/.changeset/healthy-planes-smash.md
@@ -1,0 +1,5 @@
+---
+'lit-element': major
+---
+
+Remove UpdatingElement alias for ReactiveElement

--- a/.changeset/yellow-starfishes-rush.md
+++ b/.changeset/yellow-starfishes-rush.md
@@ -1,0 +1,5 @@
+---
+'lit-element': major
+---
+
+Remove re-export of decorators from main lit-element module

--- a/packages/lit-element/src/index.ts
+++ b/packages/lit-element/src/index.ts
@@ -7,11 +7,3 @@
 export * from '@lit/reactive-element';
 export * from 'lit-html';
 export * from './lit-element.js';
-export * from './decorators.js';
-
-console.warn(
-  "The main 'lit-element' module entrypoint is deprecated. Please update " +
-    "your imports to use the 'lit' package: 'lit' and 'lit/decorators.ts' " +
-    "or import from 'lit-element/lit-element.ts'. See " +
-    'https://lit.dev/msg/deprecated-import-path for more information.'
-);

--- a/packages/lit-element/src/lit-element.ts
+++ b/packages/lit-element/src/lit-element.ts
@@ -79,10 +79,6 @@ export namespace Unstable {
   }
 }
 
-// For backwards compatibility export ReactiveElement as UpdatingElement. Note,
-// IE transpilation requires exporting like this.
-export const UpdatingElement = ReactiveElement;
-
 const DEV_MODE = true;
 
 let issueWarning: (code: string, warning: string) => void;

--- a/packages/lit-element/src/test/lit-element_test.ts
+++ b/packages/lit-element/src/test/lit-element_test.ts
@@ -4,14 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {
-  html,
-  LitElement,
-  UpdatingElement,
-  ReactiveElement,
-  Part,
-  nothing,
-} from 'lit-element';
+import {html, LitElement, ReactiveElement, Part, nothing} from 'lit-element';
 import {directive, AsyncDirective} from 'lit-html/async-directive.js';
 import {
   canTestLitElement,
@@ -306,15 +299,6 @@ import {createRef, ref} from 'lit-html/directives/ref.js';
 
   test('can use ReactiveElement', async () => {
     class A extends ReactiveElement {}
-    customElements.define(generateElementName(), A);
-    const a = new A();
-    container.appendChild(a);
-    await a.updateComplete;
-    assert.ok(a.hasUpdated);
-  });
-
-  test('can use UpdatingElement', async () => {
-    class A extends UpdatingElement {}
     customElements.define(generateElementName(), A);
     const a = new A();
     container.appendChild(a);

--- a/packages/reactive-element/README.md
+++ b/packages/reactive-element/README.md
@@ -9,10 +9,6 @@
 
 A simple low level base class for creating fast, lightweight web components.
 
-## About this release
-
-This is a stable release of `@lit/reactive-element` 1.0.0 (part of the Lit 2.0 release). If upgrading from previous versions of `UpdatingElement`, please see the [Upgrade Guide](https://lit.dev/docs/releases/upgrade/).
-
 ## Documentation
 
 Full documentation is available at [lit.dev](https://lit.dev/docs/api/ReactiveElement/).

--- a/packages/ts-transformers/src/tests/idiomatic-decorators-test.ts
+++ b/packages/ts-transformers/src/tests/idiomatic-decorators-test.ts
@@ -1644,8 +1644,6 @@ const tests = (test: uvu.Test<uvu.Context>, options: ts.CompilerOptions) => {
     'lit/decorators/custom-element.js',
     '@lit/reactive-element/decorators.js',
     '@lit/reactive-element/decorators/custom-element.js',
-    'lit-element',
-    'lit-element/index.js',
     'lit-element/decorators.js',
   ]) {
     test(`various valid import specifiers [${specifier}]`, () => {
@@ -1674,7 +1672,6 @@ const tests = (test: uvu.Test<uvu.Context>, options: ts.CompilerOptions) => {
     'lit/decorators/custom-element',
     '@lit/reactive-element/decorators',
     '@lit/reactive-element/decorators/custom-element',
-    'lit-element/index',
     'lit-element/decorators',
   ]) {
     test(`various invalid import specifiers [${specifier}]`, () => {

--- a/packages/ts-transformers/src/tests/idiomatic-decorators-test.ts
+++ b/packages/ts-transformers/src/tests/idiomatic-decorators-test.ts
@@ -1692,7 +1692,8 @@ const tests = (test: uvu.Test<uvu.Context>, options: ts.CompilerOptions) => {
 
   test('only remove imports that will be transformed', () => {
     const input = `
-    import {LitElement, customElement} from 'lit-element';
+    import {LitElement} from 'lit-element';
+    import {customElement} from 'lit-element/decorators.js';
 
     @customElement('my-element')
     class MyElement extends LitElement {
@@ -1711,7 +1712,8 @@ const tests = (test: uvu.Test<uvu.Context>, options: ts.CompilerOptions) => {
 
   test("don't remove existing no-binding import", () => {
     const input = `
-    import {LitElement, customElement} from 'lit-element';
+    import {LitElement} from 'lit-element';
+    import {customElement} from 'lit-element/decorators.js';
     import './my-custom-element.js';
 
     @customElement('my-element')


### PR DESCRIPTION
This removes `UpdatingElement` from lit-element.ts and decorators from `index.ts`