### PR TITLE
Allow the provide decorator to work on private fields

### DIFF
--- a/.changeset/clever-clocks-serve.md
+++ b/.changeset/clever-clocks-serve.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/context': patch
+---
+
+Allow the provide decorator to work on private fields.

--- a/packages/labs/context/src/lib/decorators/provide.ts
+++ b/packages/labs/context/src/lib/decorators/provide.ts
@@ -16,6 +16,12 @@ import {ContextProvider} from '../controllers/context-provider.js';
  * not an arrow function.
  */
 
+type RecordOrClass<
+  K extends PropertyKey,
+  V,
+  ClassOverride
+> = ClassOverride extends Record<K, V> ? ClassOverride : Record<K, V>;
+
 /**
  * A property decorator that adds a ContextConsumer controller to the component
  * which will try and retrieve a value for the property via the Context API.
@@ -43,12 +49,13 @@ import {ContextProvider} from '../controllers/context-provider.js';
  * ```
  * @category Decorator
  */
-export function provide<ValueType>({
+export function provide<ValueType, ClassOverride>({
   context: context,
 }: {
   context: Context<unknown, ValueType>;
 }): <K extends PropertyKey>(
-  protoOrDescriptor: ReactiveElement & Record<K, ValueType>,
+  protoOrDescriptor: ReactiveElement &
+    RecordOrClass<K, ValueType, ClassOverride>,
   name?: K
   // Note TypeScript requires the return type to be `void|any`
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/labs/context/src/test/provider-and-consumer_test.ts
+++ b/packages/labs/context/src/test/provider-and-consumer_test.ts
@@ -5,12 +5,13 @@
  */
 
 import {LitElement, html, TemplateResult} from 'lit';
-import {property} from 'lit/decorators/property.js';
+import {property, state} from 'lit/decorators.js';
 
 import {Context, consume, provide} from '@lit-labs/context';
 import {assert} from '@esm-bundle/chai';
 
 const simpleContext = 'simple-context' as Context<'simple-context', number>;
+const stringContext = 'string-context' as Context<'string-context', string>;
 
 class ContextConsumerAndProviderElement extends LitElement {
   @consume({context: simpleContext, subscribe: true})
@@ -21,7 +22,17 @@ class ContextConsumerAndProviderElement extends LitElement {
   @property({type: Number})
   public value = 0;
 
+  @provide<string, any>({context: stringContext})
+  @state()
+  private _aString = 'a';
+
+  // @ts-expect-error the context type and field type are incompatible
+  @provide({context: stringContext})
+  _aNumber = 0;
+
   protected render(): TemplateResult {
+    this._aString;
+    this._aNumber;
     return html`Value <span id="value">${this.value}</span
       ><span id="fromAbove">${this.provided}</span><slot></slot>`;
   }


### PR DESCRIPTION
Possible fix for https://github.com/lit/lit/issues/3883

This adds a type parameter to `provide()` that allows overriding the inferred class type so that it can be set to `any` and allow for decorating a private or protected field.

See my comments in https://github.com/lit/lit/issues/3883 comparing this against other options.