### PR TITLE
Revert "Make _initialize and static _initializers private (#3895)"

### DIFF
--- a/.changeset/eleven-mayflies-ring.md
+++ b/.changeset/eleven-mayflies-ring.md
@@ -1,5 +1,0 @@
----
-'@lit/reactive-element': major
----
-
-Make \_initialize and static \_initializers private


### PR DESCRIPTION
This reverts commit 338e1b1ce49f307f37f91876643bed400e687c6d.

An internal subclass of ReactiveElement still needs to be able to delay calling _initialize until hydration, long after construction.

FYI @justinfagnani 