### PR TITLE
[labs/virtualizer] Add support methods to work around ResizeObserver loop limit exceeded errors

### DIFF
--- a/.changeset/thirty-months-crash.md
+++ b/.changeset/thirty-months-crash.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/virtualizer': patch
+---
+
+Added new support utilities for dealing with ResizeObserver loop limit exceeded errors.

--- a/.eslintignore
+++ b/.eslintignore
@@ -330,6 +330,10 @@ packages/labs/virtualizer/ScrollerController.js
 packages/labs/virtualizer/ScrollerController.d.ts
 packages/labs/virtualizer/ScrollerController.d.ts.map
 packages/labs/virtualizer/ScrollerController.js.map
+packages/labs/virtualizer/support/**/*.d.ts
+packages/labs/virtualizer/support/**/*.d.ts.map
+packages/labs/virtualizer/support/**/*.js
+packages/labs/virtualizer/support/**/*.js.map
 packages/labs/virtualizer/test/**/*.d.ts
 packages/labs/virtualizer/test/**/*.d.ts.map
 packages/labs/virtualizer/test/**/*.js

--- a/.prettierignore
+++ b/.prettierignore
@@ -314,6 +314,10 @@ packages/labs/virtualizer/ScrollerController.js
 packages/labs/virtualizer/ScrollerController.d.ts
 packages/labs/virtualizer/ScrollerController.d.ts.map
 packages/labs/virtualizer/ScrollerController.js.map
+packages/labs/virtualizer/support/**/*.d.ts
+packages/labs/virtualizer/support/**/*.d.ts.map
+packages/labs/virtualizer/support/**/*.js
+packages/labs/virtualizer/support/**/*.js.map
 packages/labs/virtualizer/test/**/*.d.ts
 packages/labs/virtualizer/test/**/*.d.ts.map
 packages/labs/virtualizer/test/**/*.js

--- a/packages/labs/virtualizer/.gitignore
+++ b/packages/labs/virtualizer/.gitignore
@@ -21,6 +21,10 @@
 /ScrollerController.d.ts
 /ScrollerController.d.ts.map
 /ScrollerController.js.map
+/support/**/*.d.ts
+/support/**/*.d.ts.map
+/support/**/*.js
+/support/**/*.js.map
 /test/**/*.d.ts
 /test/**/*.d.ts.map
 /test/**/*.js

