### PR TITLE
[labs/react]  Fixes `WebComponentProps` type to accept `ref` prop

### DIFF
--- a/.changeset/seven-fans-sniff.md
+++ b/.changeset/seven-fans-sniff.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/react': patch
+---
+
+Update `WebComponentProps` type to allow providing `ref` prop in JSX.

--- a/packages/labs/react/src/create-component.ts
+++ b/packages/labs/react/src/create-component.ts
@@ -42,11 +42,13 @@ export type ReactWebComponent<
   React.PropsWithoutRef<ComponentProps<I, E>> & React.RefAttributes<I>
 >;
 
+// Props derived from custom element class. Currently has limitations of making
+// all properties optional and also surfaces life cycle methods in autocomplete.
 // TODO(augustjk) Consider omitting keyof LitElement to remove "internal"
-// lifecycle methods or allow user to explicitly set the prop type instead
-// of grabbing from class
+// lifecycle methods or allow user to explicitly provide props.
 type ElementProps<I> = Partial<Omit<I, keyof HTMLElement>>;
 
+// Acceptable props to the React component.
 type ComponentProps<I, E extends EventNames = {}> = React.HTMLAttributes<I> &
   ElementProps<I> &
   EventListeners<E>;

--- a/packages/labs/react/src/create-component.ts
+++ b/packages/labs/react/src/create-component.ts
@@ -25,7 +25,10 @@ const DEV_MODE = true;
  * }
  * ```
  */
-export type WebComponentProps<I extends HTMLElement> = React.HTMLAttributes<I> &
+export type WebComponentProps<I extends HTMLElement> = React.DetailedHTMLProps<
+  React.HTMLAttributes<I>,
+  I
+> &
   // TODO(augustjk) Consider omitting keyof LitElement to remove "internal"
   // lifecycle methods or allow user to explicitly set the prop type instead
   // of grabbing from class
@@ -39,7 +42,7 @@ export type ReactWebComponent<
   I extends HTMLElement,
   E extends EventNames = {}
 > = React.ForwardRefExoticComponent<
-  React.PropsWithoutRef<WebComponentProps<I> & EventListeners<E>> &
+  React.PropsWithoutRef<React.HTMLAttributes<I> & EventListeners<E>> &
     React.RefAttributes<I>
 >;
 
@@ -218,7 +221,7 @@ export const createComponent = <
     }
   }
 
-  type ComponentProps = WebComponentProps<I> & EventListeners<E>;
+  type ComponentProps = React.HTMLAttributes<I> & EventListeners<E>;
 
   const ReactComponent = React.forwardRef<I, ComponentProps>((props, ref) => {
     const prevPropsRef = React.useRef<ComponentProps | null>(null);

--- a/packages/labs/react/src/test/create-component_test.tsx
+++ b/packages/labs/react/src/test/create-component_test.tsx
@@ -212,13 +212,13 @@ suite('createComponent', () => {
   });
 
   // Type only test to be caught at build time.
-  test.skip('renders element with expected type', async () => {
-    type TypedComponent = ReactWebComponent<BasicElement>;
+  test.skip('Wrapped component should accept props with correct types', async () => {
+    const TypedBasicElementComponent = {} as ReactWebComponent<BasicElement>;
 
-    let TypedBasicElement: TypedComponent;
+    <TypedBasicElementComponent str="str" bool={true} num={1} />;
 
     // @ts-expect-error bool prop only accepts boolean
-    <TypedBasicElement bool={'string'}></TypedBasicElement>;
+    <TypedBasicElementComponent bool={'string'} />;
   });
 
   // Type only test to be caught at build time.

--- a/packages/labs/react/src/test/create-component_test.tsx
+++ b/packages/labs/react/src/test/create-component_test.tsx
@@ -221,6 +221,11 @@ suite('createComponent', () => {
     <TypedBasicElement bool={'string'}></TypedBasicElement>;
   });
 
+  // Type only test to be caught at build time.
+  test.skip('WebComponentProps type allows "ref"', async () => {
+    <x-foo ref={React.createRef()}></x-foo>;
+  });
+
   test('works with text children', async () => {
     const name = 'World';
     act(() => {


### PR DESCRIPTION
Fixes #4060

Using `React.DetailedHTMLProps` includes the optional `ref` prop with a ref that should return the element class itself. This is the same type used for built-in elements in `React.JSX.IntrinsicElements`.

We only need the `React.DetailedHTMLProps` for `WebComponentProps` meant to be used for `IntrinsicElements` whereas the internal type for the component props still just needs the `React.HTMLAttributes` as we did before. So I added a `ElementProps` type that's shared between those.

Test for this could be better but I just added a small build-time check for now.

I want to better refactor the test to really separately test the different parts of `create-component.ts` instead of the single test render harness trying pass props to a div, an x-foo, and the wrapped component like this https://github.com/lit/lit/blob/47b48915b50d3509b262a83af1453b440a5ff595/packages/labs/react/src/test/create-component_test.tsx#L126-L132
but that should be its own PR.
