### PR TITLE
[lit-html] styleMap fails when update contains priority directive

### DIFF
--- a/.changeset/popular-shoes-carry.md
+++ b/.changeset/popular-shoes-carry.md
@@ -1,0 +1,6 @@
+---
+'lit-html': patch
+'lit': patch
+---
+
+[lit-html] styleMap fails when update contains priority directive

--- a/.changeset/popular-shoes-carry.md
+++ b/.changeset/popular-shoes-carry.md
@@ -3,4 +3,4 @@
 'lit': patch
 ---
 
-[lit-html] styleMap fails when update contains priority directive
+Fix styleMap's handling of important flags

--- a/.eslintignore
+++ b/.eslintignore
@@ -10,6 +10,7 @@ node_modules/
 .vscode/
 .wireit
 /temp
+.idea
 
 packages/benchmarks/generated/
 packages/benchmarks/generator/build/

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules/
 .vscode/
 .wireit
 /temp
+.idea

--- a/.prettierignore
+++ b/.prettierignore
@@ -10,6 +10,7 @@ node_modules/
 .vscode/
 .wireit
 /temp
+.idea
 
 packages/benchmarks/generated/
 packages/benchmarks/generator/build/

--- a/packages/lit-html/src/directives/style-map.ts
+++ b/packages/lit-html/src/directives/style-map.ts
@@ -24,6 +24,9 @@ export interface StyleInfo {
   [name: string]: string | undefined | null;
 }
 
+const IMPORTNAT_PRIORITY = 'important';
+const IMPORTANT_DIRECTIVE = '!important';
+
 class StyleMapDirective extends Directive {
   _previousStyleProperties?: Set<string>;
 
@@ -95,11 +98,13 @@ class StyleMapDirective extends Directive {
       const value = styleInfo[name];
       if (value != null) {
         this._previousStyleProperties.add(name);
-        if (name.includes('-')) {
-          style.setProperty(name, value);
+        const valueToUse = value.replace(IMPORTANT_DIRECTIVE, '');
+        const priority = valueToUse !== value ? IMPORTNAT_PRIORITY : '';
+        if (name.includes('-') || priority) {
+          style.setProperty(name, valueToUse, priority);
         } else {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          (style as any)[name] = value;
+          (style as any)[name] = valueToUse;
         }
       }
     }

--- a/packages/lit-html/src/directives/style-map.ts
+++ b/packages/lit-html/src/directives/style-map.ts
@@ -24,8 +24,11 @@ export interface StyleInfo {
   [name: string]: string | undefined | null;
 }
 
-const IMPORTNAT_PRIORITY = 'important';
-const IMPORTANT_DIRECTIVE = '!important';
+const important = 'important';
+// The leading space is important
+const importantFlag = ' !' + important;
+// How many characters to remove from a value, as a negative number
+const flagTrim = 0 - importantFlag.length;
 
 class StyleMapDirective extends Directive {
   _previousStyleProperties?: Set<string>;
@@ -98,13 +101,16 @@ class StyleMapDirective extends Directive {
       const value = styleInfo[name];
       if (value != null) {
         this._previousStyleProperties.add(name);
-        const valueToUse = value.replace(IMPORTANT_DIRECTIVE, '');
-        const priority = valueToUse !== value ? IMPORTNAT_PRIORITY : '';
-        if (name.includes('-') || priority) {
-          style.setProperty(name, valueToUse, priority);
+        const isImportant = value.endsWith(importantFlag);
+        if (name.includes('-') || isImportant) {
+          style.setProperty(
+            name,
+            isImportant ? value.slice(0, flagTrim) : value,
+            isImportant ? important : ''
+          );
         } else {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          (style as any)[name] = valueToUse;
+          (style as any)[name] = value;
         }
       }
     }

--- a/packages/lit-html/src/test/directives/style-map_test.ts
+++ b/packages/lit-html/src/test/directives/style-map_test.ts
@@ -133,6 +133,21 @@ suite('styleMap', () => {
     assert.equal(el.style.getPropertyValue('--size'), '');
   });
 
+  test('adds priority in updated properties', () => {
+    renderStyleMap({color: 'blue !important'});
+    const el = container.firstElementChild as HTMLElement;
+    assert.equal(el.style.getPropertyValue('color'), 'blue');
+    assert.equal(el.style.getPropertyPriority('color'), 'important');
+    renderStyleMap({color: 'green !important'});
+    assert.equal(el.style.getPropertyValue('color'), 'green');
+    assert.equal(el.style.getPropertyPriority('color'), 'important');
+    renderStyleMap({color: 'red'});
+    assert.equal(el.style.getPropertyValue('color'), 'red');
+    assert.equal(el.style.getPropertyPriority('color'), '');
+    renderStyleMap({});
+    assert.equal(el.style.getPropertyValue('color'), '');
+  });
+
   test('works when used with the same object', () => {
     const styleInfo: StyleInfo = {marginTop: '2px', 'padding-bottom': '4px'};
     renderStyleMap(styleInfo);


### PR DESCRIPTION
fix: #3767

Added test to verify that issue existed before, and fixed.

The fix is simple - remove the `!important` directive if exists, and set the `priority` argument in the call to `setProperty`