### PR TITLE
[labs/task] Infer the return type of Task.render()

### DIFF
--- a/.changeset/spicy-mugs-eat.md
+++ b/.changeset/spicy-mugs-eat.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/task': patch
+---
+
+Infer the return type of Task.render()

--- a/packages/labs/task/src/task.ts
+++ b/packages/labs/task/src/task.ts
@@ -327,19 +327,20 @@ export class Task<
     return this._error;
   }
 
-  render(renderer: StatusRenderer<R>) {
+  render<T extends StatusRenderer<R>>(renderer: T) {
     switch (this.status) {
       case TaskStatus.INITIAL:
-        return renderer.initial?.();
+        return renderer.initial?.() as MaybeReturnType<T['initial']>;
       case TaskStatus.PENDING:
-        return renderer.pending?.();
+        return renderer.pending?.() as MaybeReturnType<T['pending']>;
       case TaskStatus.COMPLETE:
-        return renderer.complete?.(this.value!);
+        return renderer.complete?.(this.value!) as MaybeReturnType<
+          T['complete']
+        >;
       case TaskStatus.ERROR:
-        return renderer.error?.(this.error);
+        return renderer.error?.(this.error) as MaybeReturnType<T['error']>;
       default:
-        // exhaustiveness check
-        this.status as void;
+        throw new Error(`Unexpected status: ${this.status}`);
     }
   }
 
@@ -351,3 +352,8 @@ export class Task<
       : args !== prev;
   }
 }
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+type MaybeReturnType<T extends undefined | ((...args: any) => any)> =
+  T extends (...args: any) => any ? ReturnType<T> : undefined;
+/* eslint-enable @typescript-eslint/no-explicit-any */

--- a/packages/labs/task/src/task.ts
+++ b/packages/labs/task/src/task.ts
@@ -353,7 +353,6 @@ export class Task<
   }
 }
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-type MaybeReturnType<T extends undefined | ((...args: any) => any)> =
-  T extends (...args: any) => any ? ReturnType<T> : undefined;
-/* eslint-enable @typescript-eslint/no-explicit-any */
+type MaybeReturnType<F> = F extends (...args: unknown[]) => infer R
+  ? R
+  : undefined;

--- a/packages/labs/task/src/task.ts
+++ b/packages/labs/task/src/task.ts
@@ -10,8 +10,7 @@ export interface TaskFunctionOptions {
   signal?: AbortSignal;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type TaskFunction<D extends ReadonlyArray<unknown>, R = any> = (
+export type TaskFunction<D extends ReadonlyArray<unknown>, R = unknown> = (
   args: D,
   options?: TaskFunctionOptions
 ) => R | typeof initialState | Promise<R | typeof initialState>;

--- a/packages/labs/task/src/test/task_test.ts
+++ b/packages/labs/task/src/test/task_test.ts
@@ -950,11 +950,23 @@ suite('Task', () => {
     customElements.define(generateElementName(), TestElement);
     const el = new TestElement();
 
-    const acceptNumberOrUndefined = (x?: number) => x;
+    const accept = <T>(x: T) => x;
 
-    acceptNumberOrUndefined(el.task.render({initial: () => 123}));
-    acceptNumberOrUndefined(el.task.render({complete: () => 123}));
-    acceptNumberOrUndefined(el.task.render({pending: () => 123}));
-    acceptNumberOrUndefined(el.task.render({error: () => 123}));
+    accept<number | undefined>(el.task.render({initial: () => 123}));
+    accept<number | undefined>(el.task.render({complete: () => 123}));
+    accept<number | undefined>(el.task.render({pending: () => 123}));
+    accept<number | undefined>(el.task.render({error: () => 123}));
+    accept<number | undefined>(
+      el.task.render({initial: () => 123, complete: () => 123})
+    );
+
+    accept<number>(
+      el.task.render({
+        initial: () => 123,
+        complete: () => 123,
+        pending: () => 123,
+        error: () => 123,
+      })
+    );
   });
 });

--- a/packages/labs/task/src/test/task_test.ts
+++ b/packages/labs/task/src/test/task_test.ts
@@ -942,4 +942,19 @@ suite('Task', () => {
     assert.equal(el.task.value, secondValue);
     assert.notEqual(firstValue, secondValue);
   });
+
+  test('type-only render return type test', () => {
+    class TestElement extends ReactiveElement {
+      task = new Task(this, () => 'abc');
+    }
+    customElements.define(generateElementName(), TestElement);
+    const el = new TestElement();
+
+    const acceptNumberOrUndefined = (x?: number) => x;
+
+    acceptNumberOrUndefined(el.task.render({initial: () => 123}));
+    acceptNumberOrUndefined(el.task.render({complete: () => 123}));
+    acceptNumberOrUndefined(el.task.render({pending: () => 123}));
+    acceptNumberOrUndefined(el.task.render({error: () => 123}));
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/lit/lit/issues/2301

Supersedes https://github.com/lit/lit/pull/2821