### PR TITLE
Rename ReactiveElement._initialize to __initialize

### DIFF
--- a/.changeset/serious-turkeys-warn.md
+++ b/.changeset/serious-turkeys-warn.md
@@ -1,0 +1,7 @@
+---
+'@lit/reactive-element': patch
+'lit': patch
+'lit-element': patch
+---
+
+Rename ReactiveElement.\_initialize to \_\_initialize, make it private, and remove the @internal annotation. This will help prevent collisions with subclasses that implement their own \_initialize method, while using development builds.

--- a/packages/reactive-element/src/reactive-element.ts
+++ b/packages/reactive-element/src/reactive-element.ts
@@ -928,16 +928,14 @@ export abstract class ReactiveElement
 
   constructor() {
     super();
-    this._initialize();
+    this.__initialize();
   }
 
   /**
    * Internal only override point for customizing work done when elements
    * are constructed.
-   *
-   * @internal
    */
-  _initialize() {
+  private __initialize() {
     this.__updatePromise = new Promise<boolean>(
       (res) => (this.enableUpdating = res)
     );


### PR DESCRIPTION
Rename `ReactiveElement._initialize` to `__initialize`, make it private, and remove the `@internal` annotation. This will help prevent collisions with subclasses that implement their own `_initialize` method, while using development builds.

Thanks for @thepassle for enabling the development export condition by default in Web Dev Server, which highlighted this issue!