### PR TITLE
Switch innerHTML to textContent and add some explicit types

### DIFF
--- a/.changeset/green-zoos-sleep.md
+++ b/.changeset/green-zoos-sleep.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/virtualizer': patch
+---
+
+Converted a benign innerHTML assignment to textContent.

--- a/packages/labs/virtualizer/src/Virtualizer.ts
+++ b/packages/labs/virtualizer/src/Virtualizer.ts
@@ -377,7 +377,7 @@ export class Virtualizer {
         visibility: 'hidden',
         fontSize: '2px',
       });
-      sizer.innerHTML = '&nbsp;';
+      sizer.textContent = '&nbsp;';
       sizer.setAttribute(SIZER_ATTRIBUTE, '');
       this._sizer = sizer;
     }
@@ -607,7 +607,7 @@ export class Virtualizer {
   }
 
   get _children(): Array<HTMLElement> {
-    const arr = [];
+    const arr: Array<HTMLElement> = [];
     let next = this._hostElement!.firstElementChild as HTMLElement;
     while (next) {
       if (!next.hasAttribute(SIZER_ATTRIBUTE)) {
@@ -926,7 +926,7 @@ function getParentElement(el: Element) {
 ///
 
 function getElementAncestors(el: HTMLElement, includeSelf = false) {
-  const ancestors = [];
+  const ancestors: Array<HTMLElement> = [];
   let parent = includeSelf ? el : (getParentElement(el) as HTMLElement);
   while (parent !== null) {
     ancestors.push(parent);


### PR DESCRIPTION
Internal typescript restrictions highlighted called out a use of innerHTML assignment a couple of types that were not explicit enough in Virtualizer.ts