### PR TITLE
Add thank you to community authored changes.

### DIFF
--- a/.changeset/changelog-lit.cjs
+++ b/.changeset/changelog-lit.cjs
@@ -9,10 +9,6 @@ const {
   getInfoFromPullRequest,
 } = require('@changesets/get-github-info');
 
-// Forked from: https://github.com/atlassian/changesets/blob/main/packages/changelog-github/src/index.ts
-// Remove the "Thanks!" message, as it's almost always self-congratulatory to our team
-// TODO: add back "Thanks!" for external contributors
-
 const repo = 'lit/lit';
 
 const changelogFunctions = {
@@ -99,6 +95,22 @@ const changelogFunctions = {
       };
     })();
 
+    // Only congratulate community contributions.
+    usersFromSummary = usersFromSummary.filter((user) => {
+      return ![
+        'AndrewJakubowicz',
+        'augustjk',
+        'bicknellr',
+        'dfreedm',
+        'e111077',
+        'justinfagnani',
+        'kevinpschaaf',
+        'rictic',
+        'sorvell',
+        'usergenic',
+      ].includes(user);
+    });
+
     const users = usersFromSummary.length
       ? usersFromSummary
           .map(
@@ -111,6 +123,7 @@ const changelogFunctions = {
     const prefix = [
       links.pull === null ? '' : ` ${links.pull}`,
       links.commit === null ? '' : ` ${links.commit}`,
+      users === null ? '' : ` Thanks ${users}!`,
     ].join('');
 
     return `\n\n-${prefix ? `${prefix} -` : ''} ${firstLine}\n${futureLines

--- a/.changeset/changelog-lit.cjs
+++ b/.changeset/changelog-lit.cjs
@@ -9,6 +9,8 @@ const {
   getInfoFromPullRequest,
 } = require('@changesets/get-github-info');
 
+// Forked from: https://github.com/atlassian/changesets/blob/main/packages/changelog-github/src/index.ts
+
 const repo = 'lit/lit';
 
 const changelogFunctions = {

--- a/.changeset/changelog-lit.cjs
+++ b/.changeset/changelog-lit.cjs
@@ -116,18 +116,21 @@ const changelogFunctions = {
      * @returns boolean indicating if a Lit team member was found in the string.
      */
     function containsLitTeamMemberUsername(s) {
-      return [
-        'AndrewJakubowicz',
-        'augustjk',
-        'bicknellr',
-        'dfreedm',
-        'e111077',
-        'justinfagnani',
-        'kevinpschaaf',
-        'rictic',
-        'sorvell',
-        'usergenic',
-      ].some((coreTeamUser) => s.includes(coreTeamUser));
+      return new RegExp(
+        `\\b(${[
+          'AndrewJakubowicz',
+          'augustjk',
+          'bicknellr',
+          'dfreedm',
+          'e111077',
+          'justinfagnani',
+          'kevinpschaaf',
+          'rictic',
+          'sorvell',
+          'usergenic',
+        ].join('|')})\\b`,
+        'i'
+      ).test(s);
     }
 
     const prefix = [

--- a/.changeset/changelog-lit.cjs
+++ b/.changeset/changelog-lit.cjs
@@ -95,9 +95,26 @@ const changelogFunctions = {
       };
     })();
 
-    // Only congratulate community contributions.
-    usersFromSummary = usersFromSummary.filter((user) => {
-      return ![
+    const users = usersFromSummary.length
+      ? usersFromSummary
+          .filter((u) => !containsLitTeamMemberUsername(u))
+          .map(
+            (userFromSummary) =>
+              `[@${userFromSummary}](https://github.com/${userFromSummary})`
+          )
+          .join(', ')
+      : containsLitTeamMemberUsername(links.user)
+      ? null
+      : links.user;
+
+    /**
+     * containsLitTeamMemberUsername lets us only congratulate community
+     * contributions.
+     * @param {string} s - any string that may contain a username.
+     * @returns boolean indicating if a Lit team member was found in the string.
+     */
+    function containsLitTeamMemberUsername(s) {
+      return [
         'AndrewJakubowicz',
         'augustjk',
         'bicknellr',
@@ -108,17 +125,8 @@ const changelogFunctions = {
         'rictic',
         'sorvell',
         'usergenic',
-      ].includes(user);
-    });
-
-    const users = usersFromSummary.length
-      ? usersFromSummary
-          .map(
-            (userFromSummary) =>
-              `[@${userFromSummary}](https://github.com/${userFromSummary})`
-          )
-          .join(', ')
-      : links.user;
+      ].some((coreTeamUser) => s.includes(coreTeamUser));
+    }
 
     const prefix = [
       links.pull === null ? '' : ` ${links.pull}`,

--- a/.changeset/changelog-lit.cjs
+++ b/.changeset/changelog-lit.cjs
@@ -136,7 +136,7 @@ const changelogFunctions = {
     const prefix = [
       links.pull === null ? '' : ` ${links.pull}`,
       links.commit === null ? '' : ` ${links.commit}`,
-      users === null ? '' : ` Thanks ${users}!`,
+      users === null || users === '' ? '' : ` Thanks ${users}!`,
     ].join('');
 
     return `\n\n-${prefix ? `${prefix} -` : ''} ${firstLine}\n${futureLines


### PR DESCRIPTION
Update changelog generation to add a thanks with link to the author of a community authored change. Lit team members are filtered out.


For example when I removed `augustine` from the filter, `npm run version` locally generated the following changelog entry:

### Sample entry with thank you

[#3905](https://github.com/lit/lit/pull/3905) [f8d72859](https://github.com/lit/lit/commit/f8d7285976390bbb35c540eb7b516f3748064d19) Thanks [@augustjk](https://github.com/augustjk)! - Handle non-array iterables including map directive in child parts



## Tests

### Multiple authors

Tested changesets that include multiple authors with a lit core member.

```
author:testone
author:testtwo
author:AndrewJakubowicz
```

This will render:

```
- [#3901](https://github.com/lit/lit/pull/3901) [`82e9f370`](https://github.com/lit/lit/commit/82e9f3708973709e916ccbb6d8a450110dea7755) Thanks [@testone](https://github.com/testone), [@testtwo](https://github.com/testtwo)! - <Description>
```

### Multiple authors with only lit core

```
author:AndrewJakubowicz
```

Does not render any Thanks.