--- a/packages/labs/virtualizer/package.json
+++ b/packages/labs/virtualizer/package.json
@@ -41,8 +41,8 @@
       "default": "./polyfillLoaders/ResizeObserver.js"
     },
     "./polyfills/resize-observer-polyfill/ResizeObserver.js": {
-      "types": "./polyfillLoaders/ResizeObserver.d.ts",
-      "default": "./polyfillLoaders/ResizeObserver.js"
+      "types": "./polyfills/resize-observer-polyfill/ResizeObserver.d.ts",
+      "default": "./polyfills/resize-observer-polyfill/ResizeObserver.js"
     },
     "./support/method-interception.js": {
       "types": "./support/method-interception.d.ts",

--- a/packages/labs/virtualizer/package.json
+++ b/packages/labs/virtualizer/package.json
@@ -9,52 +9,52 @@
   "type": "module",
   "exports": {
     ".": {
-      "default": "./lit-virtualizer.js",
-      "types": "./lit-virtualizer.d.ts"
+      "types": "./lit-virtualizer.d.ts",
+      "default": "./lit-virtualizer.js"
     },
     "./events.js": {
-      "default": "./events.js",
-      "types": "./events.d.ts"
+      "types": "./events.d.ts",
+      "default": "./events.js"
     },
     "./layouts/flexWrap.js": {
-      "default": "./layouts/flexWrap.js",
-      "types": "./layouts/flexWrap.d.ts"
+      "types": "./layouts/flexWrap.d.ts",
+      "default": "./layouts/flexWrap.js"
     },
     "./layouts/flow.js": {
-      "default": "./layouts/flow.js",
-      "types": "./layouts/flow.d.ts"
+      "types": "./layouts/flow.d.ts",
+      "default": "./layouts/flow.js"
     },
     "./layouts/grid.js": {
-      "default": "./layouts/grid.js",
-      "types": "./layouts/grid.d.ts"
+      "types": "./layouts/grid.d.ts",
+      "default": "./layouts/grid.js"
     },
     "./layouts/masonry.js": {
-      "default": "./layouts/masonry.js",
-      "types": "./layouts/masonry.d.ts"
+      "types": "./layouts/masonry.d.ts",
+      "default": "./layouts/masonry.js"
     },
     "./LitVirtualizer.js": {
-      "default": "./LitVirtualizer.js",
-      "types": "./LitVirtualizer.d.ts"
+      "types": "./LitVirtualizer.d.ts",
+      "default": "./LitVirtualizer.js"
     },
     "./polyfillLoaders/ResizeObserver.js": {
-      "default": "./polyfillLoaders/ResizeObserver.js",
-      "types": "./polyfillLoaders/ResizeObserver.d.ts"
+      "types": "./polyfillLoaders/ResizeObserver.d.ts",
+      "default": "./polyfillLoaders/ResizeObserver.js"
     },
     "./polyfills/resize-observer-polyfill/ResizeObserver.js": {
-      "default": "./polyfillLoaders/ResizeObserver.js",
-      "types": "./polyfillLoaders/ResizeObserver.d.ts"
+      "types": "./polyfillLoaders/ResizeObserver.d.ts",
+      "default": "./polyfillLoaders/ResizeObserver.js"
     },
     "./support/method-interception.js": {
-      "default": "./support/method-interception.js",
-      "types": "./support/method-interception.d.ts"
+      "types": "./support/method-interception.d.ts",
+      "default": "./support/method-interception.js"
     },
     "./support/resize-observer-errors.js": {
-      "default": "./support/resize-observer-errors.js",
-      "types": "./support/resize-observer-errors.d.ts"
+      "types": "./support/resize-observer-errors.d.ts",
+      "default": "./support/resize-observer-errors.js"
     },
     "./virtualize.js": {
-      "default": "./virtualize.js",
-      "types": "./virtualize.d.ts"
+      "types": "./virtualize.d.ts",
+      "default": "./virtualize.js"
     }
   },
   "scripts": {

--- a/packages/labs/virtualizer/package.json
+++ b/packages/labs/virtualizer/package.json
@@ -9,40 +9,52 @@
   "type": "module",
   "exports": {
     ".": {
-      "default": "./lit-virtualizer.js"
+      "default": "./lit-virtualizer.js",
+      "types": "./lit-virtualizer.d.ts"
     },
     "./events.js": {
-      "default": "./events.js"
+      "default": "./events.js",
+      "types": "./events.d.ts"
     },
     "./layouts/flexWrap.js": {
-      "default": "./layouts/flexWrap.js"
+      "default": "./layouts/flexWrap.js",
+      "types": "./layouts/flexWrap.d.ts"
     },
     "./layouts/flow.js": {
-      "default": "./layouts/flow.js"
+      "default": "./layouts/flow.js",
+      "types": "./layouts/flow.d.ts"
     },
     "./layouts/grid.js": {
-      "default": "./layouts/grid.js"
+      "default": "./layouts/grid.js",
+      "types": "./layouts/grid.d.ts"
     },
     "./layouts/masonry.js": {
-      "default": "./layouts/masonry.js"
+      "default": "./layouts/masonry.js",
+      "types": "./layouts/masonry.d.ts"
     },
     "./LitVirtualizer.js": {
-      "default": "./LitVirtualizer.js"
+      "default": "./LitVirtualizer.js",
+      "types": "./LitVirtualizer.d.ts"
     },
     "./polyfillLoaders/ResizeObserver.js": {
-      "default": "./polyfillLoaders/ResizeObserver.js"
+      "default": "./polyfillLoaders/ResizeObserver.js",
+      "types": "./polyfillLoaders/ResizeObserver.d.ts"
     },
     "./polyfills/resize-observer-polyfill/ResizeObserver.js": {
-      "default": "./polyfillLoaders/ResizeObserver.js"
+      "default": "./polyfillLoaders/ResizeObserver.js",
+      "types": "./polyfillLoaders/ResizeObserver.d.ts"
     },
     "./support/method-interception.js": {
-      "default": "./support/method-interception.js"
+      "default": "./support/method-interception.js",
+      "types": "./support/method-interception.d.ts"
     },
     "./support/resize-observer-errors.js": {
-      "default": "./support/resize-observer-errors.js"
+      "default": "./support/resize-observer-errors.js",
+      "types": "./support/resize-observer-errors.d.ts"
     },
     "./virtualize.js": {
-      "default": "./virtualize.js"
+      "default": "./virtualize.js",
+      "types": "./virtualize.d.ts"
     }
   },
   "scripts": {

--- a/packages/labs/virtualizer/package.json
+++ b/packages/labs/virtualizer/package.json
@@ -35,6 +35,12 @@
     "./polyfills/resize-observer-polyfill/ResizeObserver.js": {
       "default": "./polyfillLoaders/ResizeObserver.js"
     },
+    "./support/method-interception.js": {
+      "default": "./support/method-interception.js"
+    },
+    "./support/resize-observer-errors.js": {
+      "default": "./support/resize-observer-errors.js"
+    },
     "./virtualize.js": {
       "default": "./virtualize.js"
     }
@@ -78,6 +84,7 @@
         ".tsbuildinfo",
         "layouts/**/*.{js,d.ts,d.ts.map}",
         "polyfillLoaders/**/*.{js,d.ts,d.ts.map}",
+        "support/**/*.{js,d.ts,d.ts.map}",
         "test/**/*.{js,d.ts,d.ts.map}",
         "!test/screenshot/**",
         "events.{js,d.ts,d.ts.map}",

--- a/packages/labs/virtualizer/src/support/method-interception.ts
+++ b/packages/labs/virtualizer/src/support/method-interception.ts
@@ -1,0 +1,65 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export type Function = (...args: any[]) => any;
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+/**
+ * An MethodInterceptor function is defined as accepting a function it is intercepting
+ * or "wrapping" calls to.  It has the same signature as the original function, except
+ * that it has an additional first argument that is the "original" or wrapped
+ * function that may be called or not depending on the interceptor's logic.  The
+ * approach is analagous to calling super() in a subclass's method.
+ */
+export type MethodInterceptor<T extends Function> = (
+  originalFunction: T | undefined,
+  ...args: Parameters<T>
+) => ReturnType<T>;
+
+/**
+ * An InterceptorTeardown function reverses the effects of an interceptMethod().
+ */
+export type MethodInterceptorTeardown = () => void;
+
+/**
+ * Replaces the method on the object with a new method that calls the interceptor
+ * function along with the original function so the interceptor can decided how to
+ * handle the call.  Essentially enables wrapping an existing method with new logic
+ * similarly to how a subclass can call super() to invoke the superclass's method.
+ * @param object The method's host object
+ * @param methodName The name of the method to intercept/wrap
+ * @param interceptor The interceptor function that is called when the method is
+ *   called.  It is passed the original method as the first argument, followed by
+ *   the original method's arguments.
+ * @returns a teardown function that can be called to restore the original method
+ *   to the object.
+ */
+export function interceptMethod<
+  T extends {},
+  K extends keyof T,
+  F extends Function
+>(
+  target: T,
+  methodName: K,
+  interceptor: MethodInterceptor<F>
+): MethodInterceptorTeardown {
+  const originalMethod = target[methodName] as unknown as F | undefined;
+  const newMethod: Function = (...args: unknown[]) =>
+    interceptor.bind(target)(originalMethod, ...(args as Parameters<F>));
+  Object.assign(target, {[<string>methodName]: newMethod});
+  return () => {
+    if ((target[methodName] as unknown as F | undefined) !== newMethod) {
+      throw new Error(
+        `Unexpected method ${
+          methodName as string
+        } on ${target} due to out-of-sequence interceptor teardown.`
+      );
+    }
+    Object.assign(target, {[<string>methodName]: originalMethod});
+    return originalMethod as F;
+  };
+}

--- a/packages/labs/virtualizer/src/support/method-interception.ts
+++ b/packages/labs/virtualizer/src/support/method-interception.ts
@@ -54,9 +54,9 @@ export function interceptMethod<
   return () => {
     if ((target[methodName] as unknown as F | undefined) !== newMethod) {
       throw new Error(
-        `Unexpected method ${
+        `Unexpected method "${
           methodName as string
-        } on ${target} due to out-of-sequence interceptor teardown.`
+        }" on ${target} likely due to out-of-sequence interceptor teardown.`
       );
     }
     Object.assign(target, {[<string>methodName]: originalMethod});

--- a/packages/labs/virtualizer/src/support/method-interception.ts
+++ b/packages/labs/virtualizer/src/support/method-interception.ts
@@ -5,7 +5,7 @@
  */
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
-export type Function = (...args: any[]) => any;
+export type AnyFunction = (...args: any[]) => any;
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
 /**
@@ -15,7 +15,7 @@ export type Function = (...args: any[]) => any;
  * function that may be called or not depending on the interceptor's logic.  The
  * approach is analagous to calling super() in a subclass's method.
  */
-export type MethodInterceptor<T extends Function> = (
+export type MethodInterceptor<T extends AnyFunction> = (
   originalFunction: T | undefined,
   ...args: Parameters<T>
 ) => ReturnType<T>;
@@ -39,9 +39,9 @@ export type MethodInterceptorTeardown = () => void;
  *   to the object.
  */
 export function interceptMethod<
-  T extends {},
+  T extends object,
   K extends keyof T,
-  F extends Function
+  F extends AnyFunction
 >(
   target: T,
   methodName: K,

--- a/packages/labs/virtualizer/src/support/resize-observer-errors.ts
+++ b/packages/labs/virtualizer/src/support/resize-observer-errors.ts
@@ -11,7 +11,7 @@ import {
 
 /**
  * In a testing environment with a setup/before and teardown/after callback pattern, this function
- * can be used to as a succinct declaration to ignore these errors in tests.
+ * can be used as a succinct declaration to ignore these errors in tests.
  * @param before a setup callback; in Mocha, this would be the `beforeEach` function.
  * @param after a teardown callback; in Mocha, this would be the `afterEach` function.
  */

--- a/packages/labs/virtualizer/src/support/resize-observer-errors.ts
+++ b/packages/labs/virtualizer/src/support/resize-observer-errors.ts
@@ -11,9 +11,9 @@ import {
 
 /**
  * In a testing environment with a setup/before and teardown/after callback pattern, this function
- * can be used to quickly install ignore benign errors that are expected to occur in tests.  For example, if a
- * @param before
- * @param after
+ * can be used to as a succinct declaration to ignore these errors in tests.
+ * @param before a setup callback; in Mocha, this would be the `beforeEach` function.
+ * @param after a teardown callback; in Mocha, this would be the `afterEach` function.
  */
 export function setupIgnoreWindowResizeObserverLoopErrors(
   before: Function,

--- a/packages/labs/virtualizer/src/support/resize-observer-errors.ts
+++ b/packages/labs/virtualizer/src/support/resize-observer-errors.ts
@@ -1,0 +1,100 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {
+  interceptMethod,
+  MethodInterceptorTeardown,
+} from './method-interception.js';
+
+/**
+ * In a testing environment with a setup/before and teardown/after callback pattern, this function
+ * can be used to quickly install ignore benign errors that are expected to occur in tests.  For example, if a
+ * @param before
+ * @param after
+ */
+export function setupIgnoreWindowResizeObserverLoopErrors(
+  before: Function,
+  after: Function
+) {
+  let teardown: MethodInterceptorTeardown | undefined;
+  before(() => (teardown = ignoreWindowResizeObserverLoopErrors()));
+  after(() => {
+    teardown?.();
+    teardown = undefined;
+  });
+}
+
+/**
+ * Reads the message text and returns true if the message contains any text indicating an
+ * error due to too many ResizeObserver triggers.
+ * @param message The text to evaluate
+ * @returns True if text contains ResizeObserver loop limit exceeded message.
+ */
+export function isResizeObserverLoopErrorMessage(message: string): boolean {
+  return (
+    message.includes('ResizeObserver loop limit exceeded') ||
+    message.includes(
+      'ResizeObserver loop completed with undelivered notifications'
+    )
+  );
+}
+
+/**
+ * Replaces the window.onerror method with a new method that tests the error message
+ * against the given predicate function.  If the predicate returns true, the original
+ * window.onerror is not called.  Otherwise, the original window.onerror is called.
+ * This is most useful for ignoring benign errors that are expected to occur in tests.
+ * @param messagePredicate A function that returns true if the error message should
+ * cause the skip the call to the original window.onerror.
+ */
+export function ignoreWindowOnError(
+  messagePredicate: (message: string) => boolean
+): MethodInterceptorTeardown {
+  return interceptMethod(window, 'onerror', (originalOnError, ...args) => {
+    const message =
+      typeof args[0] === 'string' ? args[0] : (<ErrorEvent>args[0]).message;
+    if (messagePredicate(message)) {
+      return;
+    }
+    return originalOnError?.apply(window, args);
+  });
+}
+
+/**
+ * Patches window.onerror to ignore the "ResizeObserver loop limit
+ * exceeded" errors.
+ * @returns A function that can be used to restore the original window.onerror to the unpatched version.
+ */
+export function ignoreWindowResizeObserverLoopErrors() {
+  return ignoreWindowOnError(isResizeObserverLoopErrorMessage);
+}
+
+/**
+ * Adds an event listener to the window which prevents default event
+ * handling for "ResizeObserver loop limit exceeded errors."
+ * @returns A function that can be used to remove the event listener.
+ */
+export function preventResizeObserverLoopErrorEventDefaults() {
+  const eventListener = (ev: ErrorEvent) => {
+    if (
+      typeof ev.message === 'string' &&
+      isResizeObserverLoopErrorMessage(ev.message)
+    ) {
+      ev.preventDefault?.();
+      ev.stopPropagation?.();
+      ev.stopImmediatePropagation?.();
+      return;
+    }
+  };
+
+  const removeEventListener = () =>
+    window.removeEventListener('error', eventListener);
+
+  window.addEventListener('error', eventListener);
+
+  // Returns a function that can be used to remove the event listener.
+  return removeEventListener;
+}

--- a/packages/labs/virtualizer/src/test/scenarios/element-and-directive-parity.test.ts
+++ b/packages/labs/virtualizer/src/test/scenarios/element-and-directive-parity.test.ts
@@ -168,6 +168,10 @@ describe('lit-virtualizer and virtualize directive', () => {
     expect(uvd.shadowRoot?.textContent).not.to.include('[5 selected]');
 
     // Clearing event arrays so we can watch for specific future events.
+    await until(() => ulv.rangeChangedEvents.length > 0);
+    await until(() => ulv.rangeChangedEvents.length > 0);
+    await until(() => uvd.visibilityChangedEvents.length > 0);
+    await until(() => uvd.visibilityChangedEvents.length > 0);
     ulv.rangeChangedEvents.splice(0);
     uvd.rangeChangedEvents.splice(0);
     ulv.visibilityChangedEvents.splice(0);

--- a/packages/labs/virtualizer/src/test/support/method-interception.test.ts
+++ b/packages/labs/virtualizer/src/test/support/method-interception.test.ts
@@ -1,0 +1,66 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {interceptMethod} from '../../support/method-interception.js';
+import {expect} from '@open-wc/testing';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export type Function = (...args: any[]) => any;
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+class Greeter {
+  greet(addressee: string) {
+    return `Hello, ${addressee}`;
+  }
+}
+
+describe('Greeter', () => {
+  it('greets an addressee', () => {
+    const greeter = new Greeter();
+    expect(greeter.greet('Alice')).to.equal('Hello, Alice');
+  });
+});
+
+describe('interceptMethod', () => {
+  it('wraps an existing method with new logic', () => {
+    const greeter = new Greeter();
+    interceptMethod(greeter, 'greet', (originalGreet, addressee: string) => {
+      return `${originalGreet?.(addressee)}!!!`;
+    });
+    expect(greeter.greet('Bob')).to.equal('Hello, Bob!!!');
+  });
+
+  it('provides a function to restore the original method', () => {
+    const greeter = new Greeter();
+    const teardown = interceptMethod(
+      greeter,
+      'greet',
+      (originalGreet, addressee: string) => {
+        return `OMG ${originalGreet?.(addressee)} so MUCH!!!`;
+      }
+    );
+    expect(greeter.greet('Carol')).to.equal('OMG Hello, Carol so MUCH!!!');
+    teardown();
+    expect(greeter.greet('Carol')).to.equal('Hello, Carol');
+  });
+
+  it('can be used to assign a method where one is not present', () => {
+    const greeter: Greeter & {bye?: Function} = new Greeter();
+    expect(greeter.bye).to.be.undefined;
+    const teardown = interceptMethod(
+      greeter,
+      'bye',
+      (originalBye, addressee: string) => {
+        return `${originalBye?.(addressee)} 👋`;
+      }
+    );
+    // Note that the original method is undefined, so the interceptor does not have
+    // an original method to call and will include the string 'undefined' in its return.
+    expect(greeter.bye!('Dave')).to.equal('undefined 👋');
+    teardown();
+    expect(greeter.bye).to.be.undefined;
+  });
+});

--- a/packages/labs/virtualizer/src/test/support/resize-observer-errors.test.ts
+++ b/packages/labs/virtualizer/src/test/support/resize-observer-errors.test.ts
@@ -1,0 +1,87 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {
+  preventResizeObserverLoopErrorEventDefaults,
+  setupIgnoreWindowResizeObserverLoopErrors,
+} from '../../support/resize-observer-errors.js';
+import {expect} from '@open-wc/testing';
+import {until, ignoreWindowErrors} from '../helpers.js';
+
+let errors = 0;
+
+class CountingError extends Error {
+  constructor(message: string) {
+    ++errors;
+    super(message);
+  }
+}
+
+async function windowError(message: string) {
+  const expectedErrorCount = errors + 1;
+  setTimeout(() => {
+    throw new CountingError(message);
+  });
+  await until(() => errors >= expectedErrorCount);
+}
+
+beforeEach(() => (errors = 0));
+
+describe('setupIgnoreWindowResizeObserverLoopErrors', () => {
+  setupIgnoreWindowResizeObserverLoopErrors(beforeEach, afterEach);
+
+  it('throwing a CountingError adds to error count', () => {
+    try {
+      throw new CountingError('ResizeObserver loop limit exceeded');
+    } catch (e) {
+      expect(e).to.be.instanceOf(CountingError);
+    }
+    expect(errors).to.equal(1);
+  });
+
+  it('testing framework using window.error ignores loop limit errors', async () => {
+    expect(errors).to.equal(0);
+    await windowError('ResizeObserver loop limit exceeded');
+    await windowError(
+      'ResizeObserver loop completed with undelivered notifications'
+    );
+    expect(errors).to.equal(2);
+  });
+});
+
+describe('preventResizeObserverLoopErrorEventDefaults', () => {
+  ignoreWindowErrors(
+    beforeEach,
+    afterEach,
+    /ResizeObserver|Do not record this error/
+  );
+
+  it('event propagation and default behavior are stopped for loop limit error events', async () => {
+    const messages: string[] = [];
+    const removeEventListener = preventResizeObserverLoopErrorEventDefaults();
+
+    // Note we add the listener to record errors *after* preventResizeObserverLoopErrorEventDefaults
+    // because there is no way to reorder event listeners and prevent needs to be first in line to
+    // work properly in this case.
+    window.addEventListener('error', (e) => messages.push(e.message));
+
+    await windowError('ResizeObserver loop limit exceeded');
+    expect(messages).to.deep.equal([]);
+
+    await windowError('Do not record this error');
+    await until(() => messages.length >= 1);
+    expect(messages).to.deep.equal([
+      'Uncaught Error: Do not record this error',
+    ]);
+    removeEventListener();
+    await windowError('ResizeObserver loop limit exceeded');
+    await until(() => messages.length >= 2);
+    expect(messages).to.deep.equal([
+      'Uncaught Error: Do not record this error',
+      'Uncaught Error: ResizeObserver loop limit exceeded',
+    ]);
+  });
+});


### PR DESCRIPTION
I really struggled to find a coherent way to offer conventional methods to work around the obnoxious "ResizeObserver loop limit exceeeded" class of errors and whether or not to even do this as part of Virtualizer itself.  In the end, I think this provides enough value to warrant its addition to Virtualizer until such time as we might discover a change to Virtualizer itself or find an alternative approach that works just as well.

I factored out what we do in our test helpers into functions exported in support modules so they can be imported by end-users and leveraged in their test and/or live environments.