### PR TITLE
Remove Lit 1 -> Lit 2 migration warnings

### DIFF
--- a/.changeset/fifty-forks-decide.md
+++ b/.changeset/fifty-forks-decide.md
@@ -1,0 +1,8 @@
+---
+'@lit/reactive-element': patch
+'lit-element': patch
+'lit-html': patch
+'lit': patch
+---
+
+Remove Lit 1 -> Lit 2 migration warnings

--- a/packages/lit-element/src/lit-element.ts
+++ b/packages/lit-element/src/lit-element.ts
@@ -235,36 +235,6 @@ const polyfillSupport = DEV_MODE
   : globalThis.litElementPolyfillSupport;
 polyfillSupport?.({LitElement});
 
-// DEV mode warnings
-if (DEV_MODE) {
-  /* eslint-disable @typescript-eslint/no-explicit-any */
-  // Note, for compatibility with closure compilation, this access
-  // needs to be as a string property index.
-  (LitElement as any)['finalize'] = function (this: typeof LitElement) {
-    const finalized = (ReactiveElement as any).finalize.call(this);
-    if (!finalized) {
-      return false;
-    }
-    const warnRemovedOrRenamed = (obj: any, name: string, renamed = false) => {
-      if (obj.hasOwnProperty(name)) {
-        const ctorName = (typeof obj === 'function' ? obj : obj.constructor)
-          .name;
-        issueWarning(
-          renamed ? 'renamed-api' : 'removed-api',
-          `\`${name}\` is implemented on class ${ctorName}. It ` +
-            `has been ${renamed ? 'renamed' : 'removed'} ` +
-            `in this version of LitElement.`
-        );
-      }
-    };
-    warnRemovedOrRenamed(this, 'render');
-    warnRemovedOrRenamed(this, 'getStyles', true);
-    warnRemovedOrRenamed((this as typeof LitElement).prototype, 'adoptStyles');
-    return true;
-  };
-  /* eslint-enable @typescript-eslint/no-explicit-any */
-}
-
 /**
  * END USERS SHOULD NOT RELY ON THIS OBJECT.
  *

--- a/packages/lit-element/src/test/lit-element_dev_mode_test.ts
+++ b/packages/lit-element/src/test/lit-element_dev_mode_test.ts
@@ -5,7 +5,6 @@
  */
 
 import {LitElement} from 'lit-element';
-import {generateElementName} from './test-helpers.js';
 import {assert} from '@esm-bundle/chai';
 
 // Note, since tests are not built with production support, detect DEV_MODE
@@ -46,62 +45,6 @@ if (DEV_MODE) {
         Array.from(litWarnings).filter((v) => v?.includes('dev mode')).length,
         1
       );
-    });
-
-    test('warns when `static render` is implemented', () => {
-      class WarnRender extends LitElement {
-        static render() {}
-      }
-      customElements.define(generateElementName(), WarnRender);
-      new WarnRender();
-      assert.equal(warnings.length, 1);
-      assert.include(warnings[0], 'render');
-    });
-
-    test('warns on first instance only', () => {
-      class WarnFirstInstance extends LitElement {
-        static render() {}
-      }
-      customElements.define(generateElementName(), WarnFirstInstance);
-      new WarnFirstInstance();
-      new WarnFirstInstance();
-      new WarnFirstInstance();
-      assert.equal(warnings.length, 1);
-      assert.include(warnings[0], 'render');
-    });
-
-    test('warns once per implementation (does not spam)', () => {
-      class WarnPerImpl extends LitElement {
-        static render() {}
-      }
-      customElements.define(generateElementName(), WarnPerImpl);
-      class WarnPerImplSub extends WarnPerImpl {}
-      customElements.define(generateElementName(), WarnPerImplSub);
-      new WarnPerImpl();
-      new WarnPerImplSub();
-      assert.equal(warnings.length, 1);
-      assert.include(warnings[0], WarnPerImpl.name);
-      assert.include(warnings[0], 'render');
-    });
-
-    test('warns when `static getStyles` is implemented', () => {
-      class WarnGetStyles extends LitElement {
-        static getStyles() {}
-      }
-      customElements.define(generateElementName(), WarnGetStyles);
-      new WarnGetStyles();
-      assert.equal(warnings.length, 1);
-      assert.include(warnings[0], 'getStyles');
-    });
-
-    test('warns when `adoptStyles` is implemented', () => {
-      class WarnAdoptStyles extends LitElement {
-        adoptStyles() {}
-      }
-      customElements.define(generateElementName(), WarnAdoptStyles);
-      new WarnAdoptStyles();
-      assert.equal(warnings.length, 1);
-      assert.include(warnings[0], 'adoptStyles');
     });
   });
 }

