### PR TITLE
taskComplete reject promise if requested in error state

### DIFF
--- a/.changeset/heavy-candles-end.md
+++ b/.changeset/heavy-candles-end.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/task': patch
+---
+
+Fix taskComplete not rejecting if after an error state

--- a/packages/labs/task/src/task.ts
+++ b/packages/labs/task/src/task.ts
@@ -141,7 +141,9 @@ export class Task<
         this._resolveTaskComplete = res;
         this._rejectTaskComplete = rej;
       });
-
+      // If the status is error, return a rejected promise.
+    } else if (this.status === TaskStatus.ERROR) {
+      this._taskComplete = Promise.reject(this._error);
       // Otherwise we are at a task run's completion or this is the first
       // request and we are not in the middle of a task (i.e. INITIAL).
     } else {

--- a/packages/labs/task/src/test/task_test.ts
+++ b/packages/labs/task/src/test/task_test.ts
@@ -697,6 +697,34 @@ suite('Task', () => {
     await el.task.run();
   });
 
+  test('rejects after erroring task completes', async () => {
+    class TestElement extends ReactiveElement {
+      task = new Task(this, {
+        task: async () => {
+          throw new Error(
+            'If you see this in the console, this test is broken.'
+          );
+        },
+        autoRun: false,
+      });
+    }
+    customElements.define(generateElementName(), TestElement);
+    const el = new TestElement();
+    container.appendChild(el);
+    await el.updateComplete;
+
+    await el.task.run();
+
+    assert.equal(el.task.status, TaskStatus.ERROR);
+
+    let error: Error | undefined;
+    await el.task.taskComplete.catch((e: Error) => {
+      error = e;
+    });
+
+    assert.isTrue(error !== undefined);
+  });
+
   test('can catch error on taskComplete', async () => {
     class TestElement extends ReactiveElement {
       task = new Task(this, {


### PR DESCRIPTION
Fix bug with taskComplete not returning a rejected promise if requested on ERROR state