### PR TITLE
[labs/gen-wrapper-vue] Pin version of `vue-tsc` to ~1.3

### DIFF
--- a/.changeset/loud-poems-pay.md
+++ b/.changeset/loud-poems-pay.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/gen-wrapper-vue': patch
+---
+
+Pin version of `vue-tsc` to ~1.3

--- a/packages/labs/gen-wrapper-vue/goldens/test-element-a/package.json
+++ b/packages/labs/gen-wrapper-vue/goldens/test-element-a/package.json
@@ -19,7 +19,7 @@
     "@vitejs/plugin-vue": "^3.1.2",
     "@rollup/plugin-typescript": "^9.0.1",
     "vite": "^3.1.8",
-    "vue-tsc": "^1.0.8"
+    "vue-tsc": "~1.3.19"
   },
   "files": [
     "ElementA.*",

--- a/packages/labs/gen-wrapper-vue/src/lib/package-json-template.ts
+++ b/packages/labs/gen-wrapper-vue/src/lib/package-json-template.ts
@@ -42,7 +42,9 @@ export const packageJsonTemplate = (
         '@vitejs/plugin-vue': '^3.1.2',
         '@rollup/plugin-typescript': '^9.0.1',
         vite: '^3.1.8',
-        'vue-tsc': '^1.0.8',
+        // Pinning to this minor version due to build errors in 1.4.0
+        // See https://github.com/lit/lit/issues/3827
+        'vue-tsc': '~1.3.19',
       },
       files: [...moduleNames.map((f) => `${f}.*`)],
     },


### PR DESCRIPTION
See #3827 

Above issue is causing test failures in the pipeline.

It could be that the generated Vue code needs to be updated to alleviate the type error, but I don't know enough about Vue to tell if that's the correct thing to do. At least this is how it used to work so I'm proposing we pin this for now until we know if the type error seen in the latest version is legit.