### PR TITLE
[labs/react] Fix type compatibility with Preact when adding children

### DIFF
--- a/.changeset/silver-flies-agree.md
+++ b/.changeset/silver-flies-agree.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/react': patch
+---
+
+Fix type compatibility with Preact when adding children to wrapped components.

--- a/examples/preact/src/index.tsx
+++ b/examples/preact/src/index.tsx
@@ -24,8 +24,7 @@ export function App() {
     <>
       <ElementA foo="foo" onAChanged={() => {}}>
         This goes in default slot
-        {/* TODO(augustjk): Add this back with #4142 */}
-        {/* <div slot="stuff">This goes in stuff slot</div> */}
+        <div slot="stuff">This goes in stuff slot</div>
       </ElementA>
       <ElementEvents
         foo="foo"

--- a/packages/labs/react/src/create-component.ts
+++ b/packages/labs/react/src/create-component.ts
@@ -48,7 +48,9 @@ export type ReactWebComponent<
 // lifecycle methods or allow user to explicitly provide props.
 type ElementProps<I> = Partial<Omit<I, keyof HTMLElement>>;
 
-// Child type compatible with both React and Preact.
+// Child type compatible with both React and Preact. It's based on
+// `React.ReactNode` but using `JSX.Element` allows`VNode` to be acceptable in
+// Preact projects.
 type Child =
   | JSX.Element
   | React.ReactPortal
@@ -63,7 +65,7 @@ type ComponentProps<I, E extends EventNames = {}> = Omit<
   // Omit keyof E to prefer provided event handler mapping over React's
   // built-in event handler props.
   | keyof E
-  // Omit children to replace with out own that's compatible with Preact.
+  // Omit children to replace with our own that's compatible with Preact.
   | 'children'
 > &
   EventListeners<E> & {children?: Child | Child[]} & ElementProps<I>;

--- a/packages/labs/react/src/create-component.ts
+++ b/packages/labs/react/src/create-component.ts
@@ -48,15 +48,25 @@ export type ReactWebComponent<
 // lifecycle methods or allow user to explicitly provide props.
 type ElementProps<I> = Partial<Omit<I, keyof HTMLElement>>;
 
-// Acceptable props to the React component. Omit keyof E from HTMLAttributes to
-// prefer provided event handler mapping over React's built-in event handler
-// props.
+// Child type compatible with both React and Preact.
+type Child =
+  | JSX.Element
+  | React.ReactPortal
+  | string
+  | number
+  | boolean
+  | undefined;
+
+// Acceptable props to the React component.
 type ComponentProps<I, E extends EventNames = {}> = Omit<
   React.HTMLAttributes<I>,
-  keyof E
+  // Omit keyof E to prefer provided event handler mapping over React's
+  // built-in event handler props.
+  | keyof E
+  // Omit children to replace with out own that's compatible with Preact.
+  | 'children'
 > &
-  ElementProps<I> &
-  EventListeners<E>;
+  EventListeners<E> & {children?: Child | Child[]} & ElementProps<I>;
 
 /**
  * Type used to cast an event name with an event type when providing the


### PR DESCRIPTION
Fixes #4138

Content placed in children position in JSX are typed differently depending on whether it's React or Preact project. Children typing in Preact projects were incompatible with `children` prop of our wrapped components as they only accepted `React.ReactNode` which was more restrictive than what Preact considers as valid renderable child.

This PR adds children typing that's compatible with both React and Preact.

~~Testing for this fix working in Preact was done manually in a working branch for https://github.com/lit/lit/pull/4111. I'd be okay with holding off on merging this until I can do the updates to that branch to demonstrate the fix.~~
Mentioned PR has been merged and this branch has been rebased to that.