### PR TITLE
[reactive-element] Make decorators accept `ReactiveElement` from elsewhere

### DIFF
--- a/.changeset/heavy-bugs-vanish.md
+++ b/.changeset/heavy-bugs-vanish.md
@@ -1,0 +1,6 @@
+---
+'@lit/reactive-element': patch
+'lit': patch
+---
+
+Allow decorators to accept `ReactiveElement` class from a different source.

--- a/packages/reactive-element/src/decorators/base.ts
+++ b/packages/reactive-element/src/decorators/base.ts
@@ -6,6 +6,10 @@
 
 import {ReactiveElement} from '../reactive-element.js';
 
+export type Interface<T> = {
+  [K in keyof T]: T[K];
+};
+
 export type Constructor<T> = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   new (...args: any[]): T;
@@ -71,7 +75,7 @@ export const decorateProperty =
     descriptor?: (property: PropertyKey) => PropertyDescriptor;
   }) =>
   (
-    protoOrDescriptor: ReactiveElement | ClassElement,
+    protoOrDescriptor: Interface<ReactiveElement> | ClassElement,
     name?: PropertyKey
     // Note TypeScript requires the return type to be `void|any`
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/reactive-element/src/decorators/base.ts
+++ b/packages/reactive-element/src/decorators/base.ts
@@ -6,6 +6,11 @@
 
 import {ReactiveElement} from '../reactive-element.js';
 
+/**
+ * Generates a public interface type that removes private and protected fields.
+ * This allows accepting otherwise compatible versions of the type (e.g. from
+ * multiple copies of the same package in `node_modules`).
+ */
 export type Interface<T> = {
   [K in keyof T]: T[K];
 };


### PR DESCRIPTION
Fixes #3241 

This specifically affected decorators made with `decorateProperty` which also includes the labs/context decorators. This is a workaround until something like https://github.com/microsoft/TypeScript/issues/52119 is implemented.

Manually tested by creating a project with multiple versions of `reactive-element` installed, and replacing the nested version with one built with these changes applied.