### PR TITLE
Update README.md to include @lit-labs/context

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ lit-html 1.x source is available on the [`lit-html-1.x`](https://github.com/lit/
   - [`@lit/localize-tools`](./packages/localize-tools) - Localization tooling for use with `@lit/localize`.
 - Labs
   - [`@lit-labs/ssr`](./packages/labs/ssr) - A server package for rendering Lit templates and components on the server.
+  - [`@lit-labs/context`](./packages/labs/context) - An implementation of controllers and decorators for using the [Context Protocol](https://github.com/webcomponents-cg/community-protocols/blob/main/proposals/context.md) as defined by the Web Components Community Group
   - [`@lit-labs/ssr-client`](./packages/labs/ssr-client) - A set of client-side support modules for rendering Lit components and templates on the server using `@lit-labs/ssr`.
   - [`@lit-labs/eleventy-plugin-lit`](./packages/labs/eleventy-plugin-lit) - A plugin for Eleventy that pre-renders
     Lit components using `@lit-labs/ssr` with optional hydration.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ lit-html 1.x source is available on the [`lit-html-1.x`](https://github.com/lit/
   - [`@lit/localize-tools`](./packages/localize-tools) - Localization tooling for use with `@lit/localize`.
 - Labs
   - [`@lit-labs/ssr`](./packages/labs/ssr) - A server package for rendering Lit templates and components on the server.
-  - [`@lit-labs/context`](./packages/labs/context) - An implementation of controllers and decorators for using the [Context Protocol](https://github.com/webcomponents-cg/community-protocols/blob/main/proposals/context.md) as defined by the Web Components Community Group
+  - [`@lit-labs/context`](./packages/labs/context) - A system for passing data through a tree of elements using browser events, avoiding the need to pass properties down every layer of the tree using [a community defined protocol](https://github.com/webcomponents-cg/community-protocols/blob/main/proposals/context.md).
   - [`@lit-labs/ssr-client`](./packages/labs/ssr-client) - A set of client-side support modules for rendering Lit components and templates on the server using `@lit-labs/ssr`.
   - [`@lit-labs/eleventy-plugin-lit`](./packages/labs/eleventy-plugin-lit) - A plugin for Eleventy that pre-renders
     Lit components using `@lit-labs/ssr` with optional hydration.


### PR DESCRIPTION
@lit-labs/context was missing from the list of packages in the Labs section of the readme.md