### PR TITLE
[labs/ssr] Fix hydration for nested custom elements without attributes

### DIFF
--- a/.changeset/eighty-gifts-sparkle.md
+++ b/.changeset/eighty-gifts-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/ssr': patch
+---
+
+Fix adding node marker for hydration for nested custom elements without attributes.

--- a/.changeset/eighty-gifts-sparkle.md
+++ b/.changeset/eighty-gifts-sparkle.md
@@ -2,4 +2,4 @@
 '@lit-labs/ssr': patch
 ---
 
-Fix adding node marker for hydration for nested custom elements without attributes.
+Fix adding node marker for hydration for nested custom elements without attributes. This ensures nested custom elements have their `defer-hydration` attribute removed when parent is hydrated even without any attributes or bindings.


### PR DESCRIPTION
Fixes #3939 

The check for `node.attrs.length > 0` made it so that op code for 'possible-node-marker' was never getting added even for nested custom elements if they had no attributes. Removing that condition check fixes this. There shouldn't be much extra work being done by removing this condition as most of the code in the block are for loops over the derived `attrInfo` array which would be empty if `node.attrs.length` is `0`.
