### PR TITLE
[labs/gen-wrapper-react] Update to emit `createComponent` with option object syntax

### DIFF
--- a/.changeset/thirty-mugs-lay.md
+++ b/.changeset/thirty-mugs-lay.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/gen-wrapper-react': patch
+---
+
+Emit code that creates wrapper component using the option object syntax for `createComponent` instead of the deprecated multi arg signature.

--- a/packages/labs/gen-wrapper-react/goldens/test-element-a/src/element-a.ts
+++ b/packages/labs/gen-wrapper-react/goldens/test-element-a/src/element-a.ts
@@ -3,6 +3,11 @@ import {createComponent, EventName} from '@lit-labs/react';
 
 import {ElementA as ElementAElement} from '@lit-internal/test-element-a/element-a.js';
 
-export const ElementA = createComponent(React, 'element-a', ElementAElement, {
-  onAChanged: 'a-changed' as EventName<CustomEvent<unknown>>,
+export const ElementA = createComponent({
+  react: React,
+  tagName: 'element-a',
+  elementClass: ElementAElement,
+  events: {
+    onAChanged: 'a-changed' as EventName<CustomEvent<unknown>>,
+  },
 });

--- a/packages/labs/gen-wrapper-react/goldens/test-element-a/src/element-events.ts
+++ b/packages/labs/gen-wrapper-react/goldens/test-element-a/src/element-events.ts
@@ -11,11 +11,11 @@ export type {EventSubclass} from '@lit-internal/test-element-a/element-events.js
 export type {SpecialEvent} from '@lit-internal/test-element-a/special-event.js';
 export type {TemplateResult} from 'lit';
 
-export const ElementEvents = createComponent(
-  React,
-  'element-events',
-  ElementEventsElement,
-  {
+export const ElementEvents = createComponent({
+  react: React,
+  tagName: 'element-events',
+  elementClass: ElementEventsElement,
+  events: {
     onStringCustomEvent: 'string-custom-event' as EventName<
       CustomEvent<string>
     >,
@@ -30,5 +30,5 @@ export const ElementEvents = createComponent(
     onTemplateResultCustomEvent: 'template-result-custom-event' as EventName<
       CustomEvent<TemplateResult>
     >,
-  }
-);
+  },
+});

--- a/packages/labs/gen-wrapper-react/goldens/test-element-a/src/element-props.ts
+++ b/packages/labs/gen-wrapper-react/goldens/test-element-a/src/element-props.ts
@@ -3,11 +3,11 @@ import {createComponent, EventName} from '@lit-labs/react';
 
 import {ElementProps as ElementPropsElement} from '@lit-internal/test-element-a/element-props.js';
 
-export const ElementProps = createComponent(
-  React,
-  'element-props',
-  ElementPropsElement,
-  {
+export const ElementProps = createComponent({
+  react: React,
+  tagName: 'element-props',
+  elementClass: ElementPropsElement,
+  events: {
     onAChanged: 'a-changed' as EventName<CustomEvent<unknown>>,
-  }
-);
+  },
+});

--- a/packages/labs/gen-wrapper-react/goldens/test-element-a/src/element-slots.ts
+++ b/packages/labs/gen-wrapper-react/goldens/test-element-a/src/element-slots.ts
@@ -3,9 +3,9 @@ import {createComponent} from '@lit-labs/react';
 
 import {ElementSlots as ElementSlotsElement} from '@lit-internal/test-element-a/element-slots.js';
 
-export const ElementSlots = createComponent(
-  React,
-  'element-slots',
-  ElementSlotsElement,
-  {}
-);
+export const ElementSlots = createComponent({
+  react: React,
+  tagName: 'element-slots',
+  elementClass: ElementSlotsElement,
+  events: {},
+});

--- a/packages/labs/gen-wrapper-react/src/index.ts
+++ b/packages/labs/gen-wrapper-react/src/index.ts
@@ -193,11 +193,11 @@ const packageNameToReactPackageName = (pkgName: string) => `${pkgName}-react`;
 
 const wrapperTemplate = ({name, tagname, events}: LitElementDeclaration) => {
   return javascript`
- export const ${name} = createComponent(
-   React,
-   '${tagname}',
-   ${name}Element,
-   {
+ export const ${name} = createComponent({
+   react: React,
+   tagName: '${tagname}',
+   elementClass: ${name}Element,
+   events: {
      ${Array.from(events.values()).map((event: EventModel) => {
        const {name, type} = event;
        return javascript`
@@ -206,6 +206,6 @@ const wrapperTemplate = ({name, tagname, events}: LitElementDeclaration) => {
        }>,`;
      })}
    }
- );
+  });
  `;
 };


### PR DESCRIPTION
It should not emit deprecated syntax.