### PR TITLE
[labs/react] Prefer provided event handler types over React's built-in type

### DIFF
--- a/.changeset/kind-deers-act.md
+++ b/.changeset/kind-deers-act.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/react': patch
+---
+
+Fix type regression to prefer provided event handler prop type over React's built-in handler type.

--- a/packages/labs/react/src/create-component.ts
+++ b/packages/labs/react/src/create-component.ts
@@ -48,8 +48,13 @@ export type ReactWebComponent<
 // lifecycle methods or allow user to explicitly provide props.
 type ElementProps<I> = Partial<Omit<I, keyof HTMLElement>>;
 
-// Acceptable props to the React component.
-type ComponentProps<I, E extends EventNames = {}> = React.HTMLAttributes<I> &
+// Acceptable props to the React component. Omit keyof E from HTMLAttributes to
+// prefer provided event handler mapping over React's built-in event handler
+// props.
+type ComponentProps<I, E extends EventNames = {}> = Omit<
+  React.HTMLAttributes<I>,
+  keyof E
+> &
   ElementProps<I> &
   EventListeners<E>;
 

--- a/packages/labs/react/src/test/create-component_test.tsx
+++ b/packages/labs/react/src/test/create-component_test.tsx
@@ -226,6 +226,25 @@ suite('createComponent', () => {
     <x-foo ref={React.createRef()}></x-foo>;
   });
 
+  // Type only test to be caught at build time.
+  test.skip('Prefer passed in events over built-in React event types', async () => {
+    const TestComponent = createComponent({
+      react: React,
+      tagName: 'event-component',
+      elementClass: class EventComponent extends ReactiveElement {},
+      events: {
+        onInput: 'input' as EventName<CustomEvent<string>>,
+      },
+    });
+
+    // onInput handler below should not error
+    <TestComponent
+      onInput={(e: CustomEvent<string>) => {
+        console.log(e);
+      }}
+    />;
+  });
+
   test('works with text children', async () => {
     const name = 'World';
     act(() => {


### PR DESCRIPTION
Fixes #4093 

This was a regression introduced the 2.0.0 update to refactor `createComponent` and simplify types.

Added back the removed `Omit` from `React.HTMLAttributes`
https://github.com/lit/lit/pull/4027/files#diff-70e2e47659157c4129a63acfad45aa00d53e5314c322b4acc9e677cb1cbaf97aL27
and added a build-time type test for this.