### PR TITLE
[reactive-element] Reusing HasChanged type

### DIFF
--- a/.changeset/tall-insects-confess.md
+++ b/.changeset/tall-insects-confess.md
@@ -1,0 +1,5 @@
+---
+'@lit/reactive-element': patch
+---
+
+Reusing HasChanged type

--- a/.changeset/tall-insects-confess.md
+++ b/.changeset/tall-insects-confess.md
@@ -2,4 +2,4 @@
 '@lit/reactive-element': patch
 ---
 
-Reusing HasChanged type
+Reuse HasChanged type

--- a/packages/reactive-element/src/decorators/state.ts
+++ b/packages/reactive-element/src/decorators/state.ts
@@ -11,7 +11,7 @@
  * not an arrow function.
  */
 
-import {HasChanged} from '../reactive-element.js';
+import type {HasChanged} from '../reactive-element.js';
 import {property} from './property.js';
 
 export interface InternalPropertyDeclaration<Type = unknown> {

--- a/packages/reactive-element/src/decorators/state.ts
+++ b/packages/reactive-element/src/decorators/state.ts
@@ -11,6 +11,7 @@
  * not an arrow function.
  */
 
+import {HasChanged} from '../reactive-element.js';
 import {property} from './property.js';
 
 export interface InternalPropertyDeclaration<Type = unknown> {
@@ -19,7 +20,7 @@ export interface InternalPropertyDeclaration<Type = unknown> {
    * it is set. The function should take the `newValue` and `oldValue` and
    * return `true` if an update should be requested.
    */
-  hasChanged?(value: Type, oldValue: Type): boolean;
+  hasChanged?: HasChanged<Type>;
 }
 
 /**

--- a/packages/reactive-element/src/reactive-element.ts
+++ b/packages/reactive-element/src/reactive-element.ts
@@ -255,7 +255,7 @@ export interface PropertyDeclaration<Type = unknown, TypeHint = unknown> {
    * it is set. The function should take the `newValue` and `oldValue` and
    * return `true` if an update should be requested.
    */
-  hasChanged?(value: Type, oldValue: Type): boolean;
+  hasChanged?: HasChanged<Type>;
 
   /**
    * Indicates whether an accessor will be created for this property. By
@@ -357,8 +357,8 @@ export const defaultConverter: ComplexAttributeConverter = {
   },
 };
 
-export interface HasChanged {
-  (value: unknown, old: unknown): boolean;
+export interface HasChanged<Type = unknown> {
+  (value: Type, old: Type): boolean;
 }
 
 /**


### PR DESCRIPTION
During studying the package I noticed `HasChanged` type could have be used in different locations in the project and it's easier for a new comer to travel and understand the library if they want to contribute.
This change doesn't affect the overall logic (just TypeScript types),  I ran the tests and all passed.