### PR TITLE
[labs/task] Disambiguate `TaskFunction` type

### DIFF
--- a/.changeset/gentle-needles-perform.md
+++ b/.changeset/gentle-needles-perform.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/task': patch
+---
+
+Disambiguate `TypeFunction` type to fix type error when providing a task function making use of the abort signal.

--- a/packages/labs/task/src/task.ts
+++ b/packages/labs/task/src/task.ts
@@ -7,12 +7,12 @@ import {notEqual} from '@lit/reactive-element';
 import {ReactiveControllerHost} from '@lit/reactive-element/reactive-controller.js';
 
 export interface TaskFunctionOptions {
-  signal?: AbortSignal;
+  signal: AbortSignal;
 }
 
 export type TaskFunction<D extends ReadonlyArray<unknown>, R = unknown> = (
   args: D,
-  options?: TaskFunctionOptions
+  options: TaskFunctionOptions
 ) => R | typeof initialState | Promise<R | typeof initialState>;
 export type ArgsFunction<D extends ReadonlyArray<unknown>> = () => D;
 


### PR DESCRIPTION
Fixes #4155

The optional notation on 2nd param and the signal option made TypeScript not accept a task function with an explicit second param. Removing the `?` fixes this. Since we always provide the second argument with the abort signal when calling the provided function, it makes sense to type it so.

TypeScript is still happy to accept a function that doesn't have a 2nd param.