### PR TITLE
[labs/context] Late loaded elements can take over the context subscriptions for their children

### DIFF
--- a/.changeset/gentle-pillows-buy.md
+++ b/.changeset/gentle-pillows-buy.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/context': patch
+---
+
+Late loaded elements can take over the context subscriptions for their children.

--- a/.changeset/gentle-pillows-buy.md
+++ b/.changeset/gentle-pillows-buy.md
@@ -1,5 +1,7 @@
 ---
-'@lit-labs/context': patch
+'@lit-labs/context': major
 ---
 
 Late loaded elements can take over the context subscriptions for their children.
+
+Breaking change: ValueNotifier.addCallback now takes the consuming element as a mandatory second argument.

--- a/packages/labs/context/src/lib/context-request-event.ts
+++ b/packages/labs/context/src/lib/context-request-event.ts
@@ -51,17 +51,24 @@ export class ContextRequestEvent<C extends Context<unknown, unknown>>
   extends Event
   implements ContextRequest<C>
 {
+  readonly context: C;
+  readonly callback: ContextCallback<ContextType<C>>;
+  readonly subscribe: boolean;
+
   /**
    *
    * @param context the context key to request
    * @param callback the callback that should be invoked when the context with the specified key is available
-   * @param subscribe an optional argument, if true indicates we want to subscribe to future updates
+   * @param subscribe when, true indicates we want to subscribe to future updates
    */
-  public constructor(
-    public readonly context: C,
-    public readonly callback: ContextCallback<ContextType<C>>,
-    public readonly subscribe?: boolean
+  constructor(
+    context: C,
+    callback: ContextCallback<ContextType<C>>,
+    subscribe?: boolean
   ) {
     super('context-request', {bubbles: true, composed: true});
+    this.context = context;
+    this.callback = callback;
+    this.subscribe = subscribe ?? false;
   }
 }

--- a/packages/labs/context/src/lib/context-root.ts
+++ b/packages/labs/context/src/lib/context-root.ts
@@ -41,7 +41,7 @@ export class ContextRoot {
    *
    * @param element an element to add event listeners to
    */
-  public attach(element: HTMLElement): void {
+  attach(element: HTMLElement): void {
     element.addEventListener('context-request', this.onContextRequest);
     element.addEventListener('context-provider', this.onContextProvider);
   }
@@ -51,7 +51,7 @@ export class ContextRoot {
    *
    * @param element an element from which to remove event listeners
    */
-  public detach(element: HTMLElement): void {
+  detach(element: HTMLElement): void {
     element.removeEventListener('context-request', this.onContextRequest);
     element.removeEventListener('context-provider', this.onContextProvider);
   }

--- a/packages/labs/context/src/lib/controllers/context-consumer.ts
+++ b/packages/labs/context/src/lib/controllers/context-consumer.ts
@@ -41,7 +41,7 @@ export class ContextConsumer<
 
   private provided = false;
 
-  public value?: ContextType<C> = undefined;
+  value?: ContextType<C> = undefined;
 
   constructor(host: HostElement, options: Options<C>);
   /** @deprecated Use new ContextConsumer(host, options) */

--- a/packages/labs/context/src/lib/controllers/context-provider.ts
+++ b/packages/labs/context/src/lib/controllers/context-provider.ts
@@ -6,7 +6,7 @@
 
 import {ContextRequestEvent} from '../context-request-event.js';
 import {Context, ContextType} from '../create-context.js';
-import {ValueNotifier} from '../value-notifier.js';
+import {MovedSubscription, ValueNotifier} from '../value-notifier.js';
 import {ReactiveController, ReactiveElement} from 'lit';
 
 declare global {
@@ -29,7 +29,28 @@ export class ContextProviderEvent<
   public constructor(public readonly context: C) {
     super('context-provider', {bubbles: true, composed: true});
   }
+
+  /**
+   * Whether the element that dispatched this event can take over subscriptions
+   * from an ancestor provider.
+   */
+  declare canTakeOverSubscriptions: boolean;
+
+  /**
+   * Ongoing subscriptions that one of our ancestors was handling that are now
+   * our responsibility.
+   */
+  movedSubscriptions: undefined | MovedSubscription<ContextType<C>>[] =
+    undefined;
 }
+// True for all ContextProviderEvents that we fire, but we need to set this
+// so that ancestor providers can tell whether the provider that dispatched this
+// event will actually take over any subscriptions that they move to
+// `event.movedSubscriptions`.
+// This way we fail gracefully in the case where there's version drift, or
+// another implementor that of the context protocol that also dispatches
+// `context-provider` events but doesn't handle movedSubscriptions.
+ContextProviderEvent.prototype.canTakeOverSubscriptions = true;
 
 export interface Options<C extends Context<unknown, unknown>> {
   context: C;
@@ -83,19 +104,52 @@ export class ContextProvider<T extends Context<unknown, unknown>>
     // The check on composedPath (as opposed to ev.target) is to cover cases
     // where the consumer is in the shadowDom of the provider (in which case,
     // event.target === this.host because of event retargeting).
-    if (ev.context !== this.context || ev.composedPath()[0] === this.host) {
+    const consumerHost = ev.composedPath()[0] as Element;
+    if (ev.context !== this.context || consumerHost === this.host) {
       return;
     }
     ev.stopPropagation();
-    this.addCallback(ev.callback, ev.subscribe);
+    this.addCallback(ev.callback, ev.subscribe, consumerHost);
+  };
+
+  public onProviderRequest = (
+    ev: ContextProviderEvent<Context<unknown, unknown>>
+  ): void => {
+    // Ignore events when the context doesn't match.
+    // Also, in case an element is a consumer AND a provider
+    // of the same context, we want to avoid the element to self-register.
+    // The check on composedPath (as opposed to ev.target) is to cover cases
+    // where the consumer is in the shadowDom of the provider (in which case,
+    // event.target === this.host because of event retargeting).
+    const childProviderHost = ev.composedPath()[0] as Element;
+    if (
+      !ev.canTakeOverSubscriptions ||
+      ev.context !== this.context ||
+      childProviderHost === this.host
+    ) {
+      return;
+    }
+    const ourEv = ev as ContextProviderEvent<T>;
+    const movedSubscriptions = this.moveSubscriptionsFor(childProviderHost);
+    if (movedSubscriptions === undefined) {
+      return;
+    }
+    (ourEv.movedSubscriptions ??= []).push(...movedSubscriptions);
   };
 
   private attachListeners() {
     this.host.addEventListener('context-request', this.onContextRequest);
+    this.host.addEventListener('context-provider', this.onProviderRequest);
   }
 
   hostConnected(): void {
     // emit an event to signal a provider is available for this context
-    this.host.dispatchEvent(new ContextProviderEvent(this.context));
+    const providerEvent = new ContextProviderEvent(this.context);
+    this.host.dispatchEvent(providerEvent);
+    if (providerEvent.movedSubscriptions !== undefined) {
+      for (const {callback, consumerHost} of providerEvent.movedSubscriptions) {
+        this.addCallback(callback, true, consumerHost);
+      }
+    }
   }
 }

--- a/packages/labs/context/src/lib/controllers/context-provider.ts
+++ b/packages/labs/context/src/lib/controllers/context-provider.ts
@@ -62,8 +62,7 @@ export class ContextProvider<T extends Context<unknown, unknown>>
     super(
       (contextOrOptions as Options<T>).context !== undefined
         ? (contextOrOptions as Options<T>).initialValue
-        : initialValue,
-      host.id
+        : initialValue
     );
     this.host = host;
     if ((contextOrOptions as Options<T>).context !== undefined) {

--- a/packages/labs/context/src/lib/controllers/context-provider.ts
+++ b/packages/labs/context/src/lib/controllers/context-provider.ts
@@ -119,7 +119,7 @@ export class ContextProvider<T extends Context<unknown, unknown>>
   }
 
   private reparentSubscriptions(_childProviderHost: Element) {
-    for (const [callback, {consumerHost}] of this.callbacks) {
+    for (const [callback, {consumerHost}] of this.subscriptions) {
       if (consumerHost === undefined) {
         continue;
       }

--- a/packages/labs/context/src/lib/controllers/context-provider.ts
+++ b/packages/labs/context/src/lib/controllers/context-provider.ts
@@ -88,7 +88,7 @@ export class ContextProvider<T extends Context<unknown, unknown>>
       return;
     }
     ev.stopPropagation();
-    this.addCallback(ev.callback, ev.subscribe, consumerHost);
+    this.addCallback(ev.callback, consumerHost, ev.subscribe);
   };
 
   /**
@@ -113,9 +113,6 @@ export class ContextProvider<T extends Context<unknown, unknown>>
     // Re-parent all of our subscriptions in case this new child provider
     // should take them over.
     for (const [callback, {consumerHost}] of this.subscriptions) {
-      if (consumerHost === undefined) {
-        continue;
-      }
       consumerHost.dispatchEvent(
         new ContextRequestEvent(this.context, callback, true)
       );

--- a/packages/labs/context/src/lib/controllers/context-provider.ts
+++ b/packages/labs/context/src/lib/controllers/context-provider.ts
@@ -22,12 +22,15 @@ declare global {
 export class ContextProviderEvent<
   C extends Context<unknown, unknown>
 > extends Event {
+  readonly context: C;
+
   /**
    *
    * @param context the context which this provider can provide
    */
-  public constructor(public readonly context: C) {
+  constructor(context: C) {
     super('context-provider', {bubbles: true, composed: true});
+    this.context = context;
   }
 }
 
@@ -74,7 +77,7 @@ export class ContextProvider<T extends Context<unknown, unknown>>
     this.host.addController(this);
   }
 
-  public onContextRequest = (
+  onContextRequest = (
     ev: ContextRequestEvent<Context<unknown, unknown>>
   ): void => {
     // Only call the callback if the context matches.
@@ -97,7 +100,7 @@ export class ContextProvider<T extends Context<unknown, unknown>>
    * re-parent our subscriptions, because is a more specific provider than us
    * for its subtree.
    */
-  public onProviderRequest = (
+  onProviderRequest = (
     ev: ContextProviderEvent<Context<unknown, unknown>>
   ): void => {
     // Ignore events when the context doesn't match.

--- a/packages/labs/context/src/lib/controllers/context-provider.ts
+++ b/packages/labs/context/src/lib/controllers/context-provider.ts
@@ -6,7 +6,7 @@
 
 import {ContextRequestEvent} from '../context-request-event.js';
 import {Context, ContextType} from '../create-context.js';
-import {MovedSubscription, ValueNotifier} from '../value-notifier.js';
+import {ValueNotifier} from '../value-notifier.js';
 import {ReactiveController, ReactiveElement} from 'lit';
 
 declare global {
@@ -29,28 +29,7 @@ export class ContextProviderEvent<
   public constructor(public readonly context: C) {
     super('context-provider', {bubbles: true, composed: true});
   }
-
-  /**
-   * Whether the element that dispatched this event can take over subscriptions
-   * from an ancestor provider.
-   */
-  declare canTakeOverSubscriptions: boolean;
-
-  /**
-   * Ongoing subscriptions that one of our ancestors was handling that are now
-   * our responsibility.
-   */
-  movedSubscriptions: undefined | MovedSubscription<ContextType<C>>[] =
-    undefined;
 }
-// True for all ContextProviderEvents that we fire, but we need to set this
-// so that ancestor providers can tell whether the provider that dispatched this
-// event will actually take over any subscriptions that they move to
-// `event.movedSubscriptions`.
-// This way we fail gracefully in the case where there's version drift, or
-// another implementor that of the context protocol that also dispatches
-// `context-provider` events but doesn't handle movedSubscriptions.
-ContextProviderEvent.prototype.canTakeOverSubscriptions = true;
 
 export interface Options<C extends Context<unknown, unknown>> {
   context: C;
@@ -69,8 +48,8 @@ export class ContextProvider<T extends Context<unknown, unknown>>
   extends ValueNotifier<ContextType<T>>
   implements ReactiveController
 {
-  protected host: ReactiveElement;
-  private context: T;
+  protected readonly host: ReactiveElement;
+  private readonly context: T;
 
   constructor(host: ReactiveElement, options: Options<T>);
   /** @deprecated Use new ContextProvider(host, options) */
@@ -83,7 +62,8 @@ export class ContextProvider<T extends Context<unknown, unknown>>
     super(
       (contextOrOptions as Options<T>).context !== undefined
         ? (contextOrOptions as Options<T>).initialValue
-        : initialValue
+        : initialValue,
+      host.id
     );
     this.host = host;
     if ((contextOrOptions as Options<T>).context !== undefined) {
@@ -117,24 +97,16 @@ export class ContextProvider<T extends Context<unknown, unknown>>
   ): void => {
     // Ignore events when the context doesn't match.
     // Also, in case an element is a consumer AND a provider
-    // of the same context, we want to avoid the element to self-register.
-    // The check on composedPath (as opposed to ev.target) is to cover cases
+    // of the same context it shouldn't provide to itself.
+    // We use composedPath (as opposed to ev.target) to cover cases
     // where the consumer is in the shadowDom of the provider (in which case,
     // event.target === this.host because of event retargeting).
     const childProviderHost = ev.composedPath()[0] as Element;
-    if (
-      !ev.canTakeOverSubscriptions ||
-      ev.context !== this.context ||
-      childProviderHost === this.host
-    ) {
+    if (ev.context !== this.context || childProviderHost === this.host) {
       return;
     }
-    const ourEv = ev as ContextProviderEvent<T>;
-    const movedSubscriptions = this.moveSubscriptionsFor(childProviderHost);
-    if (movedSubscriptions === undefined) {
-      return;
-    }
-    (ourEv.movedSubscriptions ??= []).push(...movedSubscriptions);
+    this.reparentSubscriptions(childProviderHost);
+    ev.stopPropagation();
   };
 
   private attachListeners() {
@@ -146,10 +118,16 @@ export class ContextProvider<T extends Context<unknown, unknown>>
     // emit an event to signal a provider is available for this context
     const providerEvent = new ContextProviderEvent(this.context);
     this.host.dispatchEvent(providerEvent);
-    if (providerEvent.movedSubscriptions !== undefined) {
-      for (const {callback, consumerHost} of providerEvent.movedSubscriptions) {
-        this.addCallback(callback, true, consumerHost);
+  }
+
+  private reparentSubscriptions(_childProviderHost: Element) {
+    for (const [callback, {consumerHost}] of this.callbacks) {
+      if (consumerHost === undefined) {
+        continue;
       }
+      consumerHost.dispatchEvent(
+        new ContextRequestEvent(this.context, callback, true)
+      );
     }
   }
 }

--- a/packages/labs/context/src/lib/controllers/context-provider.ts
+++ b/packages/labs/context/src/lib/controllers/context-provider.ts
@@ -115,8 +115,7 @@ export class ContextProvider<T extends Context<unknown, unknown>>
 
   hostConnected(): void {
     // emit an event to signal a provider is available for this context
-    const providerEvent = new ContextProviderEvent(this.context);
-    this.host.dispatchEvent(providerEvent);
+    this.host.dispatchEvent(new ContextProviderEvent(this.context));
   }
 
   private reparentSubscriptions(_childProviderHost: Element) {

--- a/packages/labs/context/src/lib/value-notifier.ts
+++ b/packages/labs/context/src/lib/value-notifier.ts
@@ -17,25 +17,25 @@ interface CallbackInfo {
 }
 
 /**
- * A simple class which stores a value, and triggers registered callbacks when the
- * value is changed via its setter.
+ * A simple class which stores a value, and triggers registered callbacks when
+ * the value is changed via its setter.
  *
- * An implementor might use other observable patterns such as MobX or Redux to get
- * behavior like this. But this is a pretty minimal approach that will likely work
- * for a number of use cases.
+ * An implementor might use other observable patterns such as MobX or Redux to
+ * get behavior like this. But this is a pretty minimal approach that will
+ * likely work for a number of use cases.
  */
 export class ValueNotifier<T> {
   protected readonly subscriptions: Map<ContextCallback<T>, CallbackInfo> =
     new Map();
   private _value!: T;
-  public get value(): T {
+  get value(): T {
     return this._value;
   }
-  public set value(v: T) {
+  set value(v: T) {
     this.setValue(v);
   }
 
-  public setValue(v: T, force = false) {
+  setValue(v: T, force = false) {
     const update = force || !Object.is(v, this._value);
     this._value = v;
     if (update) {

--- a/packages/labs/context/src/lib/value-notifier.ts
+++ b/packages/labs/context/src/lib/value-notifier.ts
@@ -16,11 +16,6 @@ interface CallbackInfo {
   consumerHost?: Element;
 }
 
-export interface MovedSubscription<T> {
-  callback: ContextCallback<T>;
-  consumerHost: Element;
-}
-
 /**
  * A simple class which stores a value, and triggers registered callbacks when the
  * value is changed via its setter.
@@ -30,8 +25,8 @@ export interface MovedSubscription<T> {
  * for a number of use cases.
  */
 export class ValueNotifier<T> {
-  private callbacks: Map<ContextCallback<T>, CallbackInfo> = new Map();
-
+  protected readonly callbacks: Map<ContextCallback<T>, CallbackInfo> =
+    new Map();
   private _value!: T;
   public get value(): T {
     return this._value;
@@ -83,37 +78,5 @@ export class ValueNotifier<T> {
 
   clearCallbacks(): void {
     this.callbacks.clear();
-  }
-
-  /**
-   * Handle a late registration of an provider in between us and any consumers
-   * that we have ongoing subscriptions with.
-   *
-   * childProviderHost must be a provider host of T which is a descendent of
-   * our host. So we look through our active subscriptions, and if any of them
-   * are contained inside of childProviderHost, we stop handling them ourselves
-   * and we return them in an array so that the childProviderHost can handle
-   * them from now on.
-   */
-  moveSubscriptionsFor(
-    childProviderHost: Element
-  ): undefined | MovedSubscription<T>[] {
-    let result: undefined | MovedSubscription<T>[] = undefined;
-    for (const [callback, {consumerHost}] of this.callbacks) {
-      if (consumerHost === undefined) {
-        continue;
-      }
-      if (
-        childProviderHost !== consumerHost &&
-        childProviderHost.contains(consumerHost)
-      ) {
-        this.callbacks.delete(callback);
-        if (result === undefined) {
-          result = [];
-        }
-        result.push({callback, consumerHost});
-      }
-    }
-    return result;
   }
 }

--- a/packages/labs/context/src/lib/value-notifier.ts
+++ b/packages/labs/context/src/lib/value-notifier.ts
@@ -60,20 +60,21 @@ export class ValueNotifier<T> {
     subscribe?: boolean,
     consumerHost?: Element
   ): void {
-    if (subscribe) {
-      if (!this.subscriptions.has(callback)) {
-        this.subscriptions.set(callback, {
-          disposer: () => {
-            this.subscriptions.delete(callback);
-          },
-          consumerHost,
-        });
-      }
-      const {disposer} = this.subscriptions.get(callback)!;
-      callback(this.value, disposer);
-    } else {
+    if (!subscribe) {
+      // just call the callback once and we're done
       callback(this.value);
+      return;
     }
+    if (!this.subscriptions.has(callback)) {
+      this.subscriptions.set(callback, {
+        disposer: () => {
+          this.subscriptions.delete(callback);
+        },
+        consumerHost,
+      });
+    }
+    const {disposer} = this.subscriptions.get(callback)!;
+    callback(this.value, disposer);
   }
 
   clearCallbacks(): void {

--- a/packages/labs/context/src/lib/value-notifier.ts
+++ b/packages/labs/context/src/lib/value-notifier.ts
@@ -25,7 +25,7 @@ interface CallbackInfo {
  * for a number of use cases.
  */
 export class ValueNotifier<T> {
-  protected readonly callbacks: Map<ContextCallback<T>, CallbackInfo> =
+  protected readonly subscriptions: Map<ContextCallback<T>, CallbackInfo> =
     new Map();
   private _value!: T;
   public get value(): T {
@@ -50,7 +50,7 @@ export class ValueNotifier<T> {
   }
 
   updateObservers = (): void => {
-    for (const [callback, {disposer}] of this.callbacks) {
+    for (const [callback, {disposer}] of this.subscriptions) {
       callback(this._value, disposer);
     }
   };
@@ -61,15 +61,15 @@ export class ValueNotifier<T> {
     consumerHost?: Element
   ): void {
     if (subscribe) {
-      if (!this.callbacks.has(callback)) {
-        this.callbacks.set(callback, {
+      if (!this.subscriptions.has(callback)) {
+        this.subscriptions.set(callback, {
           disposer: () => {
-            this.callbacks.delete(callback);
+            this.subscriptions.delete(callback);
           },
           consumerHost,
         });
       }
-      const {disposer} = this.callbacks.get(callback)!;
+      const {disposer} = this.subscriptions.get(callback)!;
       callback(this.value, disposer);
     } else {
       callback(this.value);
@@ -77,6 +77,6 @@ export class ValueNotifier<T> {
   }
 
   clearCallbacks(): void {
-    this.callbacks.clear();
+    this.subscriptions.clear();
   }
 }

--- a/packages/labs/context/src/lib/value-notifier.ts
+++ b/packages/labs/context/src/lib/value-notifier.ts
@@ -13,7 +13,7 @@ type Disposer = () => void;
 
 interface CallbackInfo {
   disposer: Disposer;
-  consumerHost?: Element;
+  consumerHost: Element;
 }
 
 /**
@@ -57,8 +57,8 @@ export class ValueNotifier<T> {
 
   addCallback(
     callback: ContextCallback<T>,
-    subscribe?: boolean,
-    consumerHost?: Element
+    consumerHost: Element,
+    subscribe?: boolean
   ): void {
     if (!subscribe) {
       // just call the callback once and we're done

--- a/packages/labs/context/src/test/context-provider_test.ts
+++ b/packages/labs/context/src/test/context-provider_test.ts
@@ -165,7 +165,7 @@ memorySuite('memory leak test', () => {
   let container: HTMLElement;
 
   // Make a big array set on an expando to exaggerate any leaked DOM
-  const big = () => new Array(10000).fill(0);
+  const big = () => new Uint8Array(1024 * 10).fill(0);
 
   setup(async () => {
     container = document.createElement('div');

--- a/packages/labs/context/src/test/late-provider_test.ts
+++ b/packages/labs/context/src/test/late-provider_test.ts
@@ -370,14 +370,13 @@ suiteSkipIE('late context provider', () => {
     assert.equal(directChildConsumer.value, 'grandparent updated');
     assert.equal(indirectChildConsumer.value, 'late provider initial value');
 
-    // Updating the middle provider updates its childd, but not its sibling,
+    // Updating the middle provider updates its child, but not its sibling,
     // the direct child.
     const middleProvider = container.querySelector(
       'late-context-provider-4'
     ) as LateContextProvider4Element;
     middleProvider.provide.setValue('late provider updated');
     await directChildConsumer.updateComplete;
-    // bad!
     assert.equal(directChildConsumer.value, 'grandparent updated');
     assert.equal(indirectChildConsumer.value, 'late provider updated');
 

--- a/packages/labs/context/src/test/late-provider_test.ts
+++ b/packages/labs/context/src/test/late-provider_test.ts
@@ -364,11 +364,14 @@ suiteSkipIE('late context provider', () => {
         initialValue: 'late provider initial value',
       });
     }
+
+    // The indirect child now gets the late provider's initial value
     await directChildConsumer.updateComplete;
-    // bad!
     assert.equal(directChildConsumer.value, 'grandparent updated');
     assert.equal(indirectChildConsumer.value, 'late provider initial value');
 
+    // Updating the middle provider updates its childd, but not its sibling,
+    // the direct child.
     const middleProvider = container.querySelector(
       'late-context-provider-4'
     ) as LateContextProvider4Element;
@@ -376,6 +379,12 @@ suiteSkipIE('late context provider', () => {
     await directChildConsumer.updateComplete;
     // bad!
     assert.equal(directChildConsumer.value, 'grandparent updated');
+    assert.equal(indirectChildConsumer.value, 'late provider updated');
+
+    // Updating the grandparent only propagates to the direct child
+    grandparentProvider.provide.setValue('grandparent updated again');
+    await directChildConsumer.updateComplete;
+    assert.equal(directChildConsumer.value, 'grandparent updated again');
     assert.equal(indirectChildConsumer.value, 'late provider updated');
   });
 });


### PR DESCRIPTION
When context-provider event is dispatched, and `event.canTakeOverSubscriptions` is true, then parent providers of the same context can create or push to the `event.movedSubscriptions` array to indicate callbacks that they will no longer handle, but that the new provider should.

Fixes https://github.com/lit/lit/issues/2763