### PR TITLE
[labs/ssr-client] Fix for removing `@types/web-ie11` dep

### DIFF
--- a/packages/labs/ssr-client/src/lib/hydrate-lit-html.ts
+++ b/packages/labs/ssr-client/src/lib/hydrate-lit-html.ts
@@ -146,12 +146,7 @@ export const hydrate = (
   // templates
   const stack: Array<ChildPartState> = [];
 
-  const walker = document.createTreeWalker(
-    container,
-    NodeFilter.SHOW_COMMENT,
-    null,
-    false
-  );
+  const walker = document.createTreeWalker(container, NodeFilter.SHOW_COMMENT);
   let marker: Comment | null;
 
   // Walk the DOM looking for part marker comments


### PR DESCRIPTION
I brought in https://github.com/lit/lit/pull/3720 to `3.0` branch by merging in `main` which broke the build step.

This PR brings in the change done in https://github.com/lit/lit/pull/3758 to the copied code in `labs/ssr-client`.