### PR TITLE
[labs/virtualizer] Enable host to resize when total item size changes

### DIFF
--- a/.changeset/popular-masks-burn.md
+++ b/.changeset/popular-masks-burn.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/virtualizer': patch
+---
+
+Fix bug that prevented host from resizing when total item size changes.

--- a/packages/labs/virtualizer/src/Virtualizer.ts
+++ b/packages/labs/virtualizer/src/Virtualizer.ts
@@ -534,9 +534,8 @@ export class Virtualizer {
     if (_rangeChanged || _itemsChanged) {
       this._notifyRange();
       this._rangeChanged = false;
-    } else {
-      this._finishDOMUpdate();
     }
+    this._finishDOMUpdate();
   }
 
   _finishDOMUpdate() {

--- a/packages/labs/virtualizer/src/Virtualizer.ts
+++ b/packages/labs/virtualizer/src/Virtualizer.ts
@@ -217,6 +217,11 @@ export class Virtualizer {
 
   /**
    * State for `layoutComplete` promise
+   *
+   * TODO (graynorton): Consider deprecating and eventually removing
+   * `layoutComplete`, which exists more or less purely for testing
+   * purposes and isn't obviously more useful than just waiting two
+   * animation frames.
    */
   private _layoutCompletePromise: Promise<void> | null = null;
   private _layoutCompleteResolver: Function | null = null;

--- a/packages/labs/virtualizer/src/Virtualizer.ts
+++ b/packages/labs/virtualizer/src/Virtualizer.ts
@@ -217,11 +217,6 @@ export class Virtualizer {
 
   /**
    * State for `layoutComplete` promise
-   *
-   * TODO (graynorton): Consider deprecating and eventually removing
-   * `layoutComplete`, which exists more or less purely for testing
-   * purposes and isn't obviously more useful than just waiting two
-   * animation frames.
    */
   private _layoutCompletePromise: Promise<void> | null = null;
   private _layoutCompleteResolver: Function | null = null;

--- a/packages/labs/virtualizer/src/test/helpers.ts
+++ b/packages/labs/virtualizer/src/test/helpers.ts
@@ -218,19 +218,3 @@ export function ignoreWindowErrors(
     teardown = undefined;
   });
 }
-
-/**
- * An async function that waits for two animation frames. In most
- * if not all cases, Virtualizer's update and render cycle will
- * complete in this window, making this function a relatively
- * simple way to write tests.
- *
- * Virtualizer currently has some non-trivial plumbing to support
- * a `layoutComplete` promise for similar purposes, but it's unclear
- * how useful that is compared to simply waiting two frames, so we
- * may be able to deprecate it (see note in `Virtualizer.ts`).
- */
-export async function twoFrames() {
-  await new Promise((resolve) => requestAnimationFrame(resolve));
-  await new Promise((resolve) => requestAnimationFrame(resolve));
-}

--- a/packages/labs/virtualizer/src/test/helpers.ts
+++ b/packages/labs/virtualizer/src/test/helpers.ts
@@ -218,3 +218,19 @@ export function ignoreWindowErrors(
     teardown = undefined;
   });
 }
+
+/**
+ * An async function that waits for two animation frames. In most
+ * if not all cases, Virtualizer's update and render cycle will
+ * complete in this window, making this function a relatively
+ * simple way to write tests.
+ *
+ * Virtualizer currently has some non-trivial plumbing to support
+ * a `layoutComplete` promise for similar purposes, but it's unclear
+ * how useful that is compared to simply waiting two frames, so we
+ * may be able to deprecate it (see note in `Virtualizer.ts`).
+ */
+export async function twoFrames() {
+  await new Promise((resolve) => requestAnimationFrame(resolve));
+  await new Promise((resolve) => requestAnimationFrame(resolve));
+}

--- a/packages/labs/virtualizer/src/test/scenarios/item-changes.test.ts
+++ b/packages/labs/virtualizer/src/test/scenarios/item-changes.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {array, ignoreBenignErrors, twoFrames} from '../helpers.js';
+import {array, ignoreBenignErrors, twoFrames, pass} from '../helpers.js';
 import {LitVirtualizer} from '../../lit-virtualizer.js';
 import {nothing} from 'lit';
 import {expect, html, fixture} from '@open-wc/testing';
