### PR TITLE
[labs/ssr-client] Bump `lit-html` dependency version

### DIFF
--- a/.changeset/clever-kids-mix.md
+++ b/.changeset/clever-kids-mix.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/ssr-client': patch
+---
+
+Bump minimum version of `lit-html` dependency to 2.7.1 which includes needed shared internals.

--- a/packages/labs/ssr-client/package.json
+++ b/packages/labs/ssr-client/package.json
@@ -130,7 +130,7 @@
   "dependencies": {
     "@lit/reactive-element": "^1.0.0",
     "lit": "^2.0.0",
-    "lit-html": "^2.0.0"
+    "lit-html": "^2.7.1"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Fixes #3899 

This dependency bump ensures users have the needed version of `lit-html` installed for hydration code to work.