### PR TITLE
[labs/analyzer] CSS variable fallbacks

### DIFF
--- a/.changeset/modern-numbers-turn.md
+++ b/.changeset/modern-numbers-turn.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/analyzer': minor
+---
+
+Add CSS Custom Property fallback (default) values to manifest

--- a/packages/labs/analyzer/src/lib/javascript/jsdoc.ts
+++ b/packages/labs/analyzer/src/lib/javascript/jsdoc.ts
@@ -49,18 +49,20 @@ const parseNameDescRE = /^(?<name>^\S+)(?:\s?-\s+)?(?<description>[\s\S]*)$/m;
 // Regex for parsing optional name and description from JSDoc comments, where
 // the dash is required before the description (syntax for `@slot` tag, whose
 // default slot has no name)
-const parseNameDashDescRE =
-  /^(?<name>^\S*)?(?:\s+-\s+(?<description>[\s\S]*))?$/m;
+const parseNameDashDescRE = /^(?<name>^\S*)?(?:\s+-\s+(?<description>.+))?$/m;
 
-// Regex for parsing name and description from JSDoc comments
+// Regex for parsing optional name, default, and description from JSDoc comments
 const parseNameDefaultDescRE =
-  /^\[(?<name>[^[\s=]*)=(?<defaultValue>[^\]]*)\](?:\s+-\s+(?<description>[\s\S]*))?/m;
+  /^\[(?<name>[^[\s=]+)=?(?<defaultValue>[^\]]+)?\](?:\s+-\s+(?<description>.+))?/m;
 
 // Regex for parsing optional name and description from JSDoc comments, where
 // the dash is required before the description (syntax for `@slot` tag, whose
 // default slot has no name)
 const parseNameDefaultDashDescRE =
