### PR TITLE
[labs/ssr] Context support via `Event.composedPath()` shim

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -25,6 +25,7 @@ packages/benchmarks/**/*.js
 packages/benchmarks/**/*.js.map
 
 packages/context/development/
+packages/context/node/
 packages/context/test/
 packages/context/node_modules/
 packages/context/lib/

--- a/.prettierignore
+++ b/.prettierignore
@@ -25,6 +25,7 @@ packages/benchmarks/**/*.js
 packages/benchmarks/**/*.js.map
 
 packages/context/development/
+packages/context/node/
 packages/context/test/
 packages/context/node_modules/
 packages/context/lib/

--- a/package-lock.json
+++ b/package-lock.json
@@ -26362,6 +26362,7 @@
       "version": "1.1.0",
       "license": "BSD-3-Clause",
       "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.0.0",
         "@lit/reactive-element": "^1.6.2 || ^2.0.0"
       },
       "devDependencies": {

--- a/packages/context/.gitignore
+++ b/packages/context/.gitignore
@@ -1,4 +1,5 @@
 /development/
+/node/
 /test/
 /node_modules/
 /lib/

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -19,6 +19,10 @@
   "exports": {
     ".": {
       "types": "./development/index.d.ts",
+      "node": {
+        "development": "./node/development/index.js",
+        "default": "./node/index.js"
+      },
       "development": "./development/index.js",
       "default": "./index.js"
     }
@@ -27,6 +31,7 @@
     "/src/",
     "!/src/test/",
     "/lib/",
+    "/node/",
     "/development/",
     "!/development/test/",
     "/index.{d.ts,d.ts.map,js,js.map}"
@@ -209,7 +214,8 @@
   },
   "author": "Google LLC",
   "dependencies": {
-    "@lit/reactive-element": "^1.6.2 || ^2.0.0"
+    "@lit/reactive-element": "^1.6.2 || ^2.0.0",
+    "@lit-labs/ssr-dom-shim": "^1.0.0"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4-fix.0",

--- a/packages/context/rollup.config.js
+++ b/packages/context/rollup.config.js
@@ -9,10 +9,12 @@ import {createRequire} from 'module';
 
 export default litProdConfig({
   packageName: createRequire(import.meta.url)('./package.json').name,
+  includeNodeBuild: true,
   entryPoints: ['index'],
   external: [
     '@lit/reactive-element',
     '@lit/reactive-element/decorators/base.js',
+    '@lit-labs/ssr-dom-shim',
     'lit',
     'lit/directive.js',
   ],

--- a/packages/labs/ssr/src/lib/dom-shim.ts
+++ b/packages/labs/ssr/src/lib/dom-shim.ts
@@ -14,6 +14,9 @@
 
 import fetch from 'node-fetch';
 import {
+  EventTargetWithParent,
+  EventWithPath,
+  CustomEvent,
   HTMLElement,
   Element,
   CustomElementRegistry,
@@ -55,6 +58,9 @@ export const getWindow = ({
   }
 
   const window = {
+    EventTarget: EventTargetWithParent,
+    Event: EventWithPath,
+    CustomEvent,
     Element,
     HTMLElement,
     Document,

--- a/packages/labs/ssr/src/test/lib/render-lit_test.ts
+++ b/packages/labs/ssr/src/test/lib/render-lit_test.ts
@@ -700,6 +700,13 @@ for (const global of [emptyVmGlobal, shimmedVmGlobal]) {
       render(renderServerOnlyElementPart);
     }, /Server-only templates don't support element parts/);
   });
+
+  test('dispatchEvent', async () => {
+    const {render, eventDispatch} = await setup();
+    const result = render(eventDispatch);
+
+    assert.match(result, '<p><!--lit-part-->set<!--/lit-part--></p>');
+  });
 }
 
 test.run();

--- a/packages/labs/ssr/src/test/test-files/render-test-module.ts
+++ b/packages/labs/ssr/src/test/test-files/render-test-module.ts
@@ -375,3 +375,40 @@ export const renderServerScriptNotJavaScript = serverhtml`
 // This doesn't have to make sense, the test is that it'll throw at the
 // template preparation phase.
 export const renderServerOnlyElementPart = serverhtml`<div ${'foo'}></div>`;
+
+/* Events */
+
+@customElement('test-event-dispatch')
+export class TestEventDispatch extends LitElement {
+  @property() testProperty!: string;
+
+  override connectedCallback() {
+    super.connectedCallback();
+    const event = new CustomEvent('test-event', {
+      bubbles: true,
+      detail: {testProperty: 'initial'},
+    });
+    this.dispatchEvent(event);
+    this.testProperty = event.detail.testProperty;
+  }
+
+  override render() {
+    return html`<p>${this.testProperty}</p>`;
+  }
+}
+
+@customElement('test-event-listen')
+export class TestEventListen extends LitElement {
+  override connectedCallback() {
+    super.connectedCallback();
+    this.addEventListener('test-event', (e: Event) => {
+      (e as CustomEvent<{testProperty: string}>).detail.testProperty = 'set';
+    });
+  }
+
+  override render() {
+    return html`<test-event-dispatch></test-event-dispatch>`;
+  }
+}
+
+export const eventDispatch = html`<test-event-listen></test-event-listen>`;

--- a/packages/reactive-element/src/reactive-element.ts
+++ b/packages/reactive-element/src/reactive-element.ts
@@ -1110,6 +1110,10 @@ export abstract class ReactiveElement
     this.__controllers?.forEach((c) => c.hostConnected?.());
   }
 
+  serverCallback() {
+    this.__controllers?.forEach((c) => c.hostConnected?.());
+  }
+
   /**
    * Note, this method should be considered final and not overridden. It is
    * overridden on the element instance with a function that triggers the first

--- a/rollup-common.js
+++ b/rollup-common.js
@@ -286,6 +286,13 @@ const injectNodeDomShimIntoReactiveElement = [
       '**/packages/labs/ssr-client/development/lib/hydrate-lit-html.js',
     ],
   }),
+  inject({
+    Event: ['@lit-labs/ssr-dom-shim', 'Event'],
+    include: [
+      '**/packages/context/development/lib/context-request-event.js',
+      '**/packages/context/development/lib/controllers/context-provider.js',
+    ],
+  }),
   replace({
     preventAssignment: true,
     values: {


### PR DESCRIPTION
This is rebased version of https://github.com/lit/lit/pull/2309 with [additional updates](https://github.com/lit/lit/pull/4082/files/66e4e1f6c451c7c3991ce0a93f2b807b92562c9a..a21b50e0e3de37172d712229aa347e5d72136e17):

- [x] Replaced `connectedCallback()` with `serverCallback()` that also calls `Controller.hostConnected()`
- [x] Added shim for [`Event.composedPath()`](https://developer.mozilla.org/en-US/docs/Web/API/Event/composedPath) method that replaces [incompatible](https://github.com/lit/lit/blob/d586f8b9cee6bdd26b682064fe0fc0915d0572da/packages/labs/context/src/lib/controllers/context-provider.ts#L89) `Node.js` [implementation](https://nodejs.org/docs/latest-v14.x/api/events.html#events_event_composedpath)
- [x] Added `Node.js` build for `labs/context` package that relies on new `Event` shim

I plan to supplement PR with additional tests (or maybe a demo), so it takes some time

[Repository with demo](https://github.com/PonomareVlad/lit-ssr-examples)

<details><summary>How to test this PR</summary>
<p>

Just add `overrides` field in your `package.json`:

```json
{
  "overrides": {
    "@lit-labs/ssr": "npm:@ponomarevlad/lit-labs-ssr@3.1.5-ssr-events-npm-2",
    "@lit-labs/task": "npm:@ponomarevlad/lit-labs-task@3.0.0-ssr-events-npm-2",
    "@lit-labs/router": "npm:@ponomarevlad/lit-labs-router@0.1.1-ssr-events-npm-2",
    "@lit-labs/context": "npm:@ponomarevlad/lit-labs-context@0.3.3-ssr-events-npm-2",
    "@lit-labs/ssr-client": "npm:@ponomarevlad/lit-labs-ssr-client@1.1.3-ssr-events-npm-2",
    "@lit-labs/ssr-dom-shim": "npm:@ponomarevlad/lit-labs-ssr-dom-shim@1.1.1-ssr-events-npm-2",
    "@lit/reactive-element": "npm:@ponomarevlad/reactive-element@1.6.3-ssr-events-npm-2",
    "lit-element": "npm:@ponomarevlad/lit-element@3.3.3-ssr-events-npm-2",
    "lit-html": "npm:@ponomarevlad/lit-html@2.8.0-ssr-events-npm-2",
    "lit": "npm:@ponomarevlad/lit@2.8.0-ssr-events-npm-2"
  }
}
``` 

And run `npm install` ✨

</p>
</details> 