### PR TITLE
[lit-labs/compiler] pre-release compiler on 3.0 branch

### DIFF
--- a/.changeset/nervous-frogs-approve.md
+++ b/.changeset/nervous-frogs-approve.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/compiler': patch
+---
+
+Initial release of `@lit-labs/compiler`, vending a Lit template TypeScript transformer.

--- a/packages/labs/compiler/package.json
+++ b/packages/labs/compiler/package.json
@@ -2,7 +2,6 @@
   "name": "@lit-labs/compiler",
   "description": "Compiler to prepare Lit templates at build time",
   "version": "0.0.0",
-  "private": true,
   "author": "Google LLC",
   "homepage": "https://github.com/Lit/Lit/tree/main/packages/labs/compiler",
   "license": "BSD-3-Clause",
@@ -116,5 +115,8 @@
   },
   "engines": {
     "node": ">=14.17"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
Umbrella Issue: https://github.com/lit/lit/issues/189
RFC: https://github.com/lit/rfcs/pull/21
Publish compiler issue: https://github.com/lit/lit/issues/4101

### Context

This change is scoped to the 3.0 branch, and makes it so that the compiler can be published/released as a pre-release!

This will make it possible to `npm install @lit-labs/compiler` and use it!

### Test plan

None!