-  /^\[(?<name>[^[\s=]*)=(?<defaultValue>[^\]]*)\](?:\s+-\s+(?<description>[\s\S]*))?$/m;
+  /^\[(?<name>[^[\s=]+)=?(?<defaultValue>[^\]]+)?\](?:\s+-\s+(?<description>.+))?$/m;
+
+// is it an optional jsdoc prop name?
+const isOptionalJSDocNameRegex = /^\[.+(?:=.+)?\]/;
 
 const getJSDocTagComment = (tag: ts.JSDocTag) => {
   let {comment} = tag;
@@ -144,7 +146,7 @@ export const parseNamedJSDocInfo = (
   if (comment == undefined) {
     return undefined;
   }
-  if (comment.match(/^\[.+=.+\]/)) {
+  if (isOptionalJSDocNameRegex.test(comment)) {
     const nameDefaultDesc = comment.match(
       requireDash ? parseNameDefaultDashDescRE : parseNameDefaultDescRE
     );

--- a/packages/labs/analyzer/src/lib/javascript/jsdoc.ts
+++ b/packages/labs/analyzer/src/lib/javascript/jsdoc.ts
@@ -50,7 +50,7 @@ const parseNameDashDescRE =
 
 // Regex for parsing optional name, default, and description from JSDoc comments
 const parseNameDescRE =
-  /^\[?(?<name>[^[\]\s=]+)(?:=(?<defaultValue>[^\]]+))?\]?(?<description>[\s\S]*)$/;
+  /^\[?(?<name>[^[\]\s=]+)(?:=(?<defaultValue>[^\]]+))?\]?(?:\s+-\s+)?(?<description>[\s\S]*)$/;
 
 const getJSDocTagComment = (tag: ts.JSDocTag) => {
   let {comment} = tag;

--- a/packages/labs/analyzer/src/lib/model.ts
+++ b/packages/labs/analyzer/src/lib/model.ts
@@ -534,9 +534,6 @@ export interface Described {
 
 export interface NamedDescribed extends Described {
   name: string;
-}
-
-export interface NamedDescribedDefault extends NamedDescribed {
   default?: string;
 }
 
@@ -573,7 +570,7 @@ export class CustomElementDeclaration extends ClassDeclaration {
   readonly tagname: string | undefined;
   readonly events: Map<string, Event>;
   readonly slots: Map<string, NamedDescribed>;
-  readonly cssProperties: Map<string, NamedDescribedDefault>;
+  readonly cssProperties: Map<string, NamedDescribed>;
   readonly cssParts: Map<string, NamedDescribed>;
 
   constructor(init: CustomElementDeclarationInit) {

--- a/packages/labs/analyzer/src/lib/model.ts
+++ b/packages/labs/analyzer/src/lib/model.ts
@@ -536,6 +536,10 @@ export interface NamedDescribed extends Described {
   name: string;
 }
 
+export interface NamedDescribedDefault extends NamedDescribed {
+  default?: string;
+}
+
 export interface TypedNamedDescribed extends NamedDescribed {
   type?: string;
 }
@@ -569,7 +573,7 @@ export class CustomElementDeclaration extends ClassDeclaration {
   readonly tagname: string | undefined;
   readonly events: Map<string, Event>;
   readonly slots: Map<string, NamedDescribed>;
-  readonly cssProperties: Map<string, NamedDescribed>;
+  readonly cssProperties: Map<string, NamedDescribedDefault>;
   readonly cssParts: Map<string, NamedDescribed>;
 
   constructor(init: CustomElementDeclarationInit) {

--- a/packages/labs/analyzer/src/test/lit-element/jsdoc_test.ts
+++ b/packages/labs/analyzer/src/test/lit-element/jsdoc_test.ts
@@ -104,7 +104,7 @@ for (const lang of languages) {
   test('cssProperties - Correct number found', ({getModule}) => {
     const element = getModule('element-a').getDeclaration('ElementA');
     assert.ok(element.isLitElementDeclaration());
-    assert.equal(element.cssProperties.size, 6);
+    assert.equal(element.cssProperties.size, 9);
   });
 
   test('cssProperties - no-description', ({getModule}) => {
@@ -135,6 +135,30 @@ for (const lang of languages) {
     assert.ok(prop);
     assert.equal(prop.summary, undefined);
     assert.equal(prop.description, 'Description for --with-description-dash');
+  });
+
+  test('cssProperties - default-no-description', ({getModule}) => {
+    const element = getModule('element-a').getDeclaration('ElementA');
+    assert.ok(element.isLitElementDeclaration());
+    const prop = element.cssProperties.get('--default-no-description');
+    assert.ok(prop);
+    assert.equal(prop.default, '#324fff');
+  });
+
+  test('cssProperties - default-with-description', ({getModule}) => {
+    const element = getModule('element-a').getDeclaration('ElementA');
+    assert.ok(element.isLitElementDeclaration());
+    const prop = element.cssProperties.get('--default-with-description');
+    assert.ok(prop);
+    assert.equal(prop.default, '#324fff');
+  });
+
+  test('cssProperties - default-with-description-dash', ({getModule}) => {
+    const element = getModule('element-a').getDeclaration('ElementA');
+    assert.ok(element.isLitElementDeclaration());
+    const prop = element.cssProperties.get('--default-with-description-dash');
+    assert.ok(prop);
+    assert.equal(prop.default, '#324fff');
   });
 
   test('cssProperties - short-no-description', ({getModule}) => {

--- a/packages/labs/analyzer/src/test/vanilla-element/jsdoc_test.ts
+++ b/packages/labs/analyzer/src/test/vanilla-element/jsdoc_test.ts
@@ -106,7 +106,7 @@ for (const lang of languages) {
   test('cssProperties - Correct number found', ({getModule}) => {
     const element = getModule('element-a').getDeclaration('ElementA');
     assert.ok(element.isCustomElementDeclaration());
-    assert.equal(element.cssProperties.size, 9);
+    assert.equal(element.cssProperties.size, 12);
   });
 
   test('cssProperties - no-description', ({getModule}) => {
@@ -161,6 +161,30 @@ for (const lang of languages) {
     const prop = element.cssProperties.get('--default-with-description-dash');
     assert.ok(prop);
     assert.equal(prop.default, '#324fff');
+  });
+
+  test('cssProperties - optional-no-description', ({getModule}) => {
+    const element = getModule('element-a').getDeclaration('ElementA');
+    assert.ok(element.isCustomElementDeclaration());
+    const prop = element.cssProperties.get('--optional-no-description');
+    assert.ok(prop);
+    assert.equal(prop.default, undefined);
+  });
+
+  test('cssProperties - optional-with-description', ({getModule}) => {
+    const element = getModule('element-a').getDeclaration('ElementA');
+    assert.ok(element.isCustomElementDeclaration());
+    const prop = element.cssProperties.get('--optional-with-description');
+    assert.ok(prop);
+    assert.equal(prop.default, undefined);
+  });
+
+  test('cssProperties - optional-with-description-dash', ({getModule}) => {
+    const element = getModule('element-a').getDeclaration('ElementA');
+    assert.ok(element.isCustomElementDeclaration());
+    const prop = element.cssProperties.get('--optional-with-description-dash');
+    assert.ok(prop);
+    assert.equal(prop.default, undefined);
   });
 
   test('cssProperties - short-no-description', ({getModule}) => {

--- a/packages/labs/analyzer/src/test/vanilla-element/jsdoc_test.ts
+++ b/packages/labs/analyzer/src/test/vanilla-element/jsdoc_test.ts
@@ -106,7 +106,7 @@ for (const lang of languages) {
   test('cssProperties - Correct number found', ({getModule}) => {
     const element = getModule('element-a').getDeclaration('ElementA');
     assert.ok(element.isCustomElementDeclaration());
-    assert.equal(element.cssProperties.size, 6);
+    assert.equal(element.cssProperties.size, 9);
   });
 
   test('cssProperties - no-description', ({getModule}) => {
@@ -137,6 +137,30 @@ for (const lang of languages) {
     assert.ok(prop);
     assert.equal(prop.summary, undefined);
     assert.equal(prop.description, 'Description for --with-description-dash');
+  });
+
+  test('cssProperties - default-no-description', ({getModule}) => {
+    const element = getModule('element-a').getDeclaration('ElementA');
+    assert.ok(element.isCustomElementDeclaration());
+    const prop = element.cssProperties.get('--default-no-description');
+    assert.ok(prop);
+    assert.equal(prop.default, '#324fff');
+  });
+
+  test('cssProperties - default-with-description', ({getModule}) => {
+    const element = getModule('element-a').getDeclaration('ElementA');
+    assert.ok(element.isCustomElementDeclaration());
+    const prop = element.cssProperties.get('--default-with-description');
+    assert.ok(prop);
+    assert.equal(prop.default, '#324fff');
+  });
+
+  test('cssProperties - default-with-description-dash', ({getModule}) => {
+    const element = getModule('element-a').getDeclaration('ElementA');
+    assert.ok(element.isCustomElementDeclaration());
+    const prop = element.cssProperties.get('--default-with-description-dash');
+    assert.ok(prop);
+    assert.equal(prop.default, '#324fff');
   });
 
   test('cssProperties - short-no-description', ({getModule}) => {

--- a/packages/labs/analyzer/test-files/js/jsdoc/element-a.js
+++ b/packages/labs/analyzer/test-files/js/jsdoc/element-a.js
@@ -11,7 +11,7 @@ import {LitElement} from 'lit';
  *
  * @slot - Description for default slot
  * @slot no-description
- * @slot with-description - Description for with-description
+ * @slot with-description Description for with-description
  * with wraparound
  * @slot with-description-dash - Description for with-description-dash
  * @cssPart no-description
@@ -22,6 +22,10 @@ import {LitElement} from 'lit';
  * @cssProperty --with-description Description for --with-description
  * with wraparound
  * @cssProperty --with-description-dash - Description for --with-description-dash
+ * @cssProperty [--default-no-description=#324fff]
+ * @cssProperty [--default-with-description=#324fff] Description for --default-with-description
+ * with wraparound
+ * @cssProperty [--default-with-description-dash=#324fff] - Description for --default-with-description-dash
  * @cssProp --short-no-description
  * @cssProp --short-with-description Description for --short-with-description
  * with wraparound

--- a/packages/labs/analyzer/test-files/js/vanilla-jsdoc/element-a.js
+++ b/packages/labs/analyzer/test-files/js/vanilla-jsdoc/element-a.js
@@ -24,6 +24,10 @@
  * @cssProperty [--default-with-description=#324fff] Description for --default-with-description
  * with wraparound
  * @cssProperty [--default-with-description-dash=#324fff] - Description for --default-with-description-dash
+ * @cssProperty [--optional-no-description]
+ * @cssProperty [--optional-with-description] Description for --optional-with-description
+ * with wraparound
+ * @cssProperty [--optional-with-description-dash] - Description for --optional-with-description-dash
  * @cssProp --short-no-description
  * @cssProp --short-with-description Description for --short-with-description
  * with wraparound

--- a/packages/labs/analyzer/test-files/js/vanilla-jsdoc/element-a.js
+++ b/packages/labs/analyzer/test-files/js/vanilla-jsdoc/element-a.js
@@ -9,7 +9,7 @@
  *
  * @slot - Description for default slot
  * @slot no-description
- * @slot with-description - Description for with-description
+ * @slot with-description Description for with-description
  * with wraparound
  * @slot with-description-dash - Description for with-description-dash
  * @cssPart no-description
@@ -20,6 +20,10 @@
  * @cssProperty --with-description Description for --with-description
  * with wraparound
  * @cssProperty --with-description-dash - Description for --with-description-dash
+ * @cssProperty [--default-no-description=#324fff]
+ * @cssProperty [--default-with-description=#324fff] Description for --default-with-description
+ * with wraparound
+ * @cssProperty [--default-with-description-dash=#324fff] - Description for --default-with-description-dash
  * @cssProp --short-no-description
  * @cssProp --short-with-description Description for --short-with-description
  * with wraparound

--- a/packages/labs/analyzer/test-files/ts/jsdoc/src/element-a.ts
+++ b/packages/labs/analyzer/test-files/ts/jsdoc/src/element-a.ts
@@ -23,6 +23,10 @@ import {customElement} from 'lit/decorators.js';
  * @cssProperty --with-description Description for --with-description
  * with wraparound
  * @cssProperty --with-description-dash - Description for --with-description-dash
+ * @cssProperty [--default-no-description=#324fff]
+ * @cssProperty [--default-with-description=#324fff] Description for --default-with-description
+ * with wraparound
+ * @cssProperty [--default-with-description-dash=#324fff] - Description for --default-with-description-dash
  * @cssProp --short-no-description
  * @cssProp --short-with-description Description for --short-with-description
  * with wraparound

--- a/packages/labs/analyzer/test-files/ts/vanilla-jsdoc/src/element-a.ts
+++ b/packages/labs/analyzer/test-files/ts/vanilla-jsdoc/src/element-a.ts
@@ -24,6 +24,10 @@
  * @cssProperty [--default-with-description=#324fff] Description for --default-with-description
  * with wraparound
  * @cssProperty [--default-with-description-dash=#324fff] - Description for --default-with-description-dash
+ * @cssProperty [--optional-no-description]
+ * @cssProperty [--optional-with-description] Description for --optional-with-description
+ * with wraparound
+ * @cssProperty [--optional-with-description-dash] - Description for --optional-with-description-dash
  * @cssProp --short-no-description
  * @cssProp --short-with-description Description for --short-with-description
  * with wraparound

--- a/packages/labs/analyzer/test-files/ts/vanilla-jsdoc/src/element-a.ts
+++ b/packages/labs/analyzer/test-files/ts/vanilla-jsdoc/src/element-a.ts
@@ -20,6 +20,10 @@
  * @cssProperty --with-description Description for --with-description
  * with wraparound
  * @cssProperty --with-description-dash - Description for --with-description-dash
+ * @cssProperty [--default-no-description=#324fff]
+ * @cssProperty [--default-with-description=#324fff] Description for --default-with-description
+ * with wraparound
+ * @cssProperty [--default-with-description-dash=#324fff] - Description for --default-with-description-dash
  * @cssProp --short-no-description
  * @cssProp --short-with-description Description for --short-with-description
  * with wraparound


### PR DESCRIPTION
Closes #3811

```ts
/**
 * @license
 * Copyright 2022 Google LLC
 * SPDX-License-Identifier: BSD-3-Clause
 */

import {LitElement} from 'lit';
import {customElement} from 'lit/decorators.js';

/**
 * @cssProperty [--default-no-description=#324fff]
 * @cssProperty [--default-with-description=#324fff] Description for --default-with-description
 * with wraparound
 * @cssProperty [--default-with-description-dash=#324fff] - Description for --default-with-description-dash
 */
@customElement('element-a')
export class ElementA extends LitElement {}
```
```json
{
  "cssProperties": [
    { "name": "--default-no-description", "default": "#324fff" },
    { "name": "--default-with-description", "default": "#324fff" },
    {
      "name": "--default-with-description-dash",
      "description": "Description for --default-with-description-dash",
      "default": "#324fff"
    },
  ]
}
```