### PR TITLE
[labs/react] Remove deprecated syntax and remove extra class component

### DIFF
--- a/.changeset/green-knives-appear.md
+++ b/.changeset/green-knives-appear.md
@@ -1,0 +1,19 @@
+---
+'@lit-labs/react': major
+---
+
+- [BREAKING] Removed deprecated call signature for `createComponent()` taking multiple arguments. A single option object must be passed in instead.
+
+Example:
+
+```diff
+- createComponent(React, 'my-element', MyElement, {onfoo: 'foo'})
++ createComponent({
++   react: React,
++   tagName: 'my-element',
++   elementClass: MyElement,
++   events: {onfoo: 'foo'},
++ })
+```
+
+- Refactored to move implementation directly into render function of `forwardRef` rather than creating a class component. This removes an extra React component of the same name showing up in the component tree.

--- a/packages/labs/react/src/create-component.ts
+++ b/packages/labs/react/src/create-component.ts
@@ -147,21 +147,22 @@ const setProperty = <E extends Element>(
     addOrUpdateEventListener(node, event, value as (e?: Event) => void);
     return;
   }
-
   // But don't dirty check properties; elements are assumed to do this.
   node[name as keyof E] = value as E[keyof E];
 
-  // Note, the attribute removal here for `undefined` and `null` values is done
-  // to match React's behavior on non-custom elements. It needs special handling
-  // because it does not match platform behavior. For example, setting the `id`
-  // property to `undefined` sets the attribute to the string "undefined." React
-  // "fixes" that odd behavior and the code here matches React's convention.
+  // This block is to replicate React's behavior for attributes of native
+  // elements where `undefined` or `null` values result in attributes being
+  // removed.
+  // https://github.com/facebook/react/blob/899cb95f52cc83ab5ca1eb1e268c909d3f0961e7/packages/react-dom-bindings/src/client/DOMPropertyOperations.js#L107-L141
+  //
+  // It's only needed here for native HTMLElement properties that reflect
+  // attributes of the same name but don't have that behavior like "id" or
+  // "draggable".
   if (
     (value === undefined || value === null) &&
     name in HTMLElement.prototype
   ) {
     node.removeAttribute(name);
-    return;
   }
 };
 

--- a/packages/labs/react/src/create-component.ts
+++ b/packages/labs/react/src/create-component.ts
@@ -62,7 +62,7 @@ export type ReactWebComponent<
  * `onfoo` prop will have the type `(e: FooEvent) => void`.
  */
 export type EventName<T extends Event = Event> = string & {
-  __event_type: T;
+  __eventType: T;
 };
 
 // A key value map matching React prop names to event names.
@@ -71,7 +71,7 @@ type EventNames = Record<string, EventName | string>;
 // A map of expected event listener types based on EventNames.
 type EventListeners<R extends EventNames> = {
   [K in keyof R]?: R[K] extends EventName
-    ? (e: R[K]['__event_type']) => void
+    ? (e: R[K]['__eventType']) => void
     : (e: Event) => void;
 };
 

--- a/packages/labs/react/src/test/create-component_test.tsx
+++ b/packages/labs/react/src/test/create-component_test.tsx
@@ -542,6 +542,27 @@ suite('createComponent', () => {
     );
   });
 
+  test('unsets reflected attributes from property with different specifier on null or undefined prop', async () => {
+    // Our types don't allow `ariaChecked` only `aria-checked` but it's possible
+    // for JS users and wrapper will set the property on the element
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await renderReactComponent({ariaChecked: true} as any);
+
+    // Assertion below fails for Firefox as setting the property doesn't reflect
+    // assert.equal(wrappedEl.hasAttribute('aria-checked'), true);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await renderReactComponent({ariaChecked: undefined} as any);
+    assert.equal(wrappedEl.hasAttribute('aria-checked'), false);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await renderReactComponent({ariaChecked: true} as any);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await renderReactComponent({ariaChecked: null} as any);
+    assert.equal(wrappedEl.hasAttribute('aria-checked'), false);
+  });
+
   test('can listen to events', async () => {
     let fooEvent: Event | undefined,
       fooEvent2: Event | undefined,

--- a/packages/labs/react/src/test/create-component_test.tsx
+++ b/packages/labs/react/src/test/create-component_test.tsx
@@ -543,8 +543,8 @@ suite('createComponent', () => {
   });
 
   test('unsets reflected attributes from property with different specifier on null or undefined prop', async () => {
-    // Our types don't allow `ariaChecked` only `aria-checked` but it's possible
-    // for JS users and wrapper will set the property on the element
+    // Our types don't allow `ariaChecked`, only `aria-checked`, but it's
+    // possible for JS users, and the wrapper will set the property on the element
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await renderReactComponent({ariaChecked: true} as any);
 

--- a/packages/labs/react/src/test/create-component_test.tsx
+++ b/packages/labs/react/src/test/create-component_test.tsx
@@ -31,7 +31,9 @@ declare global {
     [tagName]: BasicElement;
     'x-foo': XFoo;
   }
+}
 
+declare module 'react' {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace JSX {
     interface IntrinsicElements {
@@ -71,7 +73,7 @@ class BasicElement extends ReactiveElement {
 
   // override a react reserved property
   @property({type: String})
-  locaName = 'basic-element-x-foo';
+  override localName = 'basic-element';
 
   @property({type: Boolean, reflect: true})
   rbool = false;

--- a/packages/labs/react/src/test/create-component_test.tsx
+++ b/packages/labs/react/src/test/create-component_test.tsx
@@ -548,8 +548,10 @@ suite('createComponent', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await renderReactComponent({ariaChecked: true} as any);
 
-    // Assertion below fails for Firefox as setting the property doesn't reflect
-    // assert.equal(wrappedEl.hasAttribute('aria-checked'), true);
+    // Firefox does not implement aria properties that reflect to attribute
+    if ('ariaChecked' in HTMLElement) {
+      assert.equal(wrappedEl.hasAttribute('aria-checked'), true);
+    }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await renderReactComponent({ariaChecked: undefined} as any);


### PR DESCRIPTION
- Refactored to move implementation directly into render function of `forwardRef` rather than creating a class component. This removes an extra React component of the same name showing up in the component tree.
- Removed deprecated old signature taking separate arguments.
- Simplified typings for `WebComponentProps` and `ReactWebComponent` and added jsdoc.