### PR TITLE
[labs/ssr] Add "module" to condition name to resolve for Module Loader

### DIFF
--- a/.changeset/cool-bottles-hunt.md
+++ b/.changeset/cool-bottles-hunt.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/ssr': patch
+---
+
+Add "module" to condition names to resolve for module loader

--- a/package-lock.json
+++ b/package-lock.json
@@ -2644,6 +2644,10 @@
       "resolved": "packages/labs/test-projects/test-element-a",
       "link": true
     },
+    "node_modules/@lit-internal/test-module-package": {
+      "resolved": "packages/labs/test-projects/test-module-package",
+      "link": true
+    },
     "node_modules/@lit-internal/tests": {
       "resolved": "packages/tests",
       "link": true
@@ -25357,7 +25361,7 @@
     },
     "packages/labs/context": {
       "name": "@lit-labs/context",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit/reactive-element": "^1.5.0",
@@ -25651,7 +25655,7 @@
     },
     "packages/labs/ssr-dom-shim": {
       "name": "@lit-labs/ssr-dom-shim",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "BSD-3-Clause"
     },
     "packages/labs/ssr-react": {
@@ -25728,6 +25732,9 @@
         "typescript": "~4.7.4"
       }
     },
+    "packages/labs/test-projects/test-module-package": {
+      "version": "1.0.0"
+    },
     "packages/labs/testing": {
       "name": "@lit-labs/testing",
       "version": "0.2.1",
@@ -25745,7 +25752,7 @@
     },
     "packages/labs/virtualizer": {
       "name": "@lit-labs/virtualizer",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "lit": "^2.7.0",
@@ -25770,7 +25777,7 @@
       }
     },
     "packages/lit": {
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit/reactive-element": "^1.6.0",
@@ -25786,7 +25793,7 @@
       }
     },
     "packages/lit-element": {
-      "version": "3.3.1",
+      "version": "3.3.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.1.0",
@@ -25803,7 +25810,7 @@
       }
     },
     "packages/lit-html": {
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
@@ -25888,7 +25895,7 @@
     },
     "packages/localize-tools": {
       "name": "@lit/localize-tools",
-      "version": "0.6.8",
+      "version": "0.6.9",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit/localize": "^0.11.0",
@@ -28033,6 +28040,9 @@
         "lit": "^2.0.0",
         "typescript": "~4.7.4"
       }
+    },
+    "@lit-internal/test-module-package": {
+      "version": "file:packages/labs/test-projects/test-module-package"
     },
     "@lit-internal/tests": {
       "version": "file:packages/tests",

--- a/packages/labs/ssr/src/lib/module-loader.ts
+++ b/packages/labs/ssr/src/lib/module-loader.ts
@@ -366,7 +366,7 @@ export const resolveSpecifier = async (
       modules: ['node_modules'],
       extensions: ['.js'],
       mainFields: ['module', 'jsnext:main', 'main'],
-      conditionNames: ['node', 'import'],
+      conditionNames: ['node', 'module', 'import'],
     });
     return pathToFileURL(modulePath);
   }

--- a/packages/labs/ssr/src/test/lib/module-loader_test.ts
+++ b/packages/labs/ssr/src/test/lib/module-loader_test.ts
@@ -80,4 +80,20 @@ test('resolves a root exported path (.)', async () => {
   assert.ok(loader.cache.has(isServerPath));
 });
 
+test('prefers "module" condition over "import"', async () => {
+  const loader = new ModuleLoader();
+  const result = await loader.importModule(
+    './module-package-import.js',
+    testIndex
+  );
+  const {module, path: modulePath} = result;
+  assert.is(module.namespace.packageValue, 'module');
+  assert.ok(loader.cache.has(modulePath));
+  const packagePath = path.resolve(
+    path.dirname(testIndex),
+    '../../../../test-projects/test-module-package/index.module.js'
+  );
+  assert.ok(loader.cache.has(packagePath));
+});
+
 test.run();

--- a/packages/labs/ssr/src/test/test-files/module-loader/module-package-import.js
+++ b/packages/labs/ssr/src/test/test-files/module-loader/module-package-import.js
@@ -1,0 +1,3 @@
+import {value} from '@lit-internal/test-module-package';
+
+export const packageValue = value;

--- a/packages/labs/test-projects/test-module-package/index.import.js
+++ b/packages/labs/test-projects/test-module-package/index.import.js
@@ -1,0 +1,1 @@
+export const value = 'import';

--- a/packages/labs/test-projects/test-module-package/index.js
+++ b/packages/labs/test-projects/test-module-package/index.js
@@ -1,0 +1,3 @@
+/* eslint-env node */
+
+module.exports = 'default';

--- a/packages/labs/test-projects/test-module-package/index.module.js
+++ b/packages/labs/test-projects/test-module-package/index.module.js
@@ -1,0 +1,1 @@
+export const value = 'module';

--- a/packages/labs/test-projects/test-module-package/package.json
+++ b/packages/labs/test-projects/test-module-package/package.json
@@ -1,0 +1,12 @@
+{
+  "private": true,
+  "name": "@lit-internal/test-module-package",
+  "version": "1.0.0",
+  "exports": {
+    ".": {
+      "module": "./index.module.js",
+      "import": "./index.import.js",
+      "default": "./index.js"
+    }
+  }
+}


### PR DESCRIPTION
This was causing errors in lit.dev repo running eleventy plugin in VM mode.
![image](https://user-images.githubusercontent.com/40413829/234709607-ee40cdb1-7560-4c42-96c7-fd43ebc4e6d3.png)

This was when trying to load `tslib` which has these package exports
```json
    "exports": {
        ".": {
            "module": "./tslib.es6.js",
            "import": "./modules/index.js",
            "default": "./tslib.js"
        },
```
and we actually want the "module" export, as the "import" one is causing the error above.