### PR TITLE
[infra] Add benchmarks report workflow

### DIFF
--- a/.github/workflows/benchmarks-report.yaml
+++ b/.github/workflows/benchmarks-report.yaml
@@ -1,0 +1,48 @@
+name: Report Benchmark Results
+
+on:
+  workflow_run:
+    workflows: ['Benchmarks Test']
+    branches: ['**']
+    types:
+      - completed
+      - requested
+
+jobs:
+  # Optional job to update existing comments with a "benchmarks are running" text
+  report_running:
+    name: Report benchmarks are in-progress
+    runs-on: ubuntu-latest
+    # Only add the "benchmarks are running" text when the workflow_run starts
+    if: ${{ github.event.action == 'requested' }}
+    steps:
+      - name: Report Tachometer Running
+        uses: andrewiggins/tachometer-reporter-action@v2
+        with:
+          # Set initialize true so this action just creates the comment and adds
+          # the "benchmarks are running" text
+          initialize: true
+
+  report_results:
+    name: Report benchmark results
+    runs-on: ubuntu-latest
+    # Only run this job if the event action was "completed" and the triggering
+    # workflow_run was successful
+    if: ${{ github.event.action == 'completed' && github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      # Download the artifact from the triggering workflow that contains the
+      # Tachometer results to report
+      - uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: ${{ github.event.workflow.id }}
+          run_id: ${{ github.event.workflow_run.id }}
+          name: results
+          path: results
+
+      # Create/update the comment with the latest results
+      - name: Report Tachometer Results
+        uses: andrewiggins/tachometer-reporter-action@main
+        with:
+          path: results/*.json
+          pr-bench-name: this-change
+          base-bench-name: tip-of-tree


### PR DESCRIPTION
This is the first step in allowing benchmarks to run for PRs from forks.

Approach is taken from https://github.com/andrewiggins/tachometer-reporter-action#working-with-forks

The [`workflow_run` hook](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run) for GitHub Actions only works when the workflow file is present in the default branch. This PR is to add this, but looks for workflow named "Benchmarks Test".

Once merged, I'll update this PR https://github.com/lit/lit/pull/4038 to rename the Benchmarks workflow to Benchmarks Test to see if this report result workflow works.