### PR TITLE
[lit-html] Make RefOrCallback generic

### DIFF
--- a/.changeset/smooth-swans-sin.md
+++ b/.changeset/smooth-swans-sin.md
@@ -1,5 +1,6 @@
 ---
 'lit-html': patch
+'lit': patch
 ---
 
 Make RefOrCallback generic like Ref<T>

--- a/.changeset/smooth-swans-sin.md
+++ b/.changeset/smooth-swans-sin.md
@@ -1,0 +1,5 @@
+---
+'lit-html': patch
+---
+
+Make RefOrCallback generic like Ref<T>

--- a/packages/lit-html/src/directives/ref.ts
+++ b/packages/lit-html/src/directives/ref.ts
@@ -38,7 +38,7 @@ const lastElementForContextAndCallback: WeakMap<
   WeakMap<Function, Element | undefined>
 > = new WeakMap();
 
-export type RefOrCallback = Ref | ((el: Element | undefined) => void);
+export type RefOrCallback<T = Element> = Ref<T> | ((el: T | undefined) => void);
 
 class RefDirective extends AsyncDirective {
   private _element?: Element;


### PR DESCRIPTION
Make `RefOrCallback` generic like `Ref<T>`.

Fixes #3966 