### PR TITLE
[lit-html][labs/ssr-client] Fix compiled template support

### DIFF
--- a/.changeset/chilled-drinks-travel.md
+++ b/.changeset/chilled-drinks-travel.md
@@ -1,0 +1,7 @@
+---
+'@lit-labs/ssr-client': minor
+'lit-html': minor
+'lit': minor
+---
+
+Fix return type of `isTemplateResult` helper to include the `CompiledTemplateResult` and fix the `cache` directive to work correctly with `CompiledTemplateResult`s. Add an explicit error message for ssr hydration to throw on `CompiledTemplate`s. Any usage of `isTemplateResult` without a second argument should also be handling the compiled template.

--- a/.changeset/chilled-drinks-travel.md
+++ b/.changeset/chilled-drinks-travel.md
@@ -1,5 +1,5 @@
 ---
-'@lit-labs/ssr-client': minor
+'@lit-labs/ssr-client': patch
 'lit-html': minor
 'lit': minor
 ---

--- a/.changeset/chilled-drinks-travel.md
+++ b/.changeset/chilled-drinks-travel.md
@@ -1,7 +1,6 @@
 ---
-'@lit-labs/ssr-client': patch
 'lit-html': minor
 'lit': minor
 ---
 
-Fix return type of `isTemplateResult` helper to include the `CompiledTemplateResult` and fix the `cache` directive to work correctly with `CompiledTemplateResult`s. Add an explicit error message for ssr hydration to throw on `CompiledTemplate`s. Any usage of `isTemplateResult` without a second argument should also be handling the compiled template.
+Fix return type of `isTemplateResult` helper to include the `CompiledTemplateResult` and fix the `cache` directive to work correctly with `CompiledTemplateResult`s. Also add an explicit `isCompiledTemplateResult` helper.

--- a/.changeset/five-baboons-speak.md
+++ b/.changeset/five-baboons-speak.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/ssr-client': patch
+---
+
+Add better error message during hydration when throwing on `CompiledTemplate`s.