--- a/packages/reactive-element/src/test/reactive-element_dev_mode_test.ts
+++ b/packages/reactive-element/src/test/reactive-element_dev_mode_test.ts
@@ -62,54 +62,6 @@ if (DEV_MODE) {
       );
     });
 
-    test('warns when `initialize` is implemented', () => {
-      class WarnInitialize extends ReactiveElement {
-        initialize() {}
-      }
-      customElements.define(generateElementName(), WarnInitialize);
-      new WarnInitialize();
-      assert.equal(warnings.length, 1);
-      assert.include(warnings[0], WarnInitialize.name);
-      assert.include(warnings[0], 'initialize');
-    });
-
-    test('warns on first instance only', () => {
-      class WarnFirstInstance extends ReactiveElement {
-        initialize() {}
-      }
-      customElements.define(generateElementName(), WarnFirstInstance);
-      new WarnFirstInstance();
-      new WarnFirstInstance();
-      new WarnFirstInstance();
-      assert.equal(warnings.length, 1);
-      assert.include(warnings[0], WarnFirstInstance.name);
-      assert.include(warnings[0], 'initialize');
-    });
-
-    test('warns once per implementation (does not spam)', () => {
-      class WarnPerImplBase extends ReactiveElement {
-        initialize() {}
-      }
-      customElements.define(generateElementName(), WarnPerImplBase);
-      class WarnPerImplSub extends WarnPerImplBase {}
-      customElements.define(generateElementName(), WarnPerImplSub);
-      new WarnPerImplBase();
-      new WarnPerImplSub();
-      assert.equal(warnings.length, 1);
-      assert.include(warnings[0], WarnPerImplBase.name);
-      assert.include(warnings[0], 'initialize');
-    });
-
-    test('warns when `requestUpdateInternal` is implemented', () => {
-      class WarnRequestUpdateInternal extends ReactiveElement {
-        requestUpdateInternal() {}
-      }
-      customElements.define(generateElementName(), WarnRequestUpdateInternal);
-      new WarnRequestUpdateInternal();
-      assert.equal(warnings.length, 1);
-      assert.include(warnings[0], 'requestUpdateInternal');
-    });
-
     suite('shadowed reactive properties', () => {
       test('throws when reactive properties defined by the current class are shadowed by class fields', async () => {
         class ShadowedProps extends ReactiveElement {
@@ -269,20 +221,6 @@ if (DEV_MODE) {
         el.requestUpdate();
         await el.updateComplete;
       });
-    });
-
-    test('warns when awaiting `requestUpdate`', async () => {
-      class WarnAwaitRequestUpdate extends ReactiveElement {}
-      customElements.define(generateElementName(), WarnAwaitRequestUpdate);
-      const a = new WarnAwaitRequestUpdate();
-      container.appendChild(a);
-      await a.requestUpdate();
-      assert.equal(warnings.length, 1);
-      assert.include(warnings[0], 'requestUpdate');
-      assert.include(warnings[0], 'Promise');
-      // warns once, does not spam.
-      await a.requestUpdate();
-      assert.equal(warnings.length, 1);
     });
 
     suite('conditional warnings', () => {


### PR DESCRIPTION
These are all dev mode things, but I think it's good to clean this up too so we don't collect cruft over time. Less code is easier to maintain.