### PR TITLE
Fix a memory leak with the shared TreeWalker

### DIFF
--- a/.changeset/few-feet-design.md
+++ b/.changeset/few-feet-design.md
@@ -1,0 +1,5 @@
+---
+'lit-html': patch
+---
+
+Fix a memory leak cause by lit-html's shared TreeWalker holding a reference to the last tree it walked.

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -634,6 +634,12 @@ const walker = d.createTreeWalker(
   false
 );
 
+// A node that we use to "park" the above TreeWalker at. This prevents the
+// TreeWalker from holding onto the DOM tree that we're processing after we're
+// done. This is necessary because we keep one TreeWalker instance for all tree
+// walks as a performance optimization.
+const walkerParkingNode = createMarker();
+
 let sanitizerFactoryInternal: SanitizerFactory = noopSanitizer;
 
 //
@@ -1005,6 +1011,7 @@ class Template {
       }
       nodeIndex++;
     }
+    walker.currentNode = walkerParkingNode;
     debugLogEvent?.({
       kind: 'template prep',
       template: this,
@@ -1155,6 +1162,7 @@ class TemplateInstance implements Disconnectable {
         nodeIndex++;
       }
     }
+    walker.currentNode = walkerParkingNode;
     return fragment;
   }
 


### PR DESCRIPTION
We weren't resetting the currentNode of the shared TreeWalker after either template prep or template cloning. This caused the TreeWalker to hold on to the last currentNode of the last tree walk.

This should always be after a clone because I can't think of a situation where we prep a template but don't immediately render it. So for the fix I set currentNode after a template clone. You can't set `TreeWalker.currentNode` to `null`, so I set it to the document.
