### PR TITLE
[labs/task] Allow tasks to have an initial value

### DIFF
--- a/.changeset/heavy-planets-obey.md
+++ b/.changeset/heavy-planets-obey.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/task': minor
+---
+
+Allow tasks to have an initial value

--- a/packages/labs/task/src/task.ts
+++ b/packages/labs/task/src/task.ts
@@ -49,6 +49,16 @@ export interface TaskConfig<T extends ReadonlyArray<unknown>, R> {
   task: TaskFunction<T, R>;
   args?: ArgsFunction<T>;
   autoRun?: boolean;
+
+  /**
+   * If initialValue is provided, the task is initialized to the COMPLETE
+   * status and the value is set to initialData.
+   *
+   * Initial args should be coherent with the initialValue, since they are
+   * assumed to be the args that would produce that value. When autoRun is
+   * `true` the task will not auto-run again until the args change.
+   */
+  initialValue?: R;
   onComplete?: (value: R) => unknown;
   onError?: (error: unknown) => unknown;
 }
@@ -184,6 +194,13 @@ export class Task<
     this._onError = taskConfig.onError;
     if (taskConfig.autoRun !== undefined) {
       this.autoRun = taskConfig.autoRun;
+    }
+    // Providing initialValue puts the task in COMPLETE state and stores the
+    // args immediately so it only runs when they change again.
+    if ('initialValue' in taskConfig) {
+      this._value = taskConfig.initialValue;
+      this.status = TaskStatus.COMPLETE;
+      this._previousArgs = this._getArgs?.();
     }
   }
 

--- a/packages/labs/task/src/test/task_test.ts
+++ b/packages/labs/task/src/test/task_test.ts
@@ -225,6 +225,36 @@ suite('Task', () => {
     assert.equal(el.taskValue, `a1,b1`);
   });
 
+  test('tasks can have initialValue', async () => {
+    // The test helpers make it hard to write proper args callbacks
+    // `args: () => [this.a, this.b]` would work, but `[el.a]` doesn't
+    // since `el` isn't initialized yet. This little hack works:
+    let initializing = true;
+    const el = getTestElement({
+      initialValue: 'initial',
+      args: () => [initializing ? 'a' : el.a, initializing ? 'b' : el.b],
+    });
+    initializing = false;
+    await renderElement(el);
+    assert.equal(el.task.status, TaskStatus.COMPLETE);
+    assert.equal(el.task.value, 'initial');
+    assert.equal(el.taskValue, 'initial');
+
+    // The task is complete, so waiting for it shouldn't change anything
+    await tasksUpdateComplete();
+    assert.equal(el.task.status, TaskStatus.COMPLETE);
+    assert.equal(el.task.value, 'initial');
+
+    // The task still reruns when arguments change
+    el.a = 'a1';
+    await tasksUpdateComplete();
+    assert.equal(el.task.status, TaskStatus.PENDING);
+    el.resolveTask();
+    await tasksUpdateComplete();
+    assert.equal(el.task.status, TaskStatus.COMPLETE);
+    assert.equal(el.taskValue, `a1,b`);
+  });
+
   test('task error is not reset on rerun', async () => {
     const el = getTestElement({args: () => [el.a, el.b]});
     await renderElement(el);

--- a/packages/labs/task/src/test/task_test.ts
+++ b/packages/labs/task/src/test/task_test.ts
@@ -245,6 +245,12 @@ suite('Task', () => {
     assert.equal(el.task.status, TaskStatus.COMPLETE);
     assert.equal(el.task.value, 'initial');
 
+    // An element update (which checks args again) should not cause a rerun
+    el.requestUpdate();
+    await tasksUpdateComplete();
+    assert.equal(el.task.status, TaskStatus.COMPLETE);
+    assert.equal(el.task.value, 'initial');
+
     // The task still reruns when arguments change
     el.a = 'a1';
     await tasksUpdateComplete();


### PR DESCRIPTION
Fixes #2367 
Supersedes #2836 

This adds an `initialValue` config option. If set, the task is put into the COMPLETE status and `initialValue` is assigned to the current value of the task. Initial args are read off synchronously so that the task won't auto-run until the args change.

This is useful for when an element has the initial data available synchronously (maybe from hydration?) and wants to make the task look like it has completed a first run.