--- a/packages/labs/ssr-client/src/lib/hydrate-lit-html.ts
+++ b/packages/labs/ssr-client/src/lib/hydrate-lit-html.ts
@@ -280,7 +280,7 @@ const openChildPart = (
       const template = (
         ChildPart.prototype as ChildPart & {
           _$getTemplate(
-            result: TemplateResult
+            value: TemplateResult
           ): ConstructorParameters<typeof TemplateInstance>[0];
         }
       )._$getTemplate(value);

--- a/packages/labs/ssr-client/src/lib/hydrate-lit-html.ts
+++ b/packages/labs/ssr-client/src/lib/hydrate-lit-html.ts
@@ -269,17 +269,22 @@ const openChildPart = (
     // if (marker.data !== 'lit-part') {
     //   throw new Error('Hydration value mismatch: Primitive found where TemplateResult expected');
     // }
-  } else if (isTemplateResult(value)) {
+  } else if (
+    isTemplateResult(value) &&
+    // Ensure this is a TemplateResult and not a CompiledTemplateResult.
+    typeof value['_$litType$'] == 'number'
+  ) {
+    const result = value as TemplateResult;
     // Check for a template result digest
-    const markerWithDigest = `lit-part ${digestForTemplateResult(value)}`;
+    const markerWithDigest = `lit-part ${digestForTemplateResult(result)}`;
     if (marker.data === markerWithDigest) {
       const template = (
         ChildPart.prototype as ChildPart & {
           _$getTemplate(
-            value: TemplateResult
+            result: TemplateResult
           ): ConstructorParameters<typeof TemplateInstance>[0];
         }
-      )._$getTemplate(value);
+      )._$getTemplate(result);
       const instance = new TemplateInstance(template, part);
       stack.push({
         type: 'template-instance',
@@ -287,7 +292,7 @@ const openChildPart = (
         part,
         templatePartIndex: 0,
         instancePartIndex: 0,
-        result: value,
+        result,
       });
       // For TemplateResult values, we set the part value to the
       // generated TemplateInstance

--- a/packages/labs/ssr-client/src/lib/hydrate-lit-html.ts
+++ b/packages/labs/ssr-client/src/lib/hydrate-lit-html.ts
@@ -269,11 +269,10 @@ const openChildPart = (
     // if (marker.data !== 'lit-part') {
     //   throw new Error('Hydration value mismatch: Primitive found where TemplateResult expected');
     // }
-  } else if (
-    isTemplateResult(value) &&
-    // Ensure this is a TemplateResult and not a CompiledTemplateResult.
-    typeof value['_$litType$'] == 'number'
-  ) {
+  } else if (isTemplateResult(value)) {
+    if (typeof value['_$litType$'] != 'number') {
+      throw new Error('compiled templates are not supported');
+    }
     const result = value as TemplateResult;
     // Check for a template result digest
     const markerWithDigest = `lit-part ${digestForTemplateResult(result)}`;

--- a/packages/labs/ssr-client/src/lib/hydrate-lit-html.ts
+++ b/packages/labs/ssr-client/src/lib/hydrate-lit-html.ts
@@ -20,6 +20,7 @@ import {
   isPrimitive,
   isSingleExpression,
   isTemplateResult,
+  isCompiledTemplateResult,
 } from 'lit-html/directive-helpers.js';
 
 // In the Node build, this import will be injected by Rollup:
@@ -270,12 +271,11 @@ const openChildPart = (
     //   throw new Error('Hydration value mismatch: Primitive found where TemplateResult expected');
     // }
   } else if (isTemplateResult(value)) {
-    if (typeof value['_$litType$'] != 'number') {
+    if (isCompiledTemplateResult(value)) {
       throw new Error('compiled templates are not supported');
     }
-    const result = value as TemplateResult;
     // Check for a template result digest
-    const markerWithDigest = `lit-part ${digestForTemplateResult(result)}`;
+    const markerWithDigest = `lit-part ${digestForTemplateResult(value)}`;
     if (marker.data === markerWithDigest) {
       const template = (
         ChildPart.prototype as ChildPart & {
@@ -283,7 +283,7 @@ const openChildPart = (
             result: TemplateResult
           ): ConstructorParameters<typeof TemplateInstance>[0];
         }
-      )._$getTemplate(result);
+      )._$getTemplate(value);
       const instance = new TemplateInstance(template, part);
       stack.push({
         type: 'template-instance',
@@ -291,7 +291,7 @@ const openChildPart = (
         part,
         templatePartIndex: 0,
         instancePartIndex: 0,
-        result,
+        result: value,
       });
       // For TemplateResult values, we set the part value to the
       // generated TemplateInstance

--- a/packages/lit-html/src/directive-helpers.ts
+++ b/packages/lit-html/src/directive-helpers.ts
@@ -50,7 +50,10 @@ export type TemplateResultType =
 
 type isTemplateResultType = {
   (val: unknown): val is TemplateResult | CompiledTemplateResult;
-  (val: unknown, type: TemplateResultType): val is TemplateResult;
+  <T extends TemplateResultType>(
+    val: unknown,
+    type: T
+  ): val is TemplateResult<T>;
 };
 
 /**
@@ -64,7 +67,16 @@ export const isTemplateResult = ((
     ? // This property needs to remain unminified.
       (value as TemplateResult)?.['_$litType$'] !== undefined
     : (value as TemplateResult)?.['_$litType$'] ===
-      type) as unknown as isTemplateResultType;
+      type) as isTemplateResultType;
+
+/**
+ * Tests if a value is a CompiledTemplateResult.
+ */
+export const isCompiledTemplateResult = (
+  value: unknown
+): value is CompiledTemplateResult => {
+  return (value as CompiledTemplateResult)?.['_$litType$']?.h != null;
+};
 
 /**
  * Tests if a value is a DirectiveResult.

--- a/packages/lit-html/src/directive-helpers.ts
+++ b/packages/lit-html/src/directive-helpers.ts
@@ -48,17 +48,23 @@ export const TemplateResultType = {
 export type TemplateResultType =
   (typeof TemplateResultType)[keyof typeof TemplateResultType];
 
+type isTemplateResultType = {
+  (val: unknown): val is TemplateResult | CompiledTemplateResult;
+  (val: unknown, type: TemplateResultType): val is TemplateResult;
+};
+
 /**
  * Tests if a value is a TemplateResult or a CompiledTemplateResult.
  */
-export const isTemplateResult = (
+export const isTemplateResult = ((
   value: unknown,
-  type?: TemplateResultType
-): value is TemplateResult | CompiledTemplateResult =>
+  type: TemplateResultType | undefined
+) =>
   type === undefined
     ? // This property needs to remain unminified.
       (value as TemplateResult)?.['_$litType$'] !== undefined
-    : (value as TemplateResult)?.['_$litType$'] === type;
+    : (value as TemplateResult)?.['_$litType$'] ===
+      type) as unknown as isTemplateResultType;
 
 /**
  * Tests if a value is a DirectiveResult.

--- a/packages/lit-html/src/directive-helpers.ts
+++ b/packages/lit-html/src/directive-helpers.ts
@@ -48,7 +48,7 @@ export const TemplateResultType = {
 export type TemplateResultType =
   (typeof TemplateResultType)[keyof typeof TemplateResultType];
 
-type isTemplateResultType = {
+type IsTemplateResult = {
   (val: unknown): val is TemplateResult | CompiledTemplateResult;
   <T extends TemplateResultType>(
     val: unknown,
@@ -59,15 +59,14 @@ type isTemplateResultType = {
 /**
  * Tests if a value is a TemplateResult or a CompiledTemplateResult.
  */
-export const isTemplateResult = ((
+export const isTemplateResult: IsTemplateResult = (
   value: unknown,
-  type: TemplateResultType | undefined
-) =>
+  type?: TemplateResultType
+): value is TemplateResult =>
   type === undefined
     ? // This property needs to remain unminified.
       (value as TemplateResult)?.['_$litType$'] !== undefined
-    : (value as TemplateResult)?.['_$litType$'] ===
-      type) as isTemplateResultType;
+    : (value as TemplateResult)?.['_$litType$'] === type;
 
 /**
  * Tests if a value is a CompiledTemplateResult.

--- a/packages/lit-html/src/directive-helpers.ts
+++ b/packages/lit-html/src/directive-helpers.ts
@@ -4,7 +4,13 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {_$LH, Part, DirectiveParent, TemplateResult} from './lit-html.js';
+import {
+  _$LH,
+  Part,
+  DirectiveParent,
+  TemplateResult,
+  CompiledTemplateResult,
+} from './lit-html.js';
 import {
   DirectiveResult,
   DirectiveClass,
@@ -43,12 +49,12 @@ export type TemplateResultType =
   (typeof TemplateResultType)[keyof typeof TemplateResultType];
 
 /**
- * Tests if a value is a TemplateResult.
+ * Tests if a value is a TemplateResult or a CompiledTemplateResult.
  */
 export const isTemplateResult = (
   value: unknown,
   type?: TemplateResultType
-): value is TemplateResult =>
+): value is TemplateResult | CompiledTemplateResult =>
   type === undefined
     ? // This property needs to remain unminified.
       (value as TemplateResult)?.['_$litType$'] !== undefined

--- a/packages/lit-html/src/directives/cache.ts
+++ b/packages/lit-html/src/directives/cache.ts
@@ -35,7 +35,7 @@ function getStringsFromTemplate(
   if (typeof template['_$litType$'] === 'number') {
     return (template as TemplateResult).strings;
   } else {
-    return (template as CompiledTemplateResult)._$litType$.h;
+    return (template as CompiledTemplateResult)['_$litType$'].h;
   }
 }
 

--- a/packages/lit-html/src/directives/cache.ts
+++ b/packages/lit-html/src/directives/cache.ts
@@ -22,6 +22,7 @@ import {
   clearPart,
   getCommittedValue,
   insertPart,
+  isCompiledTemplateResult,
   isTemplateResult,
   setCommittedValue,
 } from '../directive-helpers.js';
@@ -32,11 +33,9 @@ import {
 function getStringsFromTemplate(
   template: TemplateResult | CompiledTemplateResult
 ): TemplateStringsArray {
-  if (typeof template['_$litType$'] === 'number') {
-    return (template as TemplateResult).strings;
-  } else {
-    return (template as CompiledTemplateResult)['_$litType$'].h;
-  }
+  return isCompiledTemplateResult(template)
+    ? template['_$litType$'].h
+    : template.strings;
 }
 
 class CacheDirective extends Directive {

--- a/packages/lit-html/src/experimental-hydrate.ts
+++ b/packages/lit-html/src/experimental-hydrate.ts
@@ -274,11 +274,16 @@ const openChildPart = (
     // if (marker.data !== 'lit-part') {
     //   throw new Error('Hydration value mismatch: Primitive found where TemplateResult expected');
     // }
-  } else if (isTemplateResult(value)) {
+  } else if (
+    isTemplateResult(value) &&
+    // Ensure this is a TemplateResult and not a CompiledTemplateResult.
+    typeof value['_$litType$'] === 'number'
+  ) {
+    const result = value as TemplateResult;
     // Check for a template result digest
-    const markerWithDigest = `lit-part ${digestForTemplateResult(value)}`;
+    const markerWithDigest = `lit-part ${digestForTemplateResult(result)}`;
     if (marker.data === markerWithDigest) {
-      const template = ChildPart.prototype._$getTemplate(value);
+      const template = ChildPart.prototype._$getTemplate(result);
       const instance = new TemplateInstance(template, part);
       stack.push({
         type: 'template-instance',
@@ -286,7 +291,7 @@ const openChildPart = (
         part,
         templatePartIndex: 0,
         instancePartIndex: 0,
-        result: value,
+        result,
       });
       // For TemplateResult values, we set the part value to the
       // generated TemplateInstance

--- a/packages/lit-html/src/experimental-hydrate.ts
+++ b/packages/lit-html/src/experimental-hydrate.ts
@@ -274,11 +274,10 @@ const openChildPart = (
     // if (marker.data !== 'lit-part') {
     //   throw new Error('Hydration value mismatch: Primitive found where TemplateResult expected');
     // }
-  } else if (
-    isTemplateResult(value) &&
-    // Ensure this is a TemplateResult and not a CompiledTemplateResult.
-    typeof value['_$litType$'] === 'number'
-  ) {
+  } else if (isTemplateResult(value)) {
+    if (typeof value['_$litType$'] !== 'number') {
+      throw new Error('compiled templates are not supported');
+    }
     const result = value as TemplateResult;
     // Check for a template result digest
     const markerWithDigest = `lit-part ${digestForTemplateResult(result)}`;

--- a/packages/lit-html/src/experimental-hydrate.ts
+++ b/packages/lit-html/src/experimental-hydrate.ts
@@ -12,6 +12,7 @@ import {
   isPrimitive,
   isSingleExpression,
   isTemplateResult,
+  isCompiledTemplateResult,
 } from './directive-helpers.js';
 
 // In the Node build, this import will be injected by Rollup:
@@ -275,14 +276,13 @@ const openChildPart = (
     //   throw new Error('Hydration value mismatch: Primitive found where TemplateResult expected');
     // }
   } else if (isTemplateResult(value)) {
-    if (typeof value['_$litType$'] !== 'number') {
+    if (isCompiledTemplateResult(value)) {
       throw new Error('compiled templates are not supported');
     }
-    const result = value as TemplateResult;
     // Check for a template result digest
-    const markerWithDigest = `lit-part ${digestForTemplateResult(result)}`;
+    const markerWithDigest = `lit-part ${digestForTemplateResult(value)}`;
     if (marker.data === markerWithDigest) {
-      const template = ChildPart.prototype._$getTemplate(result);
+      const template = ChildPart.prototype._$getTemplate(value);
       const instance = new TemplateInstance(template, part);
       stack.push({
         type: 'template-instance',
@@ -290,7 +290,7 @@ const openChildPart = (
         part,
         templatePartIndex: 0,
         instancePartIndex: 0,
-        result,
+        result: value,
       });
       // For TemplateResult values, we set the part value to the
       // generated TemplateInstance

--- a/packages/lit-html/src/test/directive-helpers_test.ts
+++ b/packages/lit-html/src/test/directive-helpers_test.ts
@@ -10,6 +10,7 @@ import {
   svg,
   TemplateResult,
   CompiledTemplateResult,
+  CompiledTemplate,
 } from 'lit-html';
 import {assert} from '@esm-bundle/chai';
 import {stripExpressionComments} from '@lit-labs/testing';
@@ -22,6 +23,7 @@ import {
   removePart,
   setChildPartValue,
   TemplateResultType,
+  isCompiledTemplateResult,
 } from 'lit-html/directive-helpers.js';
 import {classMap} from 'lit-html/directives/class-map.js';
 import {
@@ -29,6 +31,12 @@ import {
   Directive,
   AsyncDirective,
 } from 'lit-html/async-directive.js';
+
+const branding_tag = (s: TemplateStringsArray) => s;
+const _$lit_template_1: CompiledTemplate = {
+  h: branding_tag``,
+  parts: [],
+};
 
 suite('directive-helpers', () => {
   let container: HTMLDivElement;
@@ -70,6 +78,31 @@ suite('directive-helpers', () => {
     assert.isFalse(isTemplateResult(null, TemplateResultType.HTML));
     assert.isFalse(isTemplateResult(undefined, TemplateResultType.HTML));
     assert.isFalse(isTemplateResult({}, TemplateResultType.HTML));
+
+    assert.isTrue(
+      isTemplateResult({
+        _$litType$: _$lit_template_1,
+        values: [],
+      })
+    );
+    assert.isFalse(
+      isTemplateResult(
+        {
+          _$litType$: _$lit_template_1,
+          values: [],
+        },
+        TemplateResultType.HTML
+      )
+    );
+    assert.isFalse(
+      isTemplateResult(
+        {
+          _$litType$: _$lit_template_1,
+          values: [],
+        },
+        TemplateResultType.SVG
+      )
+    );
   });
 
   test('isTemplateResult type only test', () => {
@@ -93,6 +126,21 @@ suite('directive-helpers', () => {
     if (isTemplateResult(v, TemplateResultType.SVG)) {
       acceptTemplateResult(v);
     }
+  });
+
+  test('isCompiledTemplateResult', () => {
+    assert.isTrue(
+      isCompiledTemplateResult({
+        _$litType$: _$lit_template_1,
+        values: [],
+      })
+    );
+
+    assert.isFalse(isCompiledTemplateResult(html``));
+    assert.isFalse(isCompiledTemplateResult(svg``));
+    assert.isFalse(isCompiledTemplateResult(null));
+    assert.isFalse(isCompiledTemplateResult(undefined));
+    assert.isFalse(isCompiledTemplateResult({}));
   });
 
   test('isDirectiveResult', () => {

--- a/packages/lit-html/src/test/directive-helpers_test.ts
+++ b/packages/lit-html/src/test/directive-helpers_test.ts
@@ -112,6 +112,12 @@ suite('directive-helpers', () => {
     function acceptTemplateOrCompiledTemplateResult(
       _v: TemplateResult | CompiledTemplateResult
     ) {}
+    function acceptTemplateResultHtml(
+      _v: TemplateResult<typeof TemplateResultType.HTML>
+    ) {}
+    function acceptTemplateResultSvg(
+      _v: TemplateResult<typeof TemplateResultType.SVG>
+    ) {}
 
     const v = html`` as TemplateResult | CompiledTemplateResult;
     if (isTemplateResult(v)) {
@@ -122,9 +128,15 @@ suite('directive-helpers', () => {
     }
     if (isTemplateResult(v, TemplateResultType.HTML)) {
       acceptTemplateResult(v);
+      acceptTemplateResultHtml(v);
+      // @ts-expect-error v is an html template result
+      acceptTemplateResultSvg(v);
     }
     if (isTemplateResult(v, TemplateResultType.SVG)) {
       acceptTemplateResult(v);
+      acceptTemplateResultSvg(v);
+      // @ts-expect-error v is an svg template result
+      acceptTemplateResultHtml(v);
     }
   });
 

--- a/packages/lit-html/src/test/directive-helpers_test.ts
+++ b/packages/lit-html/src/test/directive-helpers_test.ts
@@ -3,7 +3,14 @@
  * Copyright 2020 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
  */
-import {html, ChildPart, render, svg} from 'lit-html';
+import {
+  html,
+  ChildPart,
+  render,
+  svg,
+  TemplateResult,
+  CompiledTemplateResult,
+} from 'lit-html';
 import {assert} from '@esm-bundle/chai';
 import {stripExpressionComments} from '@lit-labs/testing';
 import {
@@ -63,6 +70,29 @@ suite('directive-helpers', () => {
     assert.isFalse(isTemplateResult(null, TemplateResultType.HTML));
     assert.isFalse(isTemplateResult(undefined, TemplateResultType.HTML));
     assert.isFalse(isTemplateResult({}, TemplateResultType.HTML));
+  });
+
+  test('isTemplateResult type only test', () => {
+    // This test has no runtime checks, and fails at build time if there are
+    // type issues.
+    function acceptTemplateResult(_v: TemplateResult) {}
+    function acceptTemplateOrCompiledTemplateResult(
+      _v: TemplateResult | CompiledTemplateResult
+    ) {}
+
+    const v = html`` as TemplateResult | CompiledTemplateResult;
+    if (isTemplateResult(v)) {
+      acceptTemplateOrCompiledTemplateResult(v);
+
+      // @ts-expect-error v could be a CompiledTemplateResult
+      acceptTemplateResult(v);
+    }
+    if (isTemplateResult(v, TemplateResultType.HTML)) {
+      acceptTemplateResult(v);
+    }
+    if (isTemplateResult(v, TemplateResultType.SVG)) {
+      acceptTemplateResult(v);
+    }
   });
 
   test('isDirectiveResult', () => {

--- a/packages/lit-html/src/test/directives/cache_test.ts
+++ b/packages/lit-html/src/test/directives/cache_test.ts
@@ -4,11 +4,16 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {html, render, nothing} from 'lit-html';
+import {html, render, nothing, CompiledTemplate} from 'lit-html';
 import {cache} from 'lit-html/directives/cache.js';
 import {stripExpressionComments} from '@lit-labs/testing';
 import {assert} from '@esm-bundle/chai';
 import {directive, AsyncDirective} from 'lit-html/async-directive.js';
+
+// For compiled template tests
+import {_$LH} from 'lit-html/private-ssr-support.js';
+
+const branding_tag = (s: TemplateStringsArray) => s;
 
 suite('cache directive', () => {
   let container: HTMLDivElement;
@@ -22,6 +27,78 @@ suite('cache directive', () => {
       render(
         html`${cache(
           condition ? html`<div v=${v}></div>` : html`<span v=${v}></span>`
+        )}`,
+        container
+      );
+
+    renderCached(true, 'A');
+    assert.equal(
+      stripExpressionComments(container.innerHTML),
+      '<div v="A"></div>'
+    );
+    const element1 = container.firstElementChild;
+
+    renderCached(false, 'B');
+    assert.equal(
+      stripExpressionComments(container.innerHTML),
+      '<span v="B"></span>'
+    );
+    const element2 = container.firstElementChild;
+
+    assert.notStrictEqual(element1, element2);
+
+    renderCached(true, 'C');
+    assert.equal(
+      stripExpressionComments(container.innerHTML),
+      '<div v="C"></div>'
+    );
+    assert.strictEqual(container.firstElementChild, element1);
+
+    renderCached(false, 'D');
+    assert.equal(
+      stripExpressionComments(container.innerHTML),
+      '<span v="D"></span>'
+    );
+    assert.strictEqual(container.firstElementChild, element2);
+  });
+
+  test('caches compiled templates', () => {
+    const _$lit_template_1: CompiledTemplate = {
+      h: branding_tag`<div></div>`,
+      parts: [
+        {
+          type: 1,
+          index: 0,
+          name: 'v',
+          strings: ['', ''],
+          ctor: _$LH.AttributePart,
+        },
+      ],
+    };
+    const _$lit_template_2: CompiledTemplate = {
+      h: branding_tag`<span></span>`,
+      parts: [
+        {
+          type: 1,
+          index: 0,
+          name: 'v',
+          strings: ['', ''],
+          ctor: _$LH.AttributePart,
+        },
+      ],
+    };
+    const renderCached = (condition: any, v: string) =>
+      render(
+        html`${cache(
+          condition
+            ? {
+                _$litType$: _$lit_template_1,
+                values: [v],
+              }
+            : {
+                _$litType$: _$lit_template_2,
+                values: [v],
+              }
         )}`,
         container
       );


### PR DESCRIPTION
Change is an independent part of https://github.com/lit/lit/pull/3984

## Summary

Fix `isTemplateResult` return type to include `CompiledTemplateResult`s, and then fix locations in `lit` that didn't handle `CompiledTemplate`s. Primarily the `cache` directive.

## Changes

 - Fixes the return type of `isTemplateResult` to return the correct type (as per current implementation): a `TemplateResult` or a `CompiledTemplateResult`.
 - Fix cache directive to work with both uncompiled and compiled templates using a helper to access the template strings array.
 - Made it explicit that `hydration` and `experimental-hydration` do not work with compiled templates by making the check more strict. *Maybe could add a dev mode error?*
- Added compiled template cache directive unit test, and `isTemplateResult` type tests.

## Considerations

I marked this as a minor change, however it is a breaking change in terms of TypeScript types. The return type of `isTemplateResult` without a second argument now has an additional consideration and could break users of `isTemplateResult`. However the type now more truthfully conveys what `isTemplateResult` is asserting.

## Alternative considered:
 - Make `isTemplateResult` stricter such that the type is only a `TemplateResult`. A breaking change (although people should realistically not be depending on `CompiledTemplateResult`s yet)
 - Add the following helpers: `isCompiledTemplateResult` to check for CompiledTemplates, and `getTemplateStringsArray` to generically retrieve the template strings array from either a compiled or uncompiled template result.

## Test plan

Unit tests and type only tests added.