### PR TITLE
Fixed bug that boolean was not parsed correct

### DIFF
--- a/packages/reactive-element/src/reactive-element.ts
+++ b/packages/reactive-element/src/reactive-element.ts
@@ -335,7 +335,7 @@ export const defaultConverter: ComplexAttributeConverter = {
     let fromValue: unknown = value;
     switch (type) {
       case Boolean:
-        fromValue = value !== null;
+        fromValue = value === null ? null : Boolean(value);
         break;
       case Number:
         fromValue = value === null ? null : Number(value);


### PR DESCRIPTION
This bugged me for ours: The boolean values are not parsed correct inside the defaultParser.

I found this, when loading a LitElement asynchronously by Vue.js like this: 
`<loading-blocker :loading="loading"></loading-blocker> `