### PR TITLE
Some code golf on ReactiveElement

### DIFF
--- a/.changeset/nasty-deers-search.md
+++ b/.changeset/nasty-deers-search.md
@@ -1,0 +1,5 @@
+---
+'@lit/reactive-element': patch
+---
+
+Some code golf on ReactiveElement

--- a/scripts/check-size.js
+++ b/scripts/check-size.js
@@ -9,7 +9,7 @@ import * as fs from 'fs';
 // it's likely that we'll ask you to investigate ways to reduce the size.
 //
 // In either case, update the size here and push a new commit to your PR.
-const expectedLitCoreSize = 14750;
+const expectedLitCoreSize = 14740;
 const expectedLitHtmlSize = 7220;
 
 const litCoreSrc = fs.readFileSync('packages/lit/lit-core.min.js', 'utf8');


### PR DESCRIPTION
* Tear off Object methods to allow them to be renamed (not sure if Terser does this though) and to eliminate a dereference at the use site.
* Use logical assignment and chaining in `requestUpdate()` to collapse three property references to one.
* Remove a local variable in `requestUpdate()`
* Replace `notEqual` implementation with `Object.is`. This is the same behavior _except_ with +0 and -0, which are considered not the same with `Object.is`, but are equal under `===`.

I considered using `Object.hasOwn` since we have a lot of `x.hasOwnProperty()` calls, but `Object.hasOwn` is part of ES2022... it is polyfillable though, so maybe we should consider it?