### PR TITLE
[labs/react] Loosen type for react module in option

### DIFF
--- a/.changeset/cold-kings-explain.md
+++ b/.changeset/cold-kings-explain.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/react': patch
+---
+
+Make option type for the React module we accept to be looser. This lets users provide a smaller object with just the needed API and mitigate type incompatibilities when multiple copies of React types are present.

--- a/packages/labs/react/src/create-component.ts
+++ b/packages/labs/react/src/create-component.ts
@@ -102,10 +102,27 @@ type EventListeners<R extends EventNames> = {
     : (e: Event) => void;
 };
 
-// Interface that includes parts of the React module that we use. This allows
-// users to construct an object with just the needed methods and prevents type
-// incompatibilities when there are multiple React types being used.
-interface ReactLike {
+/**
+ * Interface that includes parts of the React module that `createComponent()`
+ * uses. Use this to create an object to pass into the `react` option.
+ *
+ * Example:
+ *
+ * ```ts
+ * const myReactLike = {
+ *   forwardRef,
+ *   useRef,
+ *   useLayoutEffect,
+ *   createElement,
+ * } satisfies ReactLike;
+ *
+ * createComponnt({
+ *   react: myReactLike,
+ *   ...
+ * });
+ * ```
+ */
+export interface ReactLike {
   forwardRef: typeof React.forwardRef;
   useRef: typeof React.useRef;
   // typeof React.useLayoutEffect uses a unique symbol brand making it


### PR DESCRIPTION
While working making the top level examples directory to part of the npm workspaces here https://github.com/lit/lit/pull/4111, I noticed the code that wraps the custom element with `createComponent()` was failing type check as the `React` type imported in the nextjs example project was a different copy than the one used by `@lit-labs/react`, and due to things like unique symbol type and function overloading, copies are not compatible. In that PR, I solved the issue by de-duping the `@types/react` package in the monorepo but we may eventually have valid reasons to have multiple copies of `@types/react` in the monorepo (should we add projects/tests with React 17, for instance).

The type change done here allows for the nextjs example project and `@lit-labs/react` to have different React types, and also only specifies APIs we use from React so users could create their own bag of React functions rather than passing in the whole module.