### PR TITLE
[labs/react] Only add `suppressHydrationWarning` prop in the client

### DIFF
--- a/.changeset/calm-deers-hope.md
+++ b/.changeset/calm-deers-hope.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/react': patch
+---
+
+Only add `suppressHydrationWarning` prop when rendered in the client. This will prevent `suppresshydrationwarning` attribute being added to the host element when using `@lit-labs/ssr-react`.

--- a/packages/labs/react/src/create-component.ts
+++ b/packages/labs/react/src/create-component.ts
@@ -371,9 +371,11 @@ the element.`);
         return createElement<React.HTMLAttributes<I>, I>(tag, props);
       }
 
-      // Suppress hydration warning for server-rendered attributes, including
-      // "defer-hydration"
-      props['suppressHydrationWarning'] = true;
+      if (!NODE_MODE) {
+        // Suppress hydration warning for server-rendered attributes, including
+        // "defer-hydration"
+        props['suppressHydrationWarning'] = true;
+      }
 
       return createElement<React.HTMLAttributes<I>, I>(tag, props);
     }


### PR DESCRIPTION
https://github.com/lit/lit/pull/3977 causes the `suppressHydrationWarning` prop to actually get emitted as an attribute on the host element for wrapped components being server rendered as shown in this test output: https://github.com/lit/lit/actions/runs/5361038597/jobs/9726603547?pr=3977#step:8:443

The `suppressHydrationWarning` only has effect on React components in the client so there's no reason to add it if in node mode.