### PR TITLE
[labs/observers] WIP: try removing initial update from ResizeController

### DIFF
--- a/packages/labs/observers/src/resize-controller.ts
+++ b/packages/labs/observers/src/resize-controller.ts
@@ -70,7 +70,7 @@ export class ResizeController<T = unknown> implements ReactiveController {
    * state and is performed async by requesting a host update and calling
    * `handleChanges` once by checking and then resetting this flag.
    */
-  private _unobservedUpdate = false;
+  // private _unobservedUpdate = false;
   /**
    * The result of processing the observer's changes via the `callback`
    * function.
@@ -129,10 +129,10 @@ export class ResizeController<T = unknown> implements ReactiveController {
     // Handle initial state as a set of 0 changes. This helps setup initial
     // state and promotes UI = f(state) since ideally the callback does not
     // rely on changes.
-    if (!this._skipInitial && this._unobservedUpdate) {
-      this.handleChanges([]);
-    }
-    this._unobservedUpdate = false;
+    // if (!this._skipInitial && this._unobservedUpdate) {
+    //   this.handleChanges([]);
+    // }
+    // this._unobservedUpdate = false;
   }
 
   /**
@@ -143,8 +143,11 @@ export class ResizeController<T = unknown> implements ReactiveController {
   observe(target: Element) {
     this._targets.add(target);
     this._observer.observe(target, this._config);
-    this._unobservedUpdate = true;
-    this._host.requestUpdate();
+    // this._unobservedUpdate = true;
+    // No public state is updated immediately when we observe an element,
+    // so we don't need to call `host.requestUpdate()`. If we add such
+    // state (like a count of observed elements), we'll need to call
+    // requestUpdate() here and unobserve().
   }
 
   /**

--- a/packages/labs/observers/src/test/resize-controller_test.ts
+++ b/packages/labs/observers/src/test/resize-controller_test.ts
@@ -117,7 +117,7 @@ if (DEV_MODE) {
     const el = await getTestElement();
 
     // Reports initial change by default
-    assert.isTrue(el.observerValue);
+    // assert.isTrue(el.observerValue, 'A');
 
     // Reports attribute change
     el.resetObserverValue();
@@ -424,14 +424,14 @@ if (DEV_MODE) {
     const el = (await renderTestElement(TestFirstUpdated)) as TestFirstUpdated;
 
     // Reports initial change by default
-    assert.isTrue(el.observerValue);
+    // assert.isTrue(el.observerValue, 'A');
 
     // Reports attribute change
     el.resetObserverValue();
     assert.isUndefined(el.observerValue);
     resizeElement(el);
     await resizeComplete();
-    assert.isTrue(el.observerValue);
+    assert.isTrue(el.observerValue, 'B');
   });
 
   test('can observe external element after host connected', async () => {


### PR DESCRIPTION
We're getting questions about why ResizeController causes two consecutive host updates. It seems like ResizeObservers already call the observer callback unconditionally, so our code to do that as well made there be two updates. Can we just remove our custom initial call to handleChanges? This would let us remove skipInitial altogether.

wdyt @sorvell ?