### PR TITLE
Make taskComplete a getter so that errors are only thrown when requested

### DIFF
--- a/.changeset/slimy-sloths-prove.md
+++ b/.changeset/slimy-sloths-prove.md
@@ -2,4 +2,4 @@
 '@lit-labs/task': patch
 ---
 
-Catch user errors in Task
+Task will not throw errors unless user requests taskComplete

--- a/.changeset/slimy-sloths-prove.md
+++ b/.changeset/slimy-sloths-prove.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/task': major
+---
+
+Catch user errors in Task

--- a/.changeset/slimy-sloths-prove.md
+++ b/.changeset/slimy-sloths-prove.md
@@ -1,5 +1,5 @@
 ---
-'@lit-labs/task': major
+'@lit-labs/task': patch
 ---
 
 Catch user errors in Task

--- a/packages/labs/task/src/task.ts
+++ b/packages/labs/task/src/task.ts
@@ -127,9 +127,9 @@ export class Task<
    * is kept and only resolved when the new run is completed.
    */
   get taskComplete(): Promise<R> {
-    // If a task exists, return the cached promise. This is true in the case
+    // If a task run exists, return the cached promise. This is true in the case
     // where the user has called taskComplete in pending or completed state
-    // before and has not run a new task since.
+    // before and has not started a new task run since.
     if (this._taskComplete) {
       return this._taskComplete;
     }
@@ -142,12 +142,10 @@ export class Task<
         this._rejectTaskComplete = rej;
       });
 
-      // Otherwise we are at a run's completion or this is the first request
-      // and we are not in the middle of a task (i.e. INITIAL).
+      // Otherwise we are at a task run's completion or this is the first
+      // request and we are not in the middle of a task (i.e. INITIAL).
     } else {
-      this._resolveTaskComplete = undefined;
-      this._rejectTaskComplete = undefined;
-      this._taskComplete = Promise.resolve(this._value as R);
+      this._taskComplete = Promise.resolve(this._value!);
     }
 
     return this._taskComplete;
