### PR TITLE
fix(analyzer): readonly fields

### DIFF
--- a/.changeset/analyzer-accessors.md
+++ b/.changeset/analyzer-accessors.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/analyzer': patch
+---
+
+Supports class accessors (pairs, readonly, or setter-only)

--- a/.changeset/analyzer-constructor-assigned.md
+++ b/.changeset/analyzer-constructor-assigned.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/analyzer': patch
+---
+
+Supports non-reactive, constructor assigned class fields

--- a/.changeset/analzyer-readonly-jsdoc.md
+++ b/.changeset/analzyer-readonly-jsdoc.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/analyzer': patch
+---
+
+Supports jsDoc `@readonly` tag on non-reactive class fields

--- a/.changeset/analzyer-readonly-ts.md
+++ b/.changeset/analzyer-readonly-ts.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/analyzer': patch
+---
+
+Supports typescript `readonly` keyword on non-reactive class fields

--- a/packages/labs/analyzer/src/lib/javascript/classes.ts
+++ b/packages/labs/analyzer/src/lib/javascript/classes.ts
@@ -111,6 +111,14 @@ export const getClassMembers = (
     // Ignore non-implementation signatures of overloaded methods by checking
     // for `node.body`.
     if (typescript.isConstructorDeclaration(node) && node.body) {
+      // TODO(bennypowers): We probably want to see if this matches what TypeScript considers a field initialization.
+      // Maybe instead of iterating through the constructor statements, we walk the body looking for any
+      // assignment expression so that we get ones inside of if statements, in parenthesized expressions, etc.
+      //
+      // Also, this doesn't cover destructuring assignment.
+      //
+      // This is ok for now because these are rare ways to "declare" a field,
+      // especially in web components where you shouldn't have constructor parameters.
       node.body.statements.forEach((node) => {
         if (
           typescript.isExpressionStatement(node) &&
@@ -188,9 +196,9 @@ export const getClassMembers = (
           type: getTypeForNode((get ?? set)!, analyzer),
           privacy: getPrivacy(typescript, (get ?? set)!),
           readonly: !!get && !set,
-          // TODO: derive from getter?
-          // default
-          // TODO: reflect, etc?
+          // TODO(bennypowers): derive from getter?
+          // default: ???
+          // TODO(bennypowers): reflect, etc?
         })
       );
     }

--- a/packages/labs/analyzer/src/lib/javascript/classes.ts
+++ b/packages/labs/analyzer/src/lib/javascript/classes.ts
@@ -122,8 +122,17 @@ export const getClassMembers = (
           default: node.initializer?.getText(),
           type: getTypeForNode(node, analyzer),
           ...parseNodeJSDocInfo(node, analyzer),
+          readonly:
+            node.modifiers?.some((mod) =>
+              typescript.isReadonlyKeywordOrPlusOrMinusToken(mod)
+            ) ||
+            (node as ts.PropertyDeclaration & {jsDoc: ts.JSDoc[]}).jsDoc?.some(
+              (doc) => doc.tags?.some((tag) => tag.tagName.text === 'readonly')
+            ),
         })
       );
