### PR TITLE
Fixes #3817

### DIFF
--- a/packages/labs/eleventy-plugin-lit/README.md
+++ b/packages/labs/eleventy-plugin-lit/README.md
@@ -349,7 +349,7 @@ The file `_includes/default.html` would then contain the following:
       if (!HTMLTemplateElement.prototype.hasOwnProperty('shadowRoot')) {
         // This browser does not have native declarative shadow DOM support, so we hide
         // the body until the template-shadowroot polyfill has executed
-        document.body.setAttribute('dsd-pending');
+        document.body.setAttribute('dsd-pending', '');
       }
     </script>
 

--- a/packages/labs/eleventy-plugin-lit/README.md
+++ b/packages/labs/eleventy-plugin-lit/README.md
@@ -344,12 +344,12 @@ The file `_includes/default.html` would then contain the following:
     </style>
   </head>
 
-  <body dsd-pending>
+  <body>
     <script>
-      if (HTMLTemplateElement.prototype.hasOwnProperty('shadowRoot')) {
-        // This browser has native declarative shadow DOM support, so we can
-        // allow painting immediately.
-        document.body.removeAttribute('dsd-pending');
+      if (!HTMLTemplateElement.prototype.hasOwnProperty('shadowRoot')) {
+        // This browser does not have native declarative shadow DOM support, so we hide
+        // the body until the template-shadowroot polyfill has executed
+        document.body.setAttribute('dsd-pending');
       }
     </script>
 


### PR DESCRIPTION
Update the example HTML document for [labs/eleventy-plugin-lit] to only hide the body element if the browser doesn't support DSD and needs to run the template-shadowroot polyfill.