@@ -62,11 +62,11 @@ describe('Virtualizer re-renders properly after changes to the `items` array', (
     // Make sure we have a Virtualizer and
     // that its initial render is correct
     expect(v).to.be.instanceOf(LitVirtualizer);
-    await twoFrames();
-    expect(v.textContent).to.contain('Item 0');
+    await pass(() => expect(v.textContent).to.contain('Item 0'));
 
     // Scroll all the way to the bottom and
     // confirm the last item is in the DOM
+    await twoFrames();
     v.scrollBy(0, 100000);
     await twoFrames();
     expect(v.textContent).to.contain('Item 99');

--- a/packages/labs/virtualizer/src/test/scenarios/item-changes.test.ts
+++ b/packages/labs/virtualizer/src/test/scenarios/item-changes.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {array, ignoreBenignErrors, pass} from '../helpers.js';
+import {array, ignoreBenignErrors} from '../helpers.js';
 import {LitVirtualizer} from '../../lit-virtualizer.js';
 import {nothing} from 'lit';
 import {expect, html, fixture} from '@open-wc/testing';
@@ -62,8 +62,8 @@ describe('Virtualizer re-renders properly after changes to the `items` array', (
     // Make sure we have a Virtualizer and
     // that its initial render is correct
     expect(v).to.be.instanceOf(LitVirtualizer);
-    await pass(() => expect(v.textContent).to.contain('Item 0'));
     await v.layoutComplete;
+    expect(v.textContent).to.contain('Item 0');
 
     // Scroll all the way to the bottom and
     // confirm the last item is in the DOM

--- a/packages/labs/virtualizer/src/test/scenarios/item-changes.test.ts
+++ b/packages/labs/virtualizer/src/test/scenarios/item-changes.test.ts
@@ -1,0 +1,88 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {array, ignoreBenignErrors, twoFrames} from '../helpers.js';
+import {LitVirtualizer} from '../../lit-virtualizer.js';
+import {nothing} from 'lit';
+import {expect, html, fixture} from '@open-wc/testing';
+
+describe('Virtualizer re-renders properly after changes to the `items` array', () => {
+  ignoreBenignErrors(beforeEach, afterEach);
+
+  it('should not produce an out-of-bounds error when the number of items is reduced', async () => {
+    interface NamedItem {
+      name: string;
+    }
+
+    const _100Items = array(100).map((_, i) => ({name: `Item ${i}`}));
+    const _50Things = array(50).map((_, i) => ({name: `Thing ${i}`}));
+
+    /**
+     * This is a repro case for
+     * https://github.com/PolymerLabs/uni-virtualizer/issues/111, included
+     * here to guard against regressions.
+     *
+     * The danger in this area of the code is that the `virtualize`
+     * directive sometimes renders its children as part of the standard
+     * directive update lifecycle (as opposed to Virtualizer's own update
+     * lifecycle), and in this case bad things can happen if the
+     * directive's cached representation of the Virtualizer's current
+     * range (the indices of the first and last items currently rendered
+     * to the DOM) has somehow gotten out of sync with the actual size
+     * of the `items` array.
+     *
+     * The (implied) contract of Virtualizer's `renderItem()` function
+     * is that the `item` argument will never be undefined, so a check
+     * like the one below should be unnecessary in application code; we
+     * do it here purely for test purposes. We track our own state and
+     * guard against an actual runtime error because `renderItem()` runs
+     * in an event handler and an error thrown in that context would not
+     * cause our test to fail.
+     */
+    let outOfBounds = false;
+    function renderItem(item: NamedItem) {
+      if (item === undefined) {
+        outOfBounds = true;
+        return nothing;
+      }
+      return html`<p>${item.name}</p>`;
+    }
+
+    const v = (await fixture(html`
+      <lit-virtualizer
+        scroller
+        .items=${_100Items}
+        .renderItem=${renderItem}
+      ></lit-virtualizer>
+    `)) as LitVirtualizer;
+
+    // Make sure we have a Virtualizer and
+    // that its initial render is correct
+    expect(v).to.be.instanceOf(LitVirtualizer);
+    await twoFrames();
+    expect(v.textContent).to.contain('Item 0');
+
+    // Scroll all the way to the bottom and
+    // confirm the last item is in the DOM
+    v.scrollBy(0, 100000);
+    await twoFrames();
+    expect(v.textContent).to.contain('Item 99');
+
+    // Replace the `items` array with one
+    // only half as long
+    v.items = _50Things;
+    await twoFrames();
+    // Make sure we've correctly re-rendered
+    // and that the new last item is in the DOM
+    expect(v.textContent).to.contain('Thing 49');
+    // If outOfBounds is true, then the directive's
+    // state has gotten out of sync (i.e., it has
+    // tried to render an item whose index is
+    // outside the bounds of the newly set `items`
+    // array).
+    expect(outOfBounds).to.be.false;
+  });
+});

--- a/packages/labs/virtualizer/src/test/scenarios/item-changes.test.ts
+++ b/packages/labs/virtualizer/src/test/scenarios/item-changes.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {array, ignoreBenignErrors, twoFrames, pass} from '../helpers.js';
+import {array, ignoreBenignErrors, pass} from '../helpers.js';
 import {LitVirtualizer} from '../../lit-virtualizer.js';
 import {nothing} from 'lit';
 import {expect, html, fixture} from '@open-wc/testing';
@@ -63,18 +63,18 @@ describe('Virtualizer re-renders properly after changes to the `items` array', (
     // that its initial render is correct
     expect(v).to.be.instanceOf(LitVirtualizer);
     await pass(() => expect(v.textContent).to.contain('Item 0'));
+    await v.layoutComplete;
 
     // Scroll all the way to the bottom and
     // confirm the last item is in the DOM
-    await twoFrames();
     v.scrollBy(0, 100000);
-    await twoFrames();
+    await v.layoutComplete;
     expect(v.textContent).to.contain('Item 99');
 
     // Replace the `items` array with one
     // only half as long
     v.items = _50Things;
-    await twoFrames();
+    await v.layoutComplete;
     // Make sure we've correctly re-rendered
     // and that the new last item is in the DOM
     expect(v.textContent).to.contain('Thing 49');

--- a/packages/labs/virtualizer/src/test/scenarios/sizing-and-styling.test.ts
+++ b/packages/labs/virtualizer/src/test/scenarios/sizing-and-styling.test.ts
@@ -115,4 +115,47 @@ describe('Properly sizing virtualizer within host element', () => {
      */
     expect(rects[4].left - leftOffset).to.equal(50);
   });
+
+  it('should resize host when total item size changes', async () => {
+    const items = array(5);
+    const root = await fixture(html`
+      <div class="root">
+        <style>
+          .container {
+            display: block;
+            position: absolute;
+            width: 200px;
+            box-sizing: border-box;
+          }
+        </style>
+        <div class="container">
+          <custom-element-containing-lit-virtualizer .items=${items}>
+          </custom-element-containing-lit-virtualizer>
+        </div>
+      </div>
+    `);
+
+    await pass(() =>
+      expect(
+        root.querySelector('custom-element-containing-lit-virtualizer')
+      ).to.be.instanceOf(CustomElementContainingLitVirtualizer)
+    );
+    const ceclv = root.querySelector<CustomElementContainingLitVirtualizer>(
+      'custom-element-containing-lit-virtualizer'
+    )!;
+    await pass(() =>
+      expect(
+        ceclv.shadowRoot?.querySelector('lit-virtualizer')
+      ).to.be.instanceOf(LitVirtualizer)
+    );
+    const litVirtualizer =
+      ceclv.shadowRoot!.querySelector<LitVirtualizer>('lit-virtualizer')!;
+    await pass(() => expect(litVirtualizer.textContent).to.contain('[4]'));
+    expect(window.getComputedStyle(litVirtualizer).height).to.equal('50px');
+    ceclv.items = ceclv.items.slice(0, ceclv.items.length - 1);
+    await pass(() => {
+      expect(litVirtualizer.textContent).not.to.contain('[4]');
+      expect(window.getComputedStyle(litVirtualizer).height).to.equal('25px');
+    });
+  });
 });

--- a/packages/labs/virtualizer/src/test/scenarios/sizing-and-styling.test.ts
+++ b/packages/labs/virtualizer/src/test/scenarios/sizing-and-styling.test.ts
@@ -116,6 +116,7 @@ describe('Properly sizing virtualizer within host element', () => {
     expect(rects[4].left - leftOffset).to.equal(50);
   });
 
+  // Regression test for https://github.com/lit/lit/issues/4080
   it('should resize host when total item size changes', async () => {
     const items = array(5);
     const root = await fixture(html`
@@ -150,9 +151,19 @@ describe('Properly sizing virtualizer within host element', () => {
     );
     const litVirtualizer =
       ceclv.shadowRoot!.querySelector<LitVirtualizer>('lit-virtualizer')!;
-    await pass(() => expect(litVirtualizer.textContent).to.contain('[4]'));
-    expect(window.getComputedStyle(litVirtualizer).height).to.equal('50px');
+
+    // Should be:
+    // [0] [1] [2] [3]
+    // [4]
+    await pass(() => {
+      expect(litVirtualizer.textContent).to.contain('[4]');
+      expect(window.getComputedStyle(litVirtualizer).height).to.equal('50px');
+    });
+
     ceclv.items = ceclv.items.slice(0, ceclv.items.length - 1);
+
+    // Now should be:
+    // [0] [1] [2] [3]
     await pass(() => {
       expect(litVirtualizer.textContent).not.to.contain('[4]');
       expect(window.getComputedStyle(litVirtualizer).height).to.equal('25px');

--- a/packages/labs/virtualizer/src/virtualize.ts
+++ b/packages/labs/virtualizer/src/virtualize.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {TemplateResult, ChildPart, html} from 'lit';
+import {TemplateResult, ChildPart, html, noChange} from 'lit';
 import {directive, DirectiveResult, PartInfo, PartType} from 'lit/directive.js';
 import {AsyncDirective} from 'lit/async-directive.js';
 import {repeat, KeyFn} from 'lit/directives/repeat.js';
@@ -88,13 +88,14 @@ class VirtualizeDirective<T = unknown> extends AsyncDirective {
 
   update(part: ChildPart, [config]: [VirtualizeDirectiveConfig<T>]) {
     this._setFunctions(config);
+    const itemsChanged = this._items !== config.items;
     this._items = config.items || [];
     if (this._virtualizer) {
       this._updateVirtualizerConfig(part, config);
     } else {
       this._initialize(part, config);
     }
-    return this.render();
+    return itemsChanged ? noChange : this.render();
   }
 
   private async _updateVirtualizerConfig(

--- a/packages/labs/virtualizer/src/virtualize.ts
+++ b/packages/labs/virtualizer/src/virtualize.ts
@@ -72,14 +72,9 @@ class VirtualizeDirective<T = unknown> extends AsyncDirective {
       this._setFunctions(config);
     }
     const itemsToRender: Array<T> = [];
-    // TODO (graynorton): Is this the best / only place to ensure
-    // that _last isn't outside the current bounds of the items array?
-    // Not sure we should ever arrive here with it out of bounds.
-    // Repro case for original issue: https://tinyurl.com/yes8b2e6
-    const lastItem = Math.min(this._items.length, this._last + 1);
 
     if (this._first >= 0 && this._last >= this._first) {
-      for (let i = this._first; i < lastItem; i++) {
+      for (let i = this._first; i <= this._last; i++) {
         itemsToRender.push(this._items[i]);
       }
     }


### PR DESCRIPTION
Fixes #4080 

Credit to @graynorton for the solution.

The changes to `virtualizer` directive's `update()` method added in https://github.com/lit/lit/pull/3133 to always `return this.render()` created a race/conflict such that the MutationObserver responsible for updating the host element would fire before the correct sizes were calculated by the virtualizer. This change now conditionally returns `noChange` to preserve the fix but also defer to virtualizer handling more updates where possible.

There was still a possibility of race happening between virtualizer state change and the mutation observer, so updated the `_updateDOM()` method on virtualizer to always call `_finishDOMUpdate()`;

Added a test for checking regression.