+    } else if (typescript.isAccessor(node)) {
+      // TODO: handle getter only, accessor pairs
     }
   });
   return {

--- a/packages/labs/analyzer/src/lib/model.ts
+++ b/packages/labs/analyzer/src/lib/model.ts
@@ -397,6 +397,7 @@ export class ClassField extends Declaration {
   privacy?: Privacy | undefined;
   inheritedFrom?: Reference | undefined;
   source?: SourceReference | undefined;
+  readonly?: boolean | undefined;
   type?: Type | undefined;
   default?: string | undefined;
   constructor(init: ClassFieldInit) {

--- a/packages/labs/analyzer/src/lib/model.ts
+++ b/packages/labs/analyzer/src/lib/model.ts
@@ -390,6 +390,7 @@ export interface ClassFieldInit extends PropertyLike {
   privacy?: Privacy | undefined;
   inheritedFrom?: Reference | undefined;
   source?: SourceReference | undefined;
+  readonly?: boolean | undefined;
 }
 
 export class ClassField extends Declaration {
@@ -408,6 +409,7 @@ export class ClassField extends Declaration {
     this.source = init.source;
     this.type = init.type;
     this.default = init.default;
+    this.readonly = init.readonly;
   }
 }
 

--- a/packages/labs/analyzer/src/lib/utils.ts
+++ b/packages/labs/analyzer/src/lib/utils.ts
@@ -44,15 +44,21 @@ export const hasProtectedModifier = (ts: TypeScript, node: ts.HasModifiers) => {
   return hasModifier(ts, node, ts.SyntaxKind.ProtectedKeyword);
 };
 
-const isPrivate = (ts: TypeScript, node: ts.HasModifiers) => {
-  return hasPrivateModifier(ts, node) || hasJSDocTag(ts, node, 'private');
+const isPrivate = (ts: TypeScript, node: ts.Node) => {
+  return (
+    (ts.canHaveModifiers(node) && hasPrivateModifier(ts, node)) ||
+    hasJSDocTag(ts, node, 'private')
+  );
 };
 
-const isProtected = (ts: TypeScript, node: ts.HasModifiers) => {
-  return hasProtectedModifier(ts, node) || hasJSDocTag(ts, node, 'protected');
+const isProtected = (ts: TypeScript, node: ts.Node) => {
+  return (
+    (ts.canHaveModifiers(node) && hasProtectedModifier(ts, node)) ||
+    hasJSDocTag(ts, node, 'protected')
+  );
 };
 
-export const getPrivacy = (ts: TypeScript, node: ts.HasModifiers): Privacy => {
+export const getPrivacy = (ts: TypeScript, node: ts.Node): Privacy => {
   return isPrivate(ts, node)
     ? 'private'
     : isProtected(ts, node)

--- a/packages/labs/analyzer/src/test/lit-element/properties_test.ts
+++ b/packages/labs/analyzer/src/test/lit-element/properties_test.ts
@@ -36,6 +36,36 @@ for (const lang of languages) {
     assert.equal(element.reactiveProperties.has('notDecorated'), false);
   });
 
+  test('getter-only accessor', ({element}) => {
+    const property = element.getField('getterOnly')!;
+    assert.ok(property);
+    assert.ok(property.type);
+    assert.equal(property.name, 'getterOnly');
+    assert.equal(property.readonly, true);
+    assert.equal(property.type?.text, 'number');
+    assert.equal(property.type?.references.length, 0);
+  });
+
+  test('accessor pair', ({element}) => {
+    const property = element.getField('accessorPair')!;
+    assert.ok(property);
+    assert.ok(property.type);
+    assert.equal(property.name, 'accessorPair');
+    assert.not.equal(property.readonly, true);
+    assert.equal(property.type?.text, 'number');
+    assert.equal(property.type?.references.length, 0);
+  });
+
+  test('readonly field', ({element}) => {
+    const property = element.getField('readonlyField')!;
+    assert.ok(property);
+    assert.ok(property.type);
+    assert.equal(property.name, 'readonlyField');
+    assert.not.equal(property.readonly, true);
+    assert.equal(property.type?.text, 'number');
+    assert.equal(property.type?.references.length, 0);
+  });
+
   test('string property with no options', ({element}) => {
     const property = element.reactiveProperties.get('noOptionsString');
     assert.ok(property);

--- a/packages/labs/analyzer/src/test/lit-element/properties_test.ts
+++ b/packages/labs/analyzer/src/test/lit-element/properties_test.ts
@@ -36,6 +36,25 @@ for (const lang of languages) {
     assert.equal(element.reactiveProperties.has('notDecorated'), false);
   });
 
+  test('constructor-assigned non-decorated field', ({element}) => {
+    const property = element.getField('constructorAssignOnly')!;
+    assert.ok(property);
+    assert.ok(property.type);
+    assert.equal(property.name, 'constructorAssignOnly');
+    assert.equal(property.type?.text, 'number');
+    assert.equal(property.type?.references.length, 0);
+  });
+
+  test('readonly field', ({element}) => {
+    const property = element.getField('readonlyField')!;
+    assert.ok(property);
+    assert.ok(property.type);
+    assert.equal(property.name, 'readonlyField');
+    assert.equal(property.readonly, true);
+    assert.equal(property.type?.text, 'number');
+    assert.equal(property.type?.references.length, 0);
+  });
+
   test('getter-only accessor', ({element}) => {
     const property = element.getField('getterOnly')!;
     assert.ok(property);
@@ -51,16 +70,6 @@ for (const lang of languages) {
     assert.ok(property);
     assert.ok(property.type);
     assert.equal(property.name, 'accessorPair');
-    assert.not.equal(property.readonly, true);
-    assert.equal(property.type?.text, 'number');
-    assert.equal(property.type?.references.length, 0);
-  });
-
-  test('readonly field', ({element}) => {
-    const property = element.getField('readonlyField')!;
-    assert.ok(property);
-    assert.ok(property.type);
-    assert.equal(property.name, 'readonlyField');
     assert.not.equal(property.readonly, true);
     assert.equal(property.type?.text, 'number');
     assert.equal(property.type?.references.length, 0);

--- a/packages/labs/analyzer/test-files/js/properties/element-a.js
+++ b/packages/labs/analyzer/test-files/js/properties/element-a.js
@@ -52,11 +52,13 @@ export class ElementA extends LitElement {
     void 0;
   }
 
+  /** @readonly */
+  readonlyField = 0;
+
   constructor() {
     super();
+    this.constructorAssignOnly = 0;
     this.notDecorated = '';
-    /** @readonly */
-    this.readonlyField = 0;
     this.noOptionsString = '';
     this.noOptionsNumber = 42;
     this.typeString = '';

--- a/packages/labs/analyzer/test-files/js/properties/element-a.js
+++ b/packages/labs/analyzer/test-files/js/properties/element-a.js
@@ -39,9 +39,24 @@ export class ElementA extends LitElement {
 
   [unsupportedPropertyName] = '';
 
+  /** @type {number} */
+  get getterOnly() {
+    return 0;
+  }
+
+  /** @type {number} */
+  get accessorPair() {
+    return 0;
+  }
+  set accessorPair(_) {
+    void 0;
+  }
+
   constructor() {
     super();
     this.notDecorated = '';
+    /** @readonly */
+    this.readonlyField = 0;
     this.noOptionsString = '';
     this.noOptionsNumber = 42;
     this.typeString = '';

--- a/packages/labs/analyzer/test-files/ts/properties/src/element-a.ts
+++ b/packages/labs/analyzer/test-files/ts/properties/src/element-a.ts
@@ -32,6 +32,19 @@ export class ElementA extends LitElement {
 
   notDecorated: string;
 
+  readonly readonlyField = 0;
+
+  get getterOnly(): number {
+    return 0;
+  }
+
+  get accessorPair(): number {
+    return 0;
+  }
+  set accessorPair(_: number) {
+    void 0;
+  }
+
   @property()
   noOptionsString: string;
 

--- a/packages/labs/analyzer/test-files/ts/properties/src/element-a.ts
+++ b/packages/labs/analyzer/test-files/ts/properties/src/element-a.ts
@@ -25,9 +25,12 @@ export class ElementA extends LitElement {
 
   declare staticProp: number;
 
+  declare constructorAssignOnly: number;
+
   constructor() {
     super();
     this.staticProp = 42;
+    this.constructorAssignOnly = 0;
   }
 
   notDecorated: string;


### PR DESCRIPTION
fixes #4136 

- [x] constructor-assigned, non-decorated fields (i have my doubts about how well i implement this)
- [x] non-decorated readonly typescript class fields
- [x] non-decorated javascript class fields with `@readonly` jsdoc
- [x] non-decorated getter-only accessors (i.e. `readonly: true`)
- [x] non-decorated accessor pairs