### PR TITLE
Fixes ContextRoot for requesters in nested shadowRoots

### DIFF
--- a/.changeset/mean-elephants-cough.md
+++ b/.changeset/mean-elephants-cough.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/context': patch
+---
+
+Fixes ContextRoot for requesters in nested shadowRoots, #3833

--- a/packages/labs/context/src/lib/context-root.ts
+++ b/packages/labs/context/src/lib/context-root.ts
@@ -94,7 +94,10 @@ export class ContextRoot {
       return;
     }
 
-    const element = event.target as HTMLElement;
+    // Note, it's important to use the initial target via composedPath()
+    // since that's the requesting element and the event may be re-targeted
+    // to an outer host element.
+    const element = event.composedPath()[0] as HTMLElement;
     const callback = event.callback;
 
     let pendingContextRequests = this.pendingContextRequests.get(event.context);


### PR DESCRIPTION
Fixes #3833.

ContextRoot now stores the root target (`event.composedPath()[0]`) to avoid issues with event re-targeting.