### PR TITLE
[lit-html] Allow undefined to be passed to the ref() directive

### DIFF
--- a/.changeset/grumpy-stingrays-grab.md
+++ b/.changeset/grumpy-stingrays-grab.md
@@ -1,5 +1,6 @@
 ---
 'lit-html': patch
+'lit': patch
 ---
 
 Allow undefined to be passed to the ref() directive

--- a/.changeset/grumpy-stingrays-grab.md
+++ b/.changeset/grumpy-stingrays-grab.md
@@ -1,0 +1,5 @@
+---
+'lit-html': patch
+---
+
+Allow undefined to be passed to the ref() directive

--- a/packages/lit-html/src/directives/ref.ts
+++ b/packages/lit-html/src/directives/ref.ts
@@ -45,7 +45,7 @@ class RefDirective extends AsyncDirective {
   private _ref?: RefOrCallback;
   private _context?: object;
 
-  render(_ref: RefOrCallback) {
+  render(_ref?: RefOrCallback) {
     return nothing;
   }
 

--- a/packages/lit-html/src/test/directives/ref_test.ts
+++ b/packages/lit-html/src/test/directives/ref_test.ts
@@ -29,6 +29,13 @@ suite('ref', () => {
     assert.equal(divRef, div);
   });
 
+  test('handles an undefined ref', () => {
+    render(html`<div ${ref(undefined)}></div>`, container);
+    const div = container.firstElementChild;
+    // Not much to assert. We mainly care that we didn't throw
+    assert.isOk(div);
+  });
+
   test('sets a ref when Ref object changes', () => {
     const divRef1 = createRef();
     const divRef2 = createRef();


### PR DESCRIPTION
Fixes https://github.com/lit/lit/issues/3965

`ref()` already handled undefined refs correctly, so this is a one-char change.