### PR TITLE
[lit-labs/context] Fix context memory leak when subscribe is true.

### DIFF
--- a/.changeset/thick-mayflies-compete.md
+++ b/.changeset/thick-mayflies-compete.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/context': patch
+---
+
+Fix a memory leak when the context consumer set `subscribe: true`.

--- a/.changeset/thick-mayflies-compete.md
+++ b/.changeset/thick-mayflies-compete.md
@@ -2,4 +2,4 @@
 '@lit-labs/context': patch
 ---
 
-Fix a memory leak when the context consumer set `subscribe: true`.
+Fix a memory leak when a context consumer sets `subscribe: true`.

--- a/packages/labs/context/src/lib/value-notifier.ts
+++ b/packages/labs/context/src/lib/value-notifier.ts
@@ -57,8 +57,11 @@ export class ValueNotifier<T> {
           this.callbacks.delete(callback);
         });
       }
+      const dispose = this.callbacks.get(callback)!;
+      callback(this.value, dispose);
+    } else {
+      callback(this.value);
     }
-    callback(this.value);
   }
 
   clearCallbacks(): void {

--- a/packages/labs/context/src/lib/value-notifier.ts
+++ b/packages/labs/context/src/lib/value-notifier.ts
@@ -20,7 +20,7 @@ type Disposer = () => void;
  * for a number of use cases.
  */
 export class ValueNotifier<T> {
-  private callbacks: Map<ContextCallback<T>, Disposer> = new Map();
+  private disposers: Map<ContextCallback<T>, Disposer> = new Map();
 
   private _value!: T;
   public get value(): T {
@@ -45,26 +45,26 @@ export class ValueNotifier<T> {
   }
 
   updateObservers = (): void => {
-    for (const [callback, disposer] of this.callbacks) {
+    for (const [callback, disposer] of this.disposers) {
       callback(this._value, disposer);
     }
   };
 
   addCallback(callback: ContextCallback<T>, subscribe?: boolean): void {
     if (subscribe) {
-      if (!this.callbacks.has(callback)) {
-        this.callbacks.set(callback, () => {
-          this.callbacks.delete(callback);
+      if (!this.disposers.has(callback)) {
+        this.disposers.set(callback, () => {
+          this.disposers.delete(callback);
         });
       }
-      const dispose = this.callbacks.get(callback)!;
-      callback(this.value, dispose);
+      const disposer = this.disposers.get(callback)!;
+      callback(this.value, disposer);
     } else {
       callback(this.value);
     }
   }
 
   clearCallbacks(): void {
-    this.callbacks.clear();
+    this.disposers.clear();
   }
 }

--- a/packages/labs/context/src/test/context-provider_test.ts
+++ b/packages/labs/context/src/test/context-provider_test.ts
@@ -171,7 +171,7 @@ memorySuite('memory leak test', () => {
     container = document.createElement('div');
     container.innerHTML = `
         <context-provider value="1000">
-            <context-consumer p="${big()}"></context-consumer>
+            <context-consumer></context-consumer>
         </context-provider>
     `;
     document.body.appendChild(container);
@@ -210,7 +210,7 @@ memorySuite('memory leak test', () => {
     // Expect the nodes that were removed to be garbage collected.
     window.gc();
     // Allow a 50% margin of heap growth; due to the 10kb expando, an actual
-    // DOM leak is orders of magnitude larger
+    // DOM leak is orders of magnitude larger.
     assert.isAtMost(
       performance.memory.usedJSHeapSize,
       heap * 1.5,

--- a/packages/labs/context/src/test/context-provider_test.ts
+++ b/packages/labs/context/src/test/context-provider_test.ts
@@ -193,6 +193,7 @@ memorySuite('memory leak test', () => {
   teardown(() => {
     document.body.removeChild(container);
   });
+
   test('attaching and removing the consumer should not leak', async () => {
     window.gc();
     const heap = performance.memory.usedJSHeapSize;

--- a/packages/labs/context/src/test/context-provider_test.ts
+++ b/packages/labs/context/src/test/context-provider_test.ts
@@ -5,10 +5,11 @@
  */
 
 import {LitElement, html, TemplateResult} from 'lit';
-import {property} from 'lit/decorators/property.js';
+import {property} from 'lit/decorators.js';
 
 import {createContext, consume, provide} from '@lit-labs/context';
 import {assert} from '@esm-bundle/chai';
+import {memorySuite} from './test_util.js';
 
 const simpleContext = createContext<number>('simple-context');
 const optionalContext = createContext<number | undefined>('optional-context');
@@ -154,6 +155,65 @@ suite('@consume: multiple instances', () => {
     await Promise.all(consumers.map((el) => el.updateComplete));
     consumers.forEach((consumer, i) =>
       assert.strictEqual(consumer.value, 500 + i)
+    );
+  });
+});
+
+memorySuite('memory leak test', () => {
+  let consumer: ContextConsumerElement;
+  let provider: ContextProviderElement;
+  let container: HTMLElement;
+
+  // Make a big array set on an expando to exaggerate any leaked DOM
+  const big = () => new Array(10000).fill(0);
+
+  setup(async () => {
+    container = document.createElement('div');
+    container.innerHTML = `
+        <context-provider value="1000">
+            <context-consumer p="${big()}"></context-consumer>
+        </context-provider>
+    `;
+    document.body.appendChild(container);
+
+    provider = container.querySelector(
+      'context-provider'
+    ) as ContextProviderElement;
+
+    consumer = container.querySelector(
+      'context-consumer'
+    ) as ContextConsumerElement;
+
+    await provider.updateComplete;
+    await consumer.updateComplete;
+
+    assert.isDefined(consumer);
+  });
+
+  teardown(() => {
+    document.body.removeChild(container);
+  });
+  test('attaching and removing the consumer should not leak', async () => {
+    window.gc();
+    const heap = performance.memory.usedJSHeapSize;
+    for (let i = 0; i < 1000; i++) {
+      // Remove the previous consumer & add a new one.
+      consumer.remove();
+      consumer = document.createElement(
+        'context-consumer'
+      ) as ContextConsumerElement;
+      (consumer as any).heapExpandoProp = big();
+      provider.appendChild(consumer);
+      await consumer.updateComplete;
+    }
+    // Expect the nodes that were removed to be garbage collected.
+    window.gc();
+    // Allow a 50% margin of heap growth; due to the 10kb expando, an actual
+    // DOM leak is orders of magnitude larger
+    assert.isAtMost(
+      performance.memory.usedJSHeapSize,
+      heap * 1.5,
+      'memory leak detected'
     );
   });
 });

--- a/packages/labs/context/src/test/test_util.ts
+++ b/packages/labs/context/src/test/test_util.ts
@@ -1,0 +1,21 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+declare global {
+  interface Window {
+    gc: () => void;
+  }
+  interface Performance {
+    memory: {
+      usedJSHeapSize: number;
+    };
+  }
+}
+
+const canRunMemoryTests =
+  globalThis.performance?.memory?.usedJSHeapSize && window.gc;
+
+export const memorySuite = canRunMemoryTests ? suite : suite.skip;


### PR DESCRIPTION
Fixes: https://github.com/lit/lit/issues/3954


The issue is that the `dispose` function was not being passed when adding the callback.
So if the element was removed before receiving any updates, it would never get access to the dispose function and could not remove the callback from the Map resulting in the unbounded leak.

The reason the element does not leak if it received an update is because `updateObservers` passes the `dispose` function:
https://github.com/lit/lit/blob/4f71df99e6df2e5fb31259c53f01f2e87209e3d5/packages/labs/context/src/lib/value-notifier.ts#L47-L51

### Testing

Tested by adding a memory test (and checking that it fails by a huge amount without fix applied).