### PR TITLE
[labs/task] Fix Task.render()'s return type always being undefined

### DIFF
--- a/.changeset/shaggy-dingos-press.md
+++ b/.changeset/shaggy-dingos-press.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/task': patch
+---
+
+Fix Task.render()'s return type always being undefined

--- a/packages/labs/task/src/task.ts
+++ b/packages/labs/task/src/task.ts
@@ -430,7 +430,7 @@ export class Task<
   }
 }
 
-type MaybeReturnType<F> = F extends (...args: unknown[]) => infer R
+type MaybeReturnType<F> = F extends (...args: never[]) => infer R
   ? R
   : undefined;
 

--- a/packages/labs/task/src/test/task_test.ts
+++ b/packages/labs/task/src/test/task_test.ts
@@ -1051,5 +1051,13 @@ suite('Task', () => {
         error: () => 123,
       })
     );
+    accept<number>(
+      el.task.render({
+        initial: () => 123,
+        complete: (value) => Number(accept<string>(value)),
+        pending: () => 123,
+        error: (error) => (error instanceof Error ? 123 : 456),
+      })
+    );
   });
 });


### PR DESCRIPTION
In TypeScript:
- `unknown` is the top type: everything can be assigned to `unknown`, and `unknown` can be only assigned to `unknown`.
- `never` is the bottom type: `never` can be assigned to everything, and only `never` can be assigned to `never`.
- Assuming a `Cat` can be assigned to an `Animal`, but not the other way around:
  - (read-only) arrays are covariant: a `Cat[]` can be assigned to an `Animal[]`, but not the other way around. In other words, arrays don't change the "order" of types, as expected.
  - function arguments are contravariant: a `(x: Animal) => boolean` can be assigned to a `(x: Cat) => boolean`, but not the other way around. In other words, function arguments flip the "order" of types.

The right-hand of the `extends` in `MaybeReturnType` is a `(...args: unknown[]) => ?`. If `(...args: T[]) => ?` is assignable to that, then `unknown` is assignable to `T`… but `unknown` can only be assigned to `unknown`, so `T` must be `unknown`. No functions can be assigned to a type of `(...args: unknown[]) => ?` unless it is also that type.

Therefore, the `extends` clause in `MaybeReturnType` was always failing for all functions, apart from the ones which had an arguments array of `unknown[]`. This caused `render`'s return type to only include `undefined`.

The function type in `MaybeReturnType` should be a function type which can have _any_ function arguments, so we should use `(...args: never[]) => ?` instead - as `never` can be assigned to everything, so everything can be assigned to `(...args: never[]) => ?`.