### PR TITLE
Coerce toggleAttribute's second arg to boolean

### DIFF
--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -1858,7 +1858,7 @@ class BooleanAttributePart extends AttributePart {
     });
     (wrap(this.element) as Element).toggleAttribute(
       this.name,
-      (value as boolean) && value !== nothing
+      !!value && value !== nothing
     );
   }
 }

--- a/packages/lit-html/src/test/lit-html_test.ts
+++ b/packages/lit-html/src/test/lit-html_test.ts
@@ -1154,6 +1154,20 @@ suite('lit-html', () => {
       assertContent('<div foo=""></div>');
       assert.isEmpty(observer.takeRecords());
     });
+
+    test('binding undefined removes the attribute', () => {
+      const go = (v: unknown) => render(html`<div ?foo=${v}></div>`, container);
+      go(undefined);
+      assertContent('<div></div>');
+      // it doesn't toggle the attribute
+      go(undefined);
+      assertContent('<div></div>');
+      // it does remove it
+      go(true);
+      assertContent('<div foo=""></div>');
+      go(undefined);
+      assertContent('<div></div>');
+    });
   });
 
   suite('properties', () => {


### PR DESCRIPTION
Otherwise binding the value `undefined` to a boolean part would mean `toggle` rather than `false`