### PR TITLE
Render result via `ReadableStream` for web runtimes (edge/workers)

### DIFF
--- a/packages/labs/ssr/src/lib/render-result-readable-stream.ts
+++ b/packages/labs/ssr/src/lib/render-result-readable-stream.ts
@@ -1,0 +1,81 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {RenderResult} from './render-result.js';
+
+type RenderResultIterator = Iterator<string | Promise<RenderResult>>;
+
+/**
+ * A Readable that reads from a RenderResult.
+ */
+export const renderResultReadableStream = (result: RenderResult) => {
+  let closed = false;
+
+  /**
+   * A stack of open iterators.
+   *
+   * We need to keep this as instance state because we can pause and resume
+   * reading values at any time and can't guarantee to run iterators to
+   * completion in any one loop.
+   */
+  const iterators = [result[Symbol.iterator]()];
+
+  const encoder = new TextEncoder();
+
+  return new ReadableStream({
+    cancel: () => void (closed = true),
+    pull: async (controller) => {
+      // This implementation reads values from the RenderResult and pushes them
+      // into the base class's Readable implementation. It tries to be as
+      // efficient as possible, which means:
+      //   1. Avoid microtasks and Promise allocations. Read and write values
+      //      synchronously when possible.
+      //   2. Write as many values to the Readable per call to _read() as
+      //      possible.
+      //
+      // To do this correctly we must adhere to the Readable contract for
+      // _read(), which states that:
+      //
+      // - The size parameter can be safely ignored
+      // - _read() should call `this.push()` as many times as it can until
+      //   `this.push()` returns false, which means the underlying Readable
+      //   does not want any more values.
+      // - `this._read()` should not be called by the underlying Readable until
+      //   after this.push() has returned false, so we can wait on a Promise
+      //   and call _read() when it resolves to continue without a race condition.
+      //   (We try to verify this with the this._waiting field)
+      // - `this.push(null)` ends the stream
+      //
+      // This means that we cannot use for/of loops to iterate on the render
+      // result, because we must be able to return in the middle of the loop
+      // and resume on the next call to _read().
+
+      // Get the current iterator
+      let iterator = iterators.pop();
+
+      while (iterator !== undefined) {
+        const next = iterator.next();
+        if (next.done === true) {
+          // Restore the outer iterator
+          iterator = iterators.pop();
+          continue;
+        }
+
+        const value = next.value;
+
+        if (typeof value === 'string') {
+          controller.enqueue(encoder.encode(value));
+          if (closed) return;
+        } else {
+          // Must be a Promise
+          iterators.push(iterator);
+          iterator = (await value)[Symbol.iterator]() as RenderResultIterator;
+        }
+      }
+      controller.close();
+    },
+  });
+};


### PR DESCRIPTION
Some runtimes (_like [Vercel Edge](https://vercel.com/docs/concepts/functions/edge-functions)_) [do not support](https://vercel.com/docs/concepts/functions/edge-functions/edge-runtime#unsupported-apis) Node.js APIs like `stream`

This can be solved using the web-compatible [Streams API](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API), which can reproduce the current rendering implementation for Node.js

[Available in Node.js globally](https://nodejs.org/docs/latest-v18.x/api/globals.html#class-readablestream) since version `18.0.0`

<details><summary>How to test this PR</summary>
<p>

Just add `overrides` field in your `package.json`:

```json
{
  "overrides": {
    "@lit-labs/ssr": "npm:@ponomarevlad/lit-labs-ssr@3.1.5-ssr-readable-stream-npm-1",
    "@lit-labs/task": "npm:@ponomarevlad/lit-labs-task@3.0.0-ssr-readable-stream-npm-1",
    "@lit-labs/router": "npm:@ponomarevlad/lit-labs-router@0.1.1-ssr-readable-stream-npm-1",
    "@lit-labs/context": "npm:@ponomarevlad/lit-labs-context@0.3.3-ssr-readable-stream-npm-1",
    "@lit-labs/ssr-client": "npm:@ponomarevlad/lit-labs-ssr-client@1.1.3-ssr-readable-stream-npm-1",
    "@lit-labs/ssr-dom-shim": "npm:@ponomarevlad/lit-labs-ssr-dom-shim@1.1.1-ssr-readable-stream-npm-1",
    "@lit/reactive-element": "npm:@ponomarevlad/reactive-element@1.6.3-ssr-readable-stream-npm-1",
    "lit-element": "npm:@ponomarevlad/lit-element@3.3.3-ssr-readable-stream-npm-1",
    "lit-html": "npm:@ponomarevlad/lit-html@2.8.0-ssr-readable-stream-npm-1",
    "lit": "npm:@ponomarevlad/lit@2.8.0-ssr-readable-stream-npm-1"
  }
}
``` 

And run `npm install` ✨

</p>
</details> 