### PR TITLE
[labs/task] Run tasks in update instead of updated

### DIFF
--- a/.changeset/chilled-jeans-march.md
+++ b/.changeset/chilled-jeans-march.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/task': major
+---
+
+Run tasks in update instead of updated

--- a/.changeset/chilled-jeans-march.md
+++ b/.changeset/chilled-jeans-march.md
@@ -2,4 +2,4 @@
 '@lit-labs/task': major
 ---
 
-Adds the `'afterUpdate'` option for `autoRun` to Task, and runs tasks by default in `hostUpdate()` instead of `hostUpdated()`.
+Adds the `'afterUpdate'` option for `autoRun` to Task, and runs tasks by default in `hostUpdate()` instead of `hostUpdated()`. `'afterUpdate'` is needed to run tasks dependent on DOM updates, but will cause multiple renders of the host element.

--- a/.changeset/chilled-jeans-march.md
+++ b/.changeset/chilled-jeans-march.md
@@ -2,4 +2,4 @@
 '@lit-labs/task': major
 ---
 
-Run tasks in update instead of updated
+Adds the `'afterUpdate'` option for `autoRun` to Task, and runs tasks by default in `hostUpdate()` instead of `hostUpdated()`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -25734,7 +25734,8 @@
       },
       "devDependencies": {
         "@lit-internal/scripts": "^1.0.0",
-        "@types/trusted-types": "^2.0.2"
+        "@types/trusted-types": "^2.0.2",
+        "lit": "^2.0.0"
       }
     },
     "packages/labs/test-projects/test-element-a": {
@@ -28392,7 +28393,8 @@
       "requires": {
         "@lit-internal/scripts": "^1.0.0",
         "@lit/reactive-element": "^1.1.0",
-        "@types/trusted-types": "^2.0.2"
+        "@types/trusted-types": "^2.0.2",
+        "lit": "^2.0.0"
       }
     },
     "@lit-labs/testing": {

--- a/packages/labs/task/package.json
+++ b/packages/labs/task/package.json
@@ -144,7 +144,8 @@
   "author": "Google LLC",
   "devDependencies": {
     "@types/trusted-types": "^2.0.2",
-    "@lit-internal/scripts": "^1.0.0"
+    "@lit-internal/scripts": "^1.0.0",
+    "lit": "^2.0.0"
   },
   "dependencies": {
     "@lit/reactive-element": "^1.1.0"

--- a/packages/labs/task/package.json
+++ b/packages/labs/task/package.json
@@ -50,12 +50,14 @@
         "build:ts",
         "build:ts:types",
         "build:rollup",
+        "../../lit:build",
         "../../reactive-element:build"
       ]
     },
     "build:ts": {
       "command": "tsc --build --pretty",
       "dependencies": [
+        "../../lit:build:ts:types",
         "../../reactive-element:build:ts:types"
       ],
       "clean": "if-file-deleted",

--- a/packages/labs/task/src/task.ts
+++ b/packages/labs/task/src/task.ts
@@ -176,22 +176,7 @@ export class Task<
    * Determines if the task is run automatically when arguments change after a
    * host update. Default to `true`.
    *
-   * If `true`, the task checks arguments during the host update (after
-   * `willUpdate()` and before `update()` in Lit) and runs if they change. For
-   * a task to see argument changes they must be done in `willUpdate()` or
-   * earlier. The host element can see task status changes caused by its own
-   * current update.
-   *
-   * If `'afterUpdate'`, the task checks arguments and runs _after_ the host
-   * update. This means that the task can see host changes done in update, such
-   * as rendered DOM. The host element can not see task status changes caused
-   * by its own update, so the task must trigger a second host update to make
-   * those changes renderable.
-   *
-   * Note: `'afterUpdate'` is unlikely to be SSR compatible in the future.
-   *
-   * If `false`, the task is not run automatically, and must be run with the
-   * {@linkcode run} method.
+   * @see {@link TaskConfig.autoRun} for more information.
    */
   autoRun: boolean | 'afterUpdate';
 

--- a/packages/labs/task/src/task.ts
+++ b/packages/labs/task/src/task.ts
@@ -66,6 +66,9 @@ export interface TaskConfig<T extends ReadonlyArray<unknown>, R> {
    * those changes renderable.
    *
    * Note: `'afterUpdate'` is unlikely to be SSR compatible in the future.
+   *
+   * If `false`, the task is not run automatically, and must be run with the
+   * {@linkcode run} method.
    */
   autoRun?: boolean | 'afterUpdate';
 

--- a/packages/labs/task/src/task.ts
+++ b/packages/labs/task/src/task.ts
@@ -51,7 +51,7 @@ export interface TaskConfig<T extends ReadonlyArray<unknown>, R> {
 
   /**
    * Determines if the task is run automatically when arguments change after a
-   * host update.
+   * host update. Default to `true`.
    *
    * If `true`, the task checks arguments during the host update (after
    * `willUpdate()` and before `update()` in Lit) and runs if they change. For
@@ -174,7 +174,25 @@ export class Task<
   status: TaskStatus = TaskStatus.INITIAL;
 
   /**
-   * Controls if they task will run when its arguments change. Defaults to true.
+   * Determines if the task is run automatically when arguments change after a
+   * host update. Default to `true`.
+   *
+   * If `true`, the task checks arguments during the host update (after
+   * `willUpdate()` and before `update()` in Lit) and runs if they change. For
+   * a task to see argument changes they must be done in `willUpdate()` or
+   * earlier. The host element can see task status changes caused by its own
+   * current update.
+   *
+   * If `'afterUpdate'`, the task checks arguments and runs _after_ the host
+   * update. This means that the task can see host changes done in update, such
+   * as rendered DOM. The host element can not see task status changes caused
+   * by its own update, so the task must trigger a second host update to make
+   * those changes renderable.
+   *
+   * Note: `'afterUpdate'` is unlikely to be SSR compatible in the future.
+   *
+   * If `false`, the task is not run automatically, and must be run with the
+   * {@linkcode run} method.
    */
   autoRun: boolean | 'afterUpdate';
 


### PR DESCRIPTION
Fixes https://github.com/lit/lit/issues/4003
Fixes https://github.com/lit/lit/issues/1808 (there were some issues in the jsdoc example)

This is a breaking change.

This also adds `'afterUpdate'` as a valid value for `autoRun`, which preserves the existing timing. That's useful for tasks that need to read state changes in update, such as DOM.