@@ -214,14 +212,10 @@ export class Task<
   async run(args?: T) {
     args ??= this._getArgs?.();
 
-    // Clear the last complete task in initial because it may be a resolved
-    // promise. Also clear if complete or error because the value returned by
+    // Clear the last complete task run in INITIAL because it may be a resolved
+    // promise. Also clear if COMPLETE or ERROR because the value returned by
     // awaiting taskComplete may have changed since last run.
-    if (
-      this.status === TaskStatus.COMPLETE ||
-      this.status === TaskStatus.ERROR ||
-      this.status === TaskStatus.INITIAL
-    ) {
+    if (this.status !== TaskStatus.PENDING) {
       this._taskComplete = undefined;
       this._resolveTaskComplete = undefined;
       this._rejectTaskComplete = undefined;

--- a/packages/labs/task/src/task.ts
+++ b/packages/labs/task/src/task.ts
@@ -257,8 +257,6 @@ export class Task<
           this._rejectTaskComplete?.(error);
         }
         this._value = result as R;
-        // The run's ended so don't generate a task complete promise and either
-        // return the existing, resolved promise or a new resolved promise.
         this._error = error;
       }
       // Request an update with the final value.

--- a/packages/labs/task/src/test/task_test.ts
+++ b/packages/labs/task/src/test/task_test.ts
@@ -630,7 +630,7 @@ suite('Task', () => {
     class TestElement extends ReactiveElement {
       task = new Task(this, {
         task: () => {
-          throw new Error('This error is not expected');
+          throw new Error('This error is expected');
         },
         autoRun: false,
         throwErrors: true,

--- a/packages/labs/task/src/test/task_test.ts
+++ b/packages/labs/task/src/test/task_test.ts
@@ -606,7 +606,8 @@ suite('Task', () => {
     class TestElement extends ReactiveElement {
       task = new Task(this, {
         task: async () => {
-          return crypto.randomUUID();
+          // Use crypto.randomUUID when it's supported in our sauce targets.
+          return Math.random() * 1000000;
         },
         autoRun: false,
       });
@@ -646,7 +647,7 @@ suite('Task', () => {
     class TestElement extends ReactiveElement {
       task = new Task(this, {
         task: async () => {
-          return crypto.randomUUID();
+          return Math.random() * 1000000;
         },
         autoRun: false,
       });
@@ -728,7 +729,7 @@ suite('Task', () => {
     class TestElement extends ReactiveElement {
       task = new Task(this, {
         task: async () => {
-          return crypto.randomUUID();
+          return Math.random() * 1000000;
         },
         autoRun: false,
       });
@@ -763,7 +764,7 @@ suite('Task', () => {
     class TestElement extends ReactiveElement {
       task = new Task(this, {
         task: async () => {
-          return crypto.randomUUID();
+          return Math.random() * 1000000;
         },
         autoRun: false,
       });

--- a/packages/labs/task/src/test/task_test.ts
+++ b/packages/labs/task/src/test/task_test.ts
@@ -601,4 +601,51 @@ suite('Task', () => {
     await tasksUpdateComplete();
     assert.isTrue(taskComplete);
   });
+
+  test('task errors are caught by default', async () => {
+    let error: Error | undefined = undefined;
+    class TestElement extends ReactiveElement {
+      task = new Task(this, {
+        task: async () => {
+          throw new Error('This error is not expected');
+        },
+        autoRun: false,
+        onError: () => {
+          this.task.taskComplete.catch((err) => {
+            error = err;
+          });
+        },
+      });
+    }
+    customElements.define(generateElementName(), TestElement);
+    const el = new TestElement();
+    container.appendChild(el);
+    await el.updateComplete;
+    await el.task.run();
+    assert.isUndefined(error);
+  });
+
+  test('task errors are thrown by when throwErrors is true', async () => {
+    let error: Error | undefined = undefined;
+    class TestElement extends ReactiveElement {
+      task = new Task(this, {
+        task: () => {
+          throw new Error('This error is not expected');
+        },
+        autoRun: false,
+        throwErrors: true,
+        onError: () => {
+          this.task.taskComplete.catch((err) => {
+            error = err;
+          });
+        },
+      });
+    }
+    customElements.define(generateElementName(), TestElement);
+    const el = new TestElement();
+    container.appendChild(el);
+    await el.updateComplete;
+    await el.task.run();
+    assert.isDefined(error);
+  });
 });

--- a/packages/labs/task/src/test/task_test.ts
+++ b/packages/labs/task/src/test/task_test.ts
@@ -617,6 +617,7 @@ suite('Task', () => {
     await el.updateComplete;
 
     const initialTaskComplete = el.task.taskComplete;
+    assert.equal(el.task.status, TaskStatus.INITIAL);
     assert.isTrue(initialTaskComplete instanceof Promise);
 
     const initialValue = await initialTaskComplete;
@@ -634,10 +635,8 @@ suite('Task', () => {
 
     const completedTaskComplete = el.task.taskComplete;
 
-    assert.notEqual(completedTaskComplete, pendingTaskComplete);
+    assert.equal(completedTaskComplete, pendingTaskComplete);
 
-    // soft check that this is a new resolved promise
-    await completedTaskComplete;
     await el.task.taskComplete;
 
     assert.equal(nextValue, el.task.value);
@@ -668,10 +667,7 @@ suite('Task', () => {
 
     const nextTaskComplete = el.task.taskComplete;
 
-    // soft check that this is a new resolved promise
-    await nextTaskComplete;
-
-    assert.notEqual(nextTaskComplete, pendingTaskComplete);
+    assert.equal(nextTaskComplete, pendingTaskComplete);
 
     el.task.run();
 
@@ -760,9 +756,7 @@ suite('Task', () => {
 
     const completeTaskComplete = el.task.taskComplete;
 
-    // soft check that this is a new resolved promise
-    await completeTaskComplete;
-    assert.notEqual(completeTaskComplete, secondTaskComplete);
+    assert.equal(completeTaskComplete, secondTaskComplete);
   });
 
   test('subsequent resolve runs do not return same value', async () => {


### PR DESCRIPTION
fixes #3946

Task now will not throw errors unless `taskComplete` is specifically called. In that case the user should catch the error on `taskComplete`.

**GOTCHAS:**

The following case is a gotcha but it's just how promises work:

```ts
taskThatThrowsAnError.taskComplete.catch(() => {});

// this will throw an error. User needs to catch here too or await previous line
await taskThatThrowsAnError.taskComplete;
```

see reproduction of native behavior [here](https://lit.dev/playground/#gist=3c498dfa3f2dc6f066527b561a015a32)