### PR TITLE
Relax the typescript version for localize-tools

### DIFF
--- a/.changeset/angry-rockets-search.md
+++ b/.changeset/angry-rockets-search.md
@@ -1,0 +1,5 @@
+---
+'@lit/localize-tools': patch
+---
+
+Relax the typescript version for compatibility with typescript > 4.7 && < 5.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -25770,7 +25770,7 @@
       }
     },
     "packages/lit": {
-      "version": "2.7.1",
+      "version": "2.7.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit/reactive-element": "^1.6.0",
@@ -25803,7 +25803,7 @@
       }
     },
     "packages/lit-html": {
-      "version": "2.7.1",
+      "version": "2.7.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
@@ -25900,7 +25900,7 @@
         "minimist": "^1.2.5",
         "parse5": "^6.0.1",
         "source-map-support": "^0.5.19",
-        "typescript": "~4.7.4"
+        "typescript": "^4.7.4"
       },
       "bin": {
         "lit-localize": "bin/lit-localize.js"
@@ -26048,7 +26048,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "ts-clone-node": "^1.0.0",
-        "typescript": "~4.7.4"
+        "typescript": "^4.7.4"
       },
       "devDependencies": {
         "@lit/localize": "^0.11.0",
@@ -28470,7 +28470,7 @@
         "parse5": "^6.0.1",
         "rimraf": "^3.0.2",
         "source-map-support": "^0.5.19",
-        "typescript": "~4.7.4",
+        "typescript": "^4.7.4",
         "typescript-json-schema": "^0.54.0"
       },
       "dependencies": {
@@ -28526,7 +28526,7 @@
         "prettier": "^2.3.2",
         "rimraf": "^3.0.2",
         "ts-clone-node": "^1.0.0",
-        "typescript": "~4.7.4"
+        "typescript": "^4.7.4"
       }
     },
     "@manypkg/find-root": {

--- a/packages/localize-tools/package.json
+++ b/packages/localize-tools/package.json
@@ -139,7 +139,7 @@
     "minimist": "^1.2.5",
     "parse5": "^6.0.1",
     "source-map-support": "^0.5.19",
-    "typescript": "~4.7.4"
+    "typescript": "^4.7.4"
   },
   "devDependencies": {
     "@lit-labs/ssr": "^3.1.0",

--- a/packages/ts-transformers/package.json
+++ b/packages/ts-transformers/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "ts-clone-node": "^1.0.0",
-    "typescript": "~4.7.4"
+    "typescript": "^4.7.4"
   },
   "devDependencies": {
     "@lit/localize": "^0.11.0",


### PR DESCRIPTION
Fixes #3739 

By relaxing the typescript version from `~4.7.4` to `^4.7.4`, we allow it to use `4.8` and `4.9` as well. This fixes the problem with localize-tools where it uses typescript 4.7, but the project used 4.8 or 4.9. This breaks because of breaking changes between 4.7 and greater.

Note: so `5.0` is not valid here. I'm not sure whether we want to allow that yet.