### PR TITLE
[lit-html] Static `html` should not add consumed value to `TemplateResult`

### DIFF
--- a/.changeset/hot-rabbits-promise.md
+++ b/.changeset/hot-rabbits-promise.md
@@ -1,0 +1,6 @@
+---
+'lit-html': patch
+'lit': patch
+---
+
+`static-html` no longer adds an item to `TemplateResult`'s value array for the last consumed static value. This fixes an error with server-side rendering of static html.

--- a/packages/labs/ssr/src/test/integration/tests/basic.ts
+++ b/packages/labs/ssr/src/test/integration/tests/basic.ts
@@ -7,6 +7,7 @@
 import '@lit-labs/ssr-client/lit-element-hydrate-support.js';
 
 import {html, noChange, nothing, Part} from 'lit';
+import {html as staticHtml, literal} from 'lit/static-html.js';
 import {
   directive,
   Directive,
@@ -4249,6 +4250,28 @@ export const tests: {[name: string]: SSRTest} = {
       ],
       stableSelectors: ['div', 'span'],
     };
+  },
+
+  /******************************************************
+   * Static html tests
+   ******************************************************/
+
+  'Static html': {
+    render(x: unknown) {
+      const tagName = x === 'foo' ? literal`div` : literal`p`;
+      return staticHtml`<${tagName}>${x}</${tagName}>`;
+    },
+    expectations: [
+      {
+        args: ['foo'],
+        html: '<div>foo</div>',
+      },
+      {
+        args: ['foo2'],
+        html: '<p>foo2</p>',
+      },
+    ],
+    stableSelectors: [],
   },
 
   /******************************************************

--- a/packages/lit-html/src/static.ts
+++ b/packages/lit-html/src/static.ts
@@ -131,7 +131,10 @@ export const withStatic =
         s += staticValue + strings[++i];
         hasStatics = true;
       }
-      dynamicValues.push(dynamicValue);
+      // If the last value is static, we don't need to push it.
+      if (i !== l) {
+        dynamicValues.push(dynamicValue);
+      }
       staticStrings.push(s);
       i++;
     }

--- a/packages/lit-html/src/test/static_test.ts
+++ b/packages/lit-html/src/test/static_test.ts
@@ -177,4 +177,12 @@ suite('static', () => {
       '<div>[object Object]</div>'
     );
   });
+
+  test('static html should not add value for consumed static expression', () => {
+    const tagName = literal`div`;
+    const template = html`<${tagName}>${'foo'}</${tagName}>`;
+    assert.equal(template.values.length, 1);
+    const template2 = html`<${tagName}>${'foo'}</${tagName}>${'bar'}`;
+    assert.equal(template2.values.length, 2);
+  });
 });


### PR DESCRIPTION
Fixes #2246 

SSR of static html was erroring due to mismatch of `partIndex` as described in issue above because we were comparing that to the length of the `values` array in `TemplateResult`.

When a static value was the last value of a template, it ended up adding the static value object to the `TemplateResult`. This wasn't an issue if a non-static value was the last value.

i.e.
```js
const tag = literal`p`;
const template = html`<${tag}>Hello, ${this.name}!</${tag}`;
```
resulted in
```js
{
  strings: ['<p>Hello, ', '!</p>'],
  values: ['World', {_$litStatic$: 'p', r: Symbol()}],
}
```
when it should be
```js
{
  strings: ['<p>Hello, ', '!</p>'],
  values: ['World'],
}
```

In client rendering this wasn't an issue as we just never accessed that value. In SSR, it was causing the error due to the unexpected extra length.