### PR TITLE
Add a Task.abort() method

### DIFF
--- a/.changeset/flat-pugs-push.md
+++ b/.changeset/flat-pugs-push.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/task': minor
+---
+
+Allow cancelling a task with a Task.abort() method

--- a/packages/labs/task/src/task.ts
+++ b/packages/labs/task/src/task.ts
@@ -241,9 +241,11 @@ export class Task<
 
     const key = ++this._callId;
     this._abortController = new AbortController();
+    let errored = false;
     try {
       result = await this._task(args!, {signal: this._abortController.signal});
     } catch (e) {
+      errored = true;
       error = e;
     }
     // If this is the most recent task call, process this value.
@@ -251,7 +253,7 @@ export class Task<
       if (result === initialState) {
         this.status = TaskStatus.INITIAL;
       } else {
-        if (error === undefined) {
+        if (errored === false) {
           try {
             this._onComplete?.(result as R);
           } catch {

--- a/packages/labs/task/src/task.ts
+++ b/packages/labs/task/src/task.ts
@@ -276,6 +276,30 @@ export class Task<
     }
   }
 
+  /**
+   * Aborts the currently pending task run by aborting the AbortSignal
+   * passed to the task function.
+   *
+   * Aborting a task does nothing if the task is not running: ie, in the
+   * complete, error, or initial states.
+   *
+   * Aborting a task does not automatically cancel the task function. The task
+   * function must be written to accept the AbortSignal and either forward it
+   * to other APIs like `fetch()`, or handle cancellation manually by using
+   * [`signal.throwIfAborted()`]{@link https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/throwIfAborted}
+   * or the
+   * [`abort`]{@link https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/abort_event}
+   * event.
+   *
+   * @param reason The reason for aborting. Passed to
+   *     `AbortController.abort()`.
+   */
+  abort(reason?: unknown) {
+    if (this.status === TaskStatus.PENDING) {
+      this._abortController?.abort(reason);
+    }
+  }
+
   get value() {
     return this._value;
   }

--- a/packages/labs/task/src/test/task_test.ts
+++ b/packages/labs/task/src/test/task_test.ts
@@ -288,7 +288,11 @@ suite('Task', () => {
     // We can abort a task
     el.task.run();
     el.task.abort('testing');
-    await el.task.taskComplete;
+    try {
+      await el.task.taskComplete;
+    } catch (e) {
+      // expected
+    }
     await tasksUpdateComplete();
     assert.strictEqual(el.signal?.aborted, true);
     assert.equal(el.task.status, TaskStatus.ERROR, 'A');

--- a/packages/labs/task/src/test/task_test.ts
+++ b/packages/labs/task/src/test/task_test.ts
@@ -68,9 +68,11 @@ suite('Task', () => {
               this.resolveTask = () => resolve(args.join(','));
               const signal = (this.signal = options?.signal);
               if (signal?.aborted) {
+                console.error('signal already aborted');
                 reject(signal.reason);
               } else {
                 signal?.addEventListener('abort', () => {
+                  console.error('signal abort event');
                   reject(signal.reason);
                 });
               }
@@ -286,6 +288,7 @@ suite('Task', () => {
     // We can abort a task
     el.task.run();
     el.task.abort('testing');
+    await el.task.taskComplete;
     await tasksUpdateComplete();
     assert.strictEqual(el.signal?.aborted, true);
     assert.equal(el.task.status, TaskStatus.ERROR, 'A');

--- a/packages/labs/task/src/test/task_test.ts
+++ b/packages/labs/task/src/test/task_test.ts
@@ -60,13 +60,7 @@ suite('Task', () => {
               this.resolveTask = () => resolve(args.join(','));
               const signal = (this.signal = options?.signal);
               signal?.addEventListener('abort', () => {
-                try {
-                  // Throw so we can reject with the same Error type the
-                  // DOM uses.
-                  signal.throwIfAborted();
-                } catch (e) {
-                  reject(e);
-                }
+                reject(signal.reason);
               });
             }),
         };

--- a/packages/labs/task/src/test/task_test.ts
+++ b/packages/labs/task/src/test/task_test.ts
@@ -16,6 +16,13 @@ import {
 import {generateElementName, nextFrame} from './test-helpers.js';
 import {assert} from '@esm-bundle/chai';
 
+const supportsAbortSignalReason = (() => {
+  const controller = new AbortController();
+  const {signal} = controller;
+  controller.abort('reason');
+  return signal.reason === 'reason';
+})();
+
 suite('Task', () => {
   let container: HTMLElement;
 
@@ -277,7 +284,9 @@ suite('Task', () => {
     await tasksUpdateComplete();
     assert.strictEqual(el.signal?.aborted, true);
     assert.equal(el.task.status, TaskStatus.ERROR);
-    assert.equal(el.task.error, 'testing');
+    if (supportsAbortSignalReason) {
+      assert.equal(el.task.error, 'testing');
+    }
 
     // We can restart the task
     el.task.run();

--- a/packages/labs/task/src/test/task_test.ts
+++ b/packages/labs/task/src/test/task_test.ts
@@ -286,21 +286,16 @@ suite('Task', () => {
     // We can abort a task
     el.task.run();
     el.task.abort('testing');
-    try {
-      await el.task.taskComplete;
-    } catch (e) {
-      // expected
-    }
     await tasksUpdateComplete();
     assert.strictEqual(el.signal?.aborted, true);
-    assert.equal(el.task.status, TaskStatus.ERROR, 'A');
+    assert.equal(el.task.status, TaskStatus.ERROR);
     if (supportsAbortSignalReason) {
       assert.equal(el.task.error, 'testing');
     }
 
     // We can restart the task
     el.task.run();
-    assert.equal(el.task.status, TaskStatus.PENDING, 'B');
+    assert.equal(el.task.status, TaskStatus.PENDING);
     assert.strictEqual(el.signal?.aborted, false);
   });
 


### PR DESCRIPTION
Fixes https://github.com/lit/lit/issues/3997

This makes task cancellation possible, but manual. It's _maybe_ desirable in some cases to somehow allow passing an AbortSignal into the task and composing it with the signal we automatically create, and but the exact requirements and shape of that API aren't clear yet. Chaining tasks is one of the more obvious use cases, but this might be doable already because aborting a task will reject its `taskComplete` promise, which can be passed to downstream tasks.