### PR TITLE
[labs/virtualizer] Update README.md

### DIFF
--- a/.changeset/silly-gorillas-arrive.md
+++ b/.changeset/silly-gorillas-arrive.md
@@ -1,0 +1,4 @@
+---
+---
+
+Updated an item in the README.md - No patch level update needed.

--- a/packages/labs/virtualizer/README.md
+++ b/packages/labs/virtualizer/README.md
@@ -280,7 +280,7 @@ export class MyItems extends LitElement {
   scrollToListItem(idx) {
     // Use the `virtualizerRef` symbol as a property key on the
     // host element to access the virtualizer reference
-    this.list[virtualizerRef].scrollElementIntoView({index: idx});
+    this.list[virtualizerRef].element(idx).scrollIntoView();
   }
 }
 ```


### PR DESCRIPTION
Changed the old `scrollElementIntoView()` in the README to use `element(x).scrollIntoView()`