### PR TITLE
fix(analyzer): jsdoc type order, lowercase tags, css syntax

### DIFF
--- a/.changeset/calm-avocados-end.md
+++ b/.changeset/calm-avocados-end.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/analyzer': patch
+---
+
+Supports `@fires {EventType} name`, with type preceding name

--- a/.changeset/lazy-radios-rhyme.md
+++ b/.changeset/lazy-radios-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/analyzer': patch
+---
+
+Supports lowercase `@cssprop`, `@cssproperty`, and `@csspart`

--- a/.changeset/selfish-lions-juggle.md
+++ b/.changeset/selfish-lions-juggle.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/analyzer': patch
+---
+
+Supports `@cssProperty {<color>} --my-color` with syntax metadata

--- a/packages/labs/analyzer/src/lib/custom-elements/custom-elements.ts
+++ b/packages/labs/analyzer/src/lib/custom-elements/custom-elements.ts
@@ -141,12 +141,13 @@ export const getJSDocData = (
           addNamedJSDocInfoToMap(slots, tag, analyzer);
           break;
         case 'cssProp':
-          addNamedJSDocInfoToMap(cssProperties, tag, analyzer);
-          break;
+        case 'cssprop':
         case 'cssProperty':
+        case 'cssproperty':
           addNamedJSDocInfoToMap(cssProperties, tag, analyzer);
           break;
         case 'cssPart':
+        case 'csspart':
           addNamedJSDocInfoToMap(cssParts, tag, analyzer);
           break;
       }

--- a/packages/labs/analyzer/src/lib/custom-elements/custom-elements.ts
+++ b/packages/labs/analyzer/src/lib/custom-elements/custom-elements.ts
@@ -20,7 +20,10 @@ import {
   NamedDescribed,
 } from '../model.js';
 import {addEventsToMap} from './events.js';
-import {parseNodeJSDocInfo, parseNamedJSDocInfo} from '../javascript/jsdoc.js';
+import {
+  parseNodeJSDocInfo,
+  parseNamedTypedJSDocInfo,
+} from '../javascript/jsdoc.js';
 
 const _isCustomElementClassDeclaration = (
   t: ts.BaseType,
@@ -112,7 +115,7 @@ const addNamedJSDocInfoToMap = (
   tag: ts.JSDocTag,
   analyzer: AnalyzerInterface
 ) => {
-  const info = parseNamedJSDocInfo(tag, analyzer);
+  const info = parseNamedTypedJSDocInfo(tag, analyzer);
   if (info !== undefined) {
     map.set(info.name, info);
   }

--- a/packages/labs/analyzer/src/lib/javascript/jsdoc.ts
+++ b/packages/labs/analyzer/src/lib/javascript/jsdoc.ts
@@ -47,7 +47,7 @@ const parseNameTypeDescRE =
 
 // Regex for parsing type, name, and description from JSDoc comments
 const parseTypeNameDescRE =
-  /^\{(?<type>[^}]+)\}\s+\[?(?<name>[^{}[\]\s=]+)(?:=(?<defaultValue>[^\]]+))?\]?(?:\s+-\s+)?(?<description>[\s\S]*)$/m;
+  /^\{(?<type>.+)\}\s+\[?(?<name>[^{}[\]\s=]+)(?:=(?<defaultValue>[^\]]+))?\]?(?:\s+-\s+)?(?<description>[\s\S]*)$/m;
 
 const getJSDocTagComment = (tag: ts.JSDocTag, analyzer: AnalyzerInterface) => {
   let {comment} = tag;

--- a/packages/labs/analyzer/src/lib/javascript/jsdoc.ts
+++ b/packages/labs/analyzer/src/lib/javascript/jsdoc.ts
@@ -111,9 +111,8 @@ export const parseNamedTypedJSDocInfo = (
   if (comment == undefined) {
     return undefined;
   }
-  const regex = comment.startsWith('{')
-    ? parseTypeNameDescRE
-    : parseNameTypeDescRE;
+  const regex =
+    comment.charAt(0) === '{' ? parseTypeNameDescRE : parseNameTypeDescRE;
   const nameTypeDesc = comment.match(regex);
   if (nameTypeDesc === null) {
     analyzer.addDiagnostic(

--- a/packages/labs/analyzer/src/lib/javascript/jsdoc.ts
+++ b/packages/labs/analyzer/src/lib/javascript/jsdoc.ts
@@ -17,8 +17,7 @@ import {
   TypedNamedDescribed,
   DeprecatableDescribed,
   AnalyzerInterface,
-  NamedDescribed,
-  NamedDescribedSyntax,
+  CSSPropertyInfo,
 } from '../model.js';
 
 export type TypeScript = typeof ts;
@@ -44,21 +43,11 @@ const normalizeLineEndings = (s: string) => s.replace(/\r/g, '').trim();
 
 // Regex for parsing name, type, and description from JSDoc comments
 const parseNameTypeDescRE =
-  /^(?<name>\S+)(?:\s+{(?<type>.*)})?(?:\s+-\s+)?(?<description>[\s\S]*)$/m;
+  /^\[?(?<name>[^{}[\]\s=]+)(?:=(?<defaultValue>[^\]]+))?\]?(?:\s+{(?<type>.*)})?(?:\s+-\s+)?(?<description>[\s\S]*)$/m;
 
 // Regex for parsing type, name, and description from JSDoc comments
 const parseTypeNameDescRE =
-  /^\{(?<type>.*)}\s+(?<name>\S+)(?:\s+-\s+)?(?<description>[\s\S]*)$/m;
-
-// Regex for parsing optional name and description from JSDoc comments, where
-// the dash is required before the description (syntax for `@slot` tag, whose
-// default slot has no name)
-const parseNameDashDescRE =
-  /^(?:\{\s*(?<type>[^}]+)\s*})?\s*\[?(?<name>[^{}[\]\s=]+)(?:=(?<defaultValue>[^\]]+))?\]?\s+-\s+(?<description>[\s\S]*)$/;
-
-// Regex for parsing optional name, default, and description from JSDoc comments
-const parseNameDescRE =
-  /^(?:\{\s*(?<type>[^}]+)\s*})?\s*\[?(?<name>[^{}[\]\s=]+)(?:=(?<defaultValue>[^\]]+))?\]?(?:\s+-\s+)?(?<description>[\s\S]*)$/;
+  /^\{(?<type>[^}]+)\}\s+\[?(?<name>[^{}[\]\s=]+)(?:=(?<defaultValue>[^\]]+))?\]?(?:\s+-\s+)?(?<description>[\s\S]*)$/m;
 
 const getJSDocTagComment = (tag: ts.JSDocTag, analyzer: AnalyzerInterface) => {
   let {comment} = tag;
@@ -102,6 +91,18 @@ const isModuleJSDocTag = (tag: ts.JSDocTag) =>
  * * @fires {Type} event-name description
  * * @fires {Type} event-name - description
  * * @fires {Type} event-name: description
+ * * @slot name
+ * * @slot name description
+ * * @slot name - description
+ * * @slot name: description
+ * * @cssProp [--name=default]
+ * * @cssProp [--name=default] description
+ * * @cssProp [--name=default] - description
+ * * @cssProp [--name=default]: description
+ * * @cssprop {<color>} [--name=default]
+ * * @cssprop {<color>} [--name=default] description
+ * * @cssprop {<color>} [--name=default] - description
+ * * @cssprop {<color>} [--name=default]: description
  */
 export const parseNamedTypedJSDocInfo = (
   tag: ts.JSDocTag,
@@ -124,82 +125,18 @@ export const parseNamedTypedJSDocInfo = (
     );
     return undefined;
   }
-  const {name, type, description} = nameTypeDesc.groups!;
-  const info: TypedNamedDescribed = {name, type};
+  const {name, type, defaultValue, description} = nameTypeDesc.groups!;
+  const info: TypedNamedDescribed = {name};
   if (description.length > 0) {
-    info.description = normalizeLineEndings(description);
-  }
-  return info;
-};
-
-function makeDashParseDiagnostic(
-  typescript: TypeScript,
-  tag: ts.JSDocTag,
-  requireDash: boolean
-) {
-  return createDiagnostic({
-    typescript,
-    node: tag,
-    message: `Unexpected JSDoc format.${
-      requireDash
-        ? ' Tag must contain a whitespace-separated dash between the name and description, ' +
-          "i.e. '@slot header - This is the description'"
-        : ''
-    }`,
-  });
-}
-
-/**
- * Parses name and description from JSDoc tag for things like `@slot`,
- * `@cssPart`, and `@cssProp`.
- *
- * Supports the following patterns following the tag (TS parses the tag for us):
- * * @slot name
- * * @slot name description
- * * @slot name - description
- * * @slot name: description
- * * @cssProp [--name=default]
- * * @cssProp [--name=default] description
- * * @cssProp [--name=default] - description
- * * @cssProp [--name=default]: description
- * * @cssprop {<color>} [--name=default]
- * * @cssprop {<color>} [--name=default] description
- * * @cssprop {<color>} [--name=default] - description
- * * @cssprop {<color>} [--name=default]: description
- */
-export const parseNamedJSDocInfo = (
-  tag: ts.JSDocTag,
-  analyzer: AnalyzerInterface,
-  requireDash = false
-): NamedDescribed | NamedDescribedSyntax | undefined => {
-  const comment = getJSDocTagComment(tag, analyzer);
-  if (comment == undefined) {
-    return undefined;
-  }
-
-  const regex = requireDash ? parseNameDashDescRE : parseNameDescRE;
-  const nameDesc = comment.match(regex);
-  if (nameDesc === null) {
-    analyzer.addDiagnostic(
-      makeDashParseDiagnostic(analyzer.typescript, tag, requireDash)
-    );
-
-    return undefined;
-  }
-  const {name, description, defaultValue, type} = nameDesc.groups!;
-
-  const info: NamedDescribed | NamedDescribedSyntax = {name};
-  if (description?.length > 0) {
     info.description = normalizeLineEndings(description);
   }
   if (defaultValue?.length > 0) {
     info.default = defaultValue;
   }
-  if (
-    tag.tagName.text.toLowerCase().startsWith('cssprop') &&
-    type?.length > 0
-  ) {
-    (info as NamedDescribedSyntax).syntax = type;
+  if (tag.tagName.text.toLowerCase().startsWith('cssprop')) {
+    (info as CSSPropertyInfo).syntax = type;
+  } else {
+    info.type = type;
   }
   return info;
 };

--- a/packages/labs/analyzer/src/lib/model.ts
+++ b/packages/labs/analyzer/src/lib/model.ts
@@ -539,6 +539,10 @@ export interface NamedDescribed extends Described {
   default?: string;
 }
 
+export interface NamedDescribedSyntax extends NamedDescribed {
+  syntax?: string;
+}
+
 export interface TypedNamedDescribed extends NamedDescribed {
   type?: string;
 }
@@ -551,7 +555,7 @@ interface CustomElementDeclarationInit extends ClassDeclarationInit {
   tagname: string | undefined;
   events: Map<string, Event>;
   slots: Map<string, NamedDescribed>;
-  cssProperties: Map<string, NamedDescribed>;
+  cssProperties: Map<string, NamedDescribedSyntax>;
   cssParts: Map<string, NamedDescribed>;
 }
 
@@ -572,7 +576,7 @@ export class CustomElementDeclaration extends ClassDeclaration {
   readonly tagname: string | undefined;
   readonly events: Map<string, Event>;
   readonly slots: Map<string, NamedDescribed>;
-  readonly cssProperties: Map<string, NamedDescribed>;
+  readonly cssProperties: Map<string, NamedDescribedSyntax>;
   readonly cssParts: Map<string, NamedDescribed>;
 
   constructor(init: CustomElementDeclarationInit) {

--- a/packages/labs/analyzer/src/lib/model.ts
+++ b/packages/labs/analyzer/src/lib/model.ts
@@ -539,7 +539,7 @@ export interface NamedDescribed extends Described {
   default?: string;
 }
 
-export interface NamedDescribedSyntax extends NamedDescribed {
+export interface CSSPropertyInfo extends NamedDescribed {
   syntax?: string;
 }
 
@@ -555,7 +555,7 @@ interface CustomElementDeclarationInit extends ClassDeclarationInit {
   tagname: string | undefined;
   events: Map<string, Event>;
   slots: Map<string, NamedDescribed>;
-  cssProperties: Map<string, NamedDescribedSyntax>;
+  cssProperties: Map<string, CSSPropertyInfo>;
   cssParts: Map<string, NamedDescribed>;
 }
 
@@ -576,7 +576,7 @@ export class CustomElementDeclaration extends ClassDeclaration {
   readonly tagname: string | undefined;
   readonly events: Map<string, Event>;
   readonly slots: Map<string, NamedDescribed>;
-  readonly cssProperties: Map<string, NamedDescribedSyntax>;
+  readonly cssProperties: Map<string, CSSPropertyInfo>;
   readonly cssParts: Map<string, NamedDescribed>;
 
   constructor(init: CustomElementDeclarationInit) {

--- a/packages/labs/analyzer/src/test/lit-element/events_test.ts
+++ b/packages/labs/analyzer/src/test/lit-element/events_test.ts
@@ -29,7 +29,7 @@ for (const lang of languages) {
   });
 
   test('Correct number of events found', ({element}) => {
-    assert.equal(element.events.size, 10);
+    assert.equal(element.events.size, 15);
   });
 
   test('Just event name', ({element}) => {
@@ -63,6 +63,16 @@ for (const lang of languages) {
     assert.equal(event.type?.references[0].isGlobal, true);
   });
 
+  test('Event with well-formed type', ({element}) => {
+    const event = element.events.get('ordered-typed-event');
+    assert.ok(event);
+    assert.equal(event.name, 'ordered-typed-event');
+    assert.equal(event.type?.text, 'MouseEvent');
+    assert.equal(event.description, undefined);
+    assert.equal(event.type?.references[0].name, 'MouseEvent');
+    assert.equal(event.type?.references[0].isGlobal, true);
+  });
+
   test('Event with type and description', ({element}) => {
     const event = element.events.get('typed-event-two');
     assert.ok(event);
@@ -71,10 +81,28 @@ for (const lang of languages) {
     assert.equal(event.description, 'This is a typed event');
   });
 
+  test('Event with well-formed type and description', ({element}) => {
+    const event = element.events.get('ordered-typed-event-two');
+    assert.ok(event);
+    assert.equal(event.name, 'ordered-typed-event-two');
+    assert.equal(event.type?.text, 'MouseEvent');
+    assert.equal(event.description, 'This is a typed event');
+  });
+
   test('Event with type and dash-separated description', ({element}) => {
     const event = element.events.get('typed-event-three');
     assert.ok(event);
     assert.equal(event.name, 'typed-event-three');
+    assert.equal(event.type?.text, 'MouseEvent');
+    assert.equal(event.description, 'This is another typed event');
+  });
+
+  test('Event with well-formed type and dash-separated description', ({
+    element,
+  }) => {
+    const event = element.events.get('ordered-typed-event-three');
+    assert.ok(event);
+    assert.equal(event.name, 'ordered-typed-event-three');
     assert.equal(event.type?.text, 'MouseEvent');
     assert.equal(event.description, 'This is another typed event');
   });
@@ -92,8 +120,34 @@ for (const lang of languages) {
     assert.equal(event.description, 'Local custom event');
   });
 
+  test('Event with local custom event well-formed type', ({element}) => {
+    const event = element.events.get('ordered-local-custom-event');
+    assert.ok(event);
+    assert.equal(event.type?.text, 'LocalCustomEvent');
+    assert.equal(
+      event.type?.references[0].package,
+      '@lit-internal/test-events'
+    );
+    assert.equal(event.type?.references[0].module, 'element-a.js');
+    assert.equal(event.type?.references[0].name, 'LocalCustomEvent');
+    assert.equal(event.description, 'Local custom event');
+  });
+
   test('Event with imported custom event type', ({element}) => {
     const event = element.events.get('external-custom-event');
+    assert.ok(event);
+    assert.equal(event.type?.text, 'ExternalCustomEvent');
+    assert.equal(
+      event.type?.references[0].package,
+      '@lit-internal/test-events'
+    );
+    assert.equal(event.type?.references[0].module, 'custom-event.js');
+    assert.equal(event.type?.references[0].name, 'ExternalCustomEvent');
+    assert.equal(event.description, 'External custom event');
+  });
+
+  test('Event with imported custom event well-formed type', ({element}) => {
+    const event = element.events.get('ordered-external-custom-event');
     assert.ok(event);
     assert.equal(event.type?.text, 'ExternalCustomEvent');
     assert.equal(
@@ -120,8 +174,45 @@ for (const lang of languages) {
     assert.equal(event.description, 'Generic custom event');
   });
 
+  test('Event with generic custom event well-formed type', ({element}) => {
+    const event = element.events.get('ordered-generic-custom-event');
+    assert.ok(event);
+    assert.equal(event.type?.text, 'CustomEvent<ExternalClass>');
+    assert.equal(event.type?.references[0].name, 'CustomEvent');
+    assert.equal(event.type?.references[0].isGlobal, true);
+    assert.equal(
+      event.type?.references[1].package,
+      '@lit-internal/test-events'
+    );
+    assert.equal(event.type?.references[1].module, 'custom-event.js');
+    assert.equal(event.type?.references[1].name, 'ExternalClass');
+    assert.equal(event.description, 'Generic custom event');
+  });
+
   test('Event with custom event type with inline detail', ({element}) => {
     const event = element.events.get('inline-detail-custom-event');
+    assert.ok(event);
+    assert.equal(
+      event.type?.text,
+      'CustomEvent<{ event: MouseEvent; more: { impl: ExternalClass; }; }>'
+    );
+    assert.equal(event.type?.references[0].name, 'CustomEvent');
+    assert.equal(event.type?.references[0].isGlobal, true);
+    assert.equal(event.type?.references[1].name, 'MouseEvent');
+    assert.equal(event.type?.references[1].isGlobal, true);
+    assert.equal(
+      event.type?.references[2].package,
+      '@lit-internal/test-events'
+    );
+    assert.equal(event.type?.references[2].module, 'custom-event.js');
+    assert.equal(event.type?.references[2].name, 'ExternalClass');
+    assert.equal(event.description, 'Inline\ndetail custom event description');
+  });
+
+  test('Event with custom event well-formed type with inline detail', ({
+    element,
+  }) => {
+    const event = element.events.get('ordered-inline-detail-custom-event');
     assert.ok(event);
     assert.equal(
       event.type?.text,

--- a/packages/labs/analyzer/src/test/lit-element/events_test.ts
+++ b/packages/labs/analyzer/src/test/lit-element/events_test.ts
@@ -29,7 +29,7 @@ for (const lang of languages) {
   });
 
   test('Correct number of events found', ({element}) => {
-    assert.equal(element.events.size, 15);
+    assert.equal(element.events.size, 17);
   });
 
   test('Just event name', ({element}) => {

--- a/packages/labs/analyzer/src/test/lit-element/jsdoc_test.ts
+++ b/packages/labs/analyzer/src/test/lit-element/jsdoc_test.ts
@@ -320,8 +320,7 @@ for (const lang of languages) {
     assert.ok(element.isLitElementDeclaration());
     const prop = element.cssProperties.get('--syntax-no-description');
     assert.ok(prop);
-    assert.equal(prop.syntax, '<syntax>');
-    assert.equal(prop.description, undefined);
+    assert.equal(prop.syntax, '<color>');
   });
 
   test.run();

--- a/packages/labs/analyzer/src/test/lit-element/jsdoc_test.ts
+++ b/packages/labs/analyzer/src/test/lit-element/jsdoc_test.ts
@@ -116,7 +116,7 @@ for (const lang of languages) {
   test('cssProperties - Correct number found', ({getModule}) => {
     const element = getModule('element-a').getDeclaration('ElementA');
     assert.ok(element.isLitElementDeclaration());
-    assert.equal(element.cssProperties.size, 25);
+    assert.equal(element.cssProperties.size, 22);
   });
 
   test('cssProperties - no-description', ({getModule}) => {

--- a/packages/labs/analyzer/src/test/lit-element/jsdoc_test.ts
+++ b/packages/labs/analyzer/src/test/lit-element/jsdoc_test.ts
@@ -63,7 +63,7 @@ for (const lang of languages) {
   test('cssParts - Correct number found', ({getModule}) => {
     const element = getModule('element-a').getDeclaration('ElementA');
     assert.ok(element.isLitElementDeclaration());
-    assert.equal(element.cssParts.size, 3);
+    assert.equal(element.cssParts.size, 6);
   });
 
   test('cssParts - no-description', ({getModule}) => {
@@ -99,18 +99,39 @@ for (const lang of languages) {
     );
   });
 
+  test('cssParts - lowercase', ({getModule}) => {
+    const element = getModule('element-a').getDeclaration('ElementA');
+    assert.ok(element.isLitElementDeclaration());
+    const part = element.cssParts.get('lower-with-description-dash');
+    assert.ok(part);
+    assert.equal(part.summary, undefined);
+    assert.equal(
+      part.description,
+      'Description for :part(with-description-dash)'
+    );
+  });
+
   // cssProperties
 
   test('cssProperties - Correct number found', ({getModule}) => {
     const element = getModule('element-a').getDeclaration('ElementA');
     assert.ok(element.isLitElementDeclaration());
-    assert.equal(element.cssProperties.size, 9);
+    assert.equal(element.cssProperties.size, 24);
   });
 
   test('cssProperties - no-description', ({getModule}) => {
     const element = getModule('element-a').getDeclaration('ElementA');
     assert.ok(element.isLitElementDeclaration());
     const prop = element.cssProperties.get('--no-description');
+    assert.ok(prop);
+    assert.equal(prop.summary, undefined);
+    assert.equal(prop.description, undefined);
+  });
+
+  test('cssProperties - lower-no-description', ({getModule}) => {
+    const element = getModule('element-a').getDeclaration('ElementA');
+    assert.ok(element.isLitElementDeclaration());
+    const prop = element.cssProperties.get('--lower-no-description');
     assert.ok(prop);
     assert.equal(prop.summary, undefined);
     assert.equal(prop.description, undefined);
@@ -128,6 +149,18 @@ for (const lang of languages) {
     );
   });
 
+  test('cssProperties - lower-with-description', ({getModule}) => {
+    const element = getModule('element-a').getDeclaration('ElementA');
+    assert.ok(element.isLitElementDeclaration());
+    const prop = element.cssProperties.get('--lower-with-description');
+    assert.ok(prop);
+    assert.equal(prop.summary, undefined);
+    assert.equal(
+      prop.description,
+      'Description for --lower-with-description\nwith wraparound'
+    );
+  });
+
   test('cssProperties - with-description-dash', ({getModule}) => {
     const element = getModule('element-a').getDeclaration('ElementA');
     assert.ok(element.isLitElementDeclaration());
@@ -137,10 +170,30 @@ for (const lang of languages) {
     assert.equal(prop.description, 'Description for --with-description-dash');
   });
 
+  test('cssProperties - lower-with-description-dash', ({getModule}) => {
+    const element = getModule('element-a').getDeclaration('ElementA');
+    assert.ok(element.isLitElementDeclaration());
+    const prop = element.cssProperties.get('--lower-with-description-dash');
+    assert.ok(prop);
+    assert.equal(prop.summary, undefined);
+    assert.equal(
+      prop.description,
+      'Description for --lower-with-description-dash'
+    );
+  });
+
   test('cssProperties - default-no-description', ({getModule}) => {
     const element = getModule('element-a').getDeclaration('ElementA');
     assert.ok(element.isLitElementDeclaration());
     const prop = element.cssProperties.get('--default-no-description');
+    assert.ok(prop);
+    assert.equal(prop.default, '#324fff');
+  });
+
+  test('cssProperties - lower-default-no-description', ({getModule}) => {
+    const element = getModule('element-a').getDeclaration('ElementA');
+    assert.ok(element.isLitElementDeclaration());
+    const prop = element.cssProperties.get('--lower-default-no-description');
     assert.ok(prop);
     assert.equal(prop.default, '#324fff');
   });
@@ -153,6 +206,14 @@ for (const lang of languages) {
     assert.equal(prop.default, '#324fff');
   });
 
+  test('cssProperties - lower-default-with-description', ({getModule}) => {
+    const element = getModule('element-a').getDeclaration('ElementA');
+    assert.ok(element.isLitElementDeclaration());
+    const prop = element.cssProperties.get('--lower-default-with-description');
+    assert.ok(prop);
+    assert.equal(prop.default, '#324fff');
+  });
+
   test('cssProperties - default-with-description-dash', ({getModule}) => {
     const element = getModule('element-a').getDeclaration('ElementA');
     assert.ok(element.isLitElementDeclaration());
@@ -161,10 +222,29 @@ for (const lang of languages) {
     assert.equal(prop.default, '#324fff');
   });
 
+  test('cssProperties - lower-default-with-description-dash', ({getModule}) => {
+    const element = getModule('element-a').getDeclaration('ElementA');
+    assert.ok(element.isLitElementDeclaration());
+    const prop = element.cssProperties.get(
+      '--lower-default-with-description-dash'
+    );
+    assert.ok(prop);
+    assert.equal(prop.default, '#324fff');
+  });
+
   test('cssProperties - short-no-description', ({getModule}) => {
     const element = getModule('element-a').getDeclaration('ElementA');
     assert.ok(element.isLitElementDeclaration());
     const prop = element.cssProperties.get('--short-no-description');
+    assert.ok(prop);
+    assert.equal(prop.summary, undefined);
+    assert.equal(prop.description, undefined);
+  });
+
+  test('cssProperties - lower-short-no-description', ({getModule}) => {
+    const element = getModule('element-a').getDeclaration('ElementA');
+    assert.ok(element.isLitElementDeclaration());
+    const prop = element.cssProperties.get('--lower-short-no-description');
     assert.ok(prop);
     assert.equal(prop.summary, undefined);
     assert.equal(prop.description, undefined);
@@ -182,6 +262,18 @@ for (const lang of languages) {
     );
   });
 
+  test('cssProperties - lower-short-with-description', ({getModule}) => {
+    const element = getModule('element-a').getDeclaration('ElementA');
+    assert.ok(element.isLitElementDeclaration());
+    const prop = element.cssProperties.get('--lower-short-with-description');
+    assert.ok(prop);
+    assert.equal(prop.summary, undefined);
+    assert.equal(
+      prop.description,
+      'Description for --lower-short-with-description\nwith wraparound'
+    );
+  });
+
   test('cssProperties - short-with-description-dash', ({getModule}) => {
     const element = getModule('element-a').getDeclaration('ElementA');
     assert.ok(element.isLitElementDeclaration());
@@ -191,6 +283,20 @@ for (const lang of languages) {
     assert.equal(
       prop.description,
       'Description for --short-with-description-dash'
+    );
+  });
+
+  test('cssProperties - lower-short-with-description-dash', ({getModule}) => {
+    const element = getModule('element-a').getDeclaration('ElementA');
+    assert.ok(element.isLitElementDeclaration());
+    const prop = element.cssProperties.get(
+      '--lower-short-with-description-dash'
+    );
+    assert.ok(prop);
+    assert.equal(prop.summary, undefined);
+    assert.equal(
+      prop.description,
+      'Description for --lower-short-with-description-dash'
     );
   });
 

--- a/packages/labs/analyzer/src/test/lit-element/jsdoc_test.ts
+++ b/packages/labs/analyzer/src/test/lit-element/jsdoc_test.ts
@@ -116,7 +116,7 @@ for (const lang of languages) {
   test('cssProperties - Correct number found', ({getModule}) => {
     const element = getModule('element-a').getDeclaration('ElementA');
     assert.ok(element.isLitElementDeclaration());
-    assert.equal(element.cssProperties.size, 24);
+    assert.equal(element.cssProperties.size, 25);
   });
 
   test('cssProperties - no-description', ({getModule}) => {
@@ -313,6 +313,15 @@ for (const lang of languages) {
     assert.equal(method.description, `Method 1 description`);
     assert.equal(method.parameters?.length, 0);
     assert.equal(method.return?.type?.text, 'void');
+  });
+
+  test('cssProperties - syntax-no-description', ({getModule}) => {
+    const element = getModule('element-a').getDeclaration('ElementA');
+    assert.ok(element.isLitElementDeclaration());
+    const prop = element.cssProperties.get('--syntax-no-description');
+    assert.ok(prop);
+    assert.equal(prop.syntax, '<syntax>');
+    assert.equal(prop.description, undefined);
   });
 
   test.run();

--- a/packages/labs/analyzer/test-files/js/events/element-a.js
+++ b/packages/labs/analyzer/test-files/js/events/element-a.js
@@ -20,12 +20,20 @@ export class LocalCustomEvent extends Event {
  * @fires event-two This is an event
  * @fires event-three - This is another event
  * @fires typed-event {MouseEvent}
+ * @fires {MouseEvent} ordered-typed-event
  * @fires typed-event-two {MouseEvent} This is a typed event
+ * @fires {MouseEvent} ordered-typed-event-two This is a typed event
  * @fires typed-event-three {MouseEvent} - This is another typed event
+ * @fires {MouseEvent} ordered-typed-event-three - This is another typed event
  * @fires external-custom-event {ExternalCustomEvent} - External custom event
+ * @fires {ExternalCustomEvent} ordered-external-custom-event - External custom event
  * @fires local-custom-event {LocalCustomEvent} - Local custom event
+ * @fires {LocalCustomEvent} ordered-local-custom-event - Local custom event
  * @fires generic-custom-event {CustomEvent<ExternalClass>} - Generic custom event
+ * @fires {CustomEvent<ExternalClass>} ordered-generic-custom-event - Generic custom event
  * @fires inline-detail-custom-event {CustomEvent<{ event: MouseEvent; more: { impl: ExternalClass; }; }>} Inline
+ * detail custom event description
+ * @fires {CustomEvent<{ event: MouseEvent; more: { impl: ExternalClass; }; }>} ordered-inline-detail-custom-event Inline
  * detail custom event description
  * @comment malformed fires tag:
  *

--- a/packages/labs/analyzer/test-files/js/jsdoc/element-a.js
+++ b/packages/labs/analyzer/test-files/js/jsdoc/element-a.js
@@ -33,7 +33,7 @@ import {LitElement} from 'lit';
  * @cssProperty [--default-with-description=#324fff] Description for --default-with-description
  * with wraparound
  * @cssProperty [--default-with-description-dash=#324fff] - Description for --default-with-description-dash
- * @cssProperty {<color>} syntax-no-description
+ * @cssProperty {<color>} --syntax-no-description
  * @cssProp --short-no-description
  * @cssProp --short-with-description Description for --short-with-description
  * with wraparound
@@ -52,10 +52,10 @@ import {LitElement} from 'lit';
  * with wraparound
  * @cssprop --lower-short-with-description-dash - Description for --lower-short-with-description-dash
  *
- * @cssProp {<color>} --has-syntax
- * @cssProp {<color>} --has-syntax-with-description Description for --has-syntax-with-description
+ * @cssProp {<color>} --syntax-short-no-description
+ * @cssProp {<color>} --syntax-short-with-description Description for --syntax-short-with-description
  * with wraparound
- * @cssProp {<color>} --has-syntax-with-description-dash - Description for --has-syntax-with-description-dash
+ * @cssProp {<color>} --syntax-short-with-description-dash - Description for --syntax-short-with-description-dash
  */
 export class ElementA extends LitElement {
   /**

--- a/packages/labs/analyzer/test-files/js/jsdoc/element-a.js
+++ b/packages/labs/analyzer/test-files/js/jsdoc/element-a.js
@@ -30,6 +30,28 @@ import {LitElement} from 'lit';
  * @cssProp --short-with-description Description for --short-with-description
  * with wraparound
  * @cssProp --short-with-description-dash - Description for --short-with-description-dash
+ *
+ * @csspart lower-no-description
+ * @csspart lower-with-description Description for :part(with-description)
+ * with wraparound
+ * @csspart lower-with-description-dash - Description for :part(with-description-dash)
+ * @cssproperty --lower-no-description
+ * @cssproperty --lower-with-description Description for --with-description
+ * with wraparound
+ * @cssproperty --lower-with-description-dash - Description for --with-description-dash
+ * @cssproperty [--lower-default-no-description=#324fff]
+ * @cssproperty [--lower-default-with-description=#324fff] Description for --default-with-description
+ * with wraparound
+ * @cssproperty [--lower-default-with-description-dash=#324fff] - Description for --default-with-description-dash
+ * @cssprop --lower-short-no-description
+ * @cssprop --lower-short-with-description Description for --short-with-description
+ * with wraparound
+ * @cssprop --lower-short-with-description-dash - Description for --short-with-description-dash
+ *
+ * @cssProp {<color>} --has-syntax
+ * @cssProp {<color>} --has-syntax-with-description Description for --has-syntax-with-description
+ * with wraparound
+ * @cssProp {<color>} --has-syntax-with-description-dash - Description for --has-syntax-with-description-dash
  */
 export class ElementA extends LitElement {
   /**

--- a/packages/labs/analyzer/test-files/js/jsdoc/element-a.js
+++ b/packages/labs/analyzer/test-files/js/jsdoc/element-a.js
@@ -33,6 +33,7 @@ import {LitElement} from 'lit';
  * @cssProperty [--default-with-description=#324fff] Description for --default-with-description
  * with wraparound
  * @cssProperty [--default-with-description-dash=#324fff] - Description for --default-with-description-dash
+ * @cssProperty {<color>} syntax-no-description
  * @cssProp --short-no-description
  * @cssProp --short-with-description Description for --short-with-description
  * with wraparound

--- a/packages/labs/analyzer/test-files/js/jsdoc/element-a.js
+++ b/packages/labs/analyzer/test-files/js/jsdoc/element-a.js
@@ -14,10 +14,17 @@ import {LitElement} from 'lit';
  * @slot with-description Description for with-description
  * with wraparound
  * @slot with-description-dash - Description for with-description-dash
+ *
  * @cssPart no-description
  * @cssPart with-description Description for :part(with-description)
  * with wraparound
  * @cssPart with-description-dash - Description for :part(with-description-dash)
+ *
+ * @csspart lower-no-description
+ * @csspart lower-with-description Description for :part(with-description)
+ * with wraparound
+ * @csspart lower-with-description-dash - Description for :part(with-description-dash)
+ *
  * @cssProperty --no-description
  * @cssProperty --with-description Description for --with-description
  * with wraparound
@@ -31,10 +38,6 @@ import {LitElement} from 'lit';
  * with wraparound
  * @cssProp --short-with-description-dash - Description for --short-with-description-dash
  *
- * @csspart lower-no-description
- * @csspart lower-with-description Description for :part(with-description)
- * with wraparound
- * @csspart lower-with-description-dash - Description for :part(with-description-dash)
  * @cssproperty --lower-no-description
  * @cssproperty --lower-with-description Description for --with-description
  * with wraparound

--- a/packages/labs/analyzer/test-files/js/jsdoc/element-a.js
+++ b/packages/labs/analyzer/test-files/js/jsdoc/element-a.js
@@ -40,17 +40,17 @@ import {LitElement} from 'lit';
  * @cssProp --short-with-description-dash - Description for --short-with-description-dash
  *
  * @cssproperty --lower-no-description
- * @cssproperty --lower-with-description Description for --with-description
+ * @cssproperty --lower-with-description Description for --lower-with-description
  * with wraparound
- * @cssproperty --lower-with-description-dash - Description for --with-description-dash
+ * @cssproperty --lower-with-description-dash - Description for --lower-with-description-dash
  * @cssproperty [--lower-default-no-description=#324fff]
- * @cssproperty [--lower-default-with-description=#324fff] Description for --default-with-description
+ * @cssproperty [--lower-default-with-description=#324fff] Description for --lower-default-with-description
  * with wraparound
- * @cssproperty [--lower-default-with-description-dash=#324fff] - Description for --default-with-description-dash
+ * @cssproperty [--lower-default-with-description-dash=#324fff] - Description for --lower-default-with-description-dash
  * @cssprop --lower-short-no-description
- * @cssprop --lower-short-with-description Description for --short-with-description
+ * @cssprop --lower-short-with-description Description for --lower-short-with-description
  * with wraparound
- * @cssprop --lower-short-with-description-dash - Description for --short-with-description-dash
+ * @cssprop --lower-short-with-description-dash - Description for --lower-short-with-description-dash
  *
  * @cssProp {<color>} --has-syntax
  * @cssProp {<color>} --has-syntax-with-description Description for --has-syntax-with-description

--- a/packages/labs/analyzer/test-files/ts/events/src/element-a.ts
+++ b/packages/labs/analyzer/test-files/ts/events/src/element-a.ts
@@ -22,12 +22,20 @@ export class LocalCustomEvent extends Event {
  * @fires event-two This is an event
  * @fires event-three - This is another event
  * @fires typed-event {MouseEvent}
+ * @fires {MouseEvent} ordered-typed-event
  * @fires typed-event-two {MouseEvent} This is a typed event
+ * @fires {MouseEvent} ordered-typed-event-two This is a typed event
  * @fires typed-event-three {MouseEvent} - This is another typed event
+ * @fires {MouseEvent} ordered-typed-event-three - This is another typed event
  * @fires external-custom-event {ExternalCustomEvent} - External custom event
+ * @fires {ExternalCustomEvent} ordered-external-custom-event - External custom event
  * @fires local-custom-event {LocalCustomEvent} - Local custom event
+ * @fires {LocalCustomEvent} ordered-local-custom-event - Local custom event
  * @fires generic-custom-event {CustomEvent<ExternalClass>} - Generic custom event
+ * @fires {CustomEvent<ExternalClass>} ordered-generic-custom-event - Generic custom event
  * @fires inline-detail-custom-event {CustomEvent<{ event: MouseEvent; more: { impl: ExternalClass; }; }>} Inline
+ * detail custom event description
+ * @fires {CustomEvent<{ event: MouseEvent; more: { impl: ExternalClass; }; }>} ordered-inline-detail-custom-event Inline
  * detail custom event description
  * @comment malformed fires tag:
  *

--- a/packages/labs/analyzer/test-files/ts/jsdoc/src/element-a.ts
+++ b/packages/labs/analyzer/test-files/ts/jsdoc/src/element-a.ts
@@ -31,6 +31,28 @@ import {customElement} from 'lit/decorators.js';
  * @cssProp --short-with-description Description for --short-with-description
  * with wraparound
  * @cssProp --short-with-description-dash - Description for --short-with-description-dash
+ *
+ * @csspart lower-no-description
+ * @csspart lower-with-description Description for :part(with-description)
+ * with wraparound
+ * @csspart lower-with-description-dash - Description for :part(with-description-dash)
+ * @cssproperty --lower-no-description
+ * @cssproperty --lower-with-description Description for --with-description
+ * with wraparound
+ * @cssproperty --lower-with-description-dash - Description for --with-description-dash
+ * @cssproperty [--lower-default-no-description=#324fff]
+ * @cssproperty [--lower-default-with-description=#324fff] Description for --default-with-description
+ * with wraparound
+ * @cssproperty [--lower-default-with-description-dash=#324fff] - Description for --default-with-description-dash
+ * @cssprop --lower-short-no-description
+ * @cssprop --lower-short-with-description Description for --short-with-description
+ * with wraparound
+ * @cssprop --lower-short-with-description-dash - Description for --short-with-description-dash
+ *
+ * @cssProp {<color>} --has-syntax
+ * @cssProp {<color>} --has-syntax-with-description Description for --has-syntax-with-description
+ * with wraparound
+ * @cssProp {<color>} --has-syntax-with-description-dash - Description for --has-syntax-with-description-dash
  */
 @customElement('element-a')
 export class ElementA extends LitElement {

--- a/packages/labs/analyzer/test-files/ts/jsdoc/src/element-a.ts
+++ b/packages/labs/analyzer/test-files/ts/jsdoc/src/element-a.ts
@@ -41,17 +41,17 @@ import {customElement} from 'lit/decorators.js';
  * @cssProp --short-with-description-dash - Description for --short-with-description-dash
  *
  * @cssproperty --lower-no-description
- * @cssproperty --lower-with-description Description for --with-description
+ * @cssproperty --lower-with-description Description for --lower-with-description
  * with wraparound
- * @cssproperty --lower-with-description-dash - Description for --with-description-dash
+ * @cssproperty --lower-with-description-dash - Description for --lower-with-description-dash
  * @cssproperty [--lower-default-no-description=#324fff]
- * @cssproperty [--lower-default-with-description=#324fff] Description for --default-with-description
+ * @cssproperty [--lower-default-with-description=#324fff] Description for --lower-default-with-description
  * with wraparound
- * @cssproperty [--lower-default-with-description-dash=#324fff] - Description for --default-with-description-dash
+ * @cssproperty [--lower-default-with-description-dash=#324fff] - Description for --lower-default-with-description-dash
  * @cssprop --lower-short-no-description
- * @cssprop --lower-short-with-description Description for --short-with-description
+ * @cssprop --lower-short-with-description Description for --lower-short-with-description
  * with wraparound
- * @cssprop --lower-short-with-description-dash - Description for --short-with-description-dash
+ * @cssprop --lower-short-with-description-dash - Description for --lower-short-with-description-dash
  *
  * @cssProp {<color>} --has-syntax
  * @cssProp {<color>} --has-syntax-with-description Description for --has-syntax-with-description

--- a/packages/labs/analyzer/test-files/ts/jsdoc/src/element-a.ts
+++ b/packages/labs/analyzer/test-files/ts/jsdoc/src/element-a.ts
@@ -15,10 +15,17 @@ import {customElement} from 'lit/decorators.js';
  * @slot with-description Description for with-description
  * with wraparound
  * @slot with-description-dash - Description for with-description-dash
+ *
  * @cssPart no-description
  * @cssPart with-description Description for :part(with-description)
  * with wraparound
  * @cssPart with-description-dash - Description for :part(with-description-dash)
+ *
+ * @csspart lower-no-description
+ * @csspart lower-with-description Description for :part(with-description)
+ * with wraparound
+ * @csspart lower-with-description-dash - Description for :part(with-description-dash)
+ *
  * @cssProperty --no-description
  * @cssProperty --with-description Description for --with-description
  * with wraparound
@@ -27,15 +34,12 @@ import {customElement} from 'lit/decorators.js';
  * @cssProperty [--default-with-description=#324fff] Description for --default-with-description
  * with wraparound
  * @cssProperty [--default-with-description-dash=#324fff] - Description for --default-with-description-dash
+ * @cssProperty {<color>} syntax-no-description
  * @cssProp --short-no-description
  * @cssProp --short-with-description Description for --short-with-description
  * with wraparound
  * @cssProp --short-with-description-dash - Description for --short-with-description-dash
  *
- * @csspart lower-no-description
- * @csspart lower-with-description Description for :part(with-description)
- * with wraparound
- * @csspart lower-with-description-dash - Description for :part(with-description-dash)
  * @cssproperty --lower-no-description
  * @cssproperty --lower-with-description Description for --with-description
  * with wraparound

--- a/packages/labs/analyzer/test-files/ts/jsdoc/src/element-a.ts
+++ b/packages/labs/analyzer/test-files/ts/jsdoc/src/element-a.ts
@@ -34,7 +34,7 @@ import {customElement} from 'lit/decorators.js';
  * @cssProperty [--default-with-description=#324fff] Description for --default-with-description
  * with wraparound
  * @cssProperty [--default-with-description-dash=#324fff] - Description for --default-with-description-dash
- * @cssProperty {<color>} syntax-no-description
+ * @cssProperty {<color>} --syntax-no-description
  * @cssProp --short-no-description
  * @cssProp --short-with-description Description for --short-with-description
  * with wraparound
@@ -53,10 +53,10 @@ import {customElement} from 'lit/decorators.js';
  * with wraparound
  * @cssprop --lower-short-with-description-dash - Description for --lower-short-with-description-dash
  *
- * @cssProp {<color>} --has-syntax
- * @cssProp {<color>} --has-syntax-with-description Description for --has-syntax-with-description
+ * @cssProp {<color>} --syntax-short-no-description
+ * @cssProp {<color>} --syntax-short-with-description Description for --syntax-short-with-description
  * with wraparound
- * @cssProp {<color>} --has-syntax-with-description-dash - Description for --has-syntax-with-description-dash
+ * @cssProp {<color>} --syntax-short-with-description-dash - Description for --syntax-short-with-description-dash
  */
 @customElement('element-a')
 export class ElementA extends LitElement {


### PR DESCRIPTION
- adds tests
- support `@cssproperty`, `@cssprop`, `@csspart` (all lowercase)
- support `@fires {Type} event-name - description`
- support `@cssProp {<syntax>} [--name=default] - description`

```js
/**

 * @fires event-name
 * @fires event-name description
 * @fires event-name - description
 * @fires event-name: description
 * @fires event-name {Type}
 * @fires event-name {Type} description
 * @fires event-name {Type} - description
 * @fires event-name {Type}: description
 * @fires {Type} event-name
 * @fires {Type} event-name description
 * @fires {Type} event-name - description
 * @fires {Type} event-name: description
 * @slot name
 * @slot name description
 * @slot name - description
 * @slot name: description
 * @cssProp [--name=default]
 * @cssProp [--name=default] description
 * @cssProp [--name=default] - description
 * @cssProp [--name=default]: description
 * @cssprop {<color>} [--name=default]
 * @cssprop {<color>} [--name=default] description
 * @cssprop {<color>} [--name=default] - description
 * @cssprop {<color>} [--name=default]: description
 */
