### PR TITLE
Update wireit, use the new quiet logger in CI testing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,6 +68,7 @@ jobs:
 
       - name: Test
         env:
+          WIREIT_LOGGER: quiet
           BROWSERS: preset:local
           CONCURRENT_BROWSERS: 3
         run: npm run test
@@ -91,5 +92,6 @@ jobs:
 
       - name: Test
         env:
+          WIREIT_LOGGER: quiet
           RUN_BROWSER_TESTS: false
         run: npm run test:windows

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "rollup-plugin-terser": "^7.0.2",
         "typescript": "~5.2.0",
         "uvu": "^0.5.6",
-        "wireit": "^0.9.5"
+        "wireit": "^0.11.0"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -23617,13 +23617,10 @@
       }
     },
     "node_modules/wireit": {
-      "version": "0.9.5",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.11.0.tgz",
+      "integrity": "sha512-s0/bgBZ6y65BfxpCm7YA/x6QokPTQrA4mAN110FCxvvp4MotAupY8f/RH8f6tGfz74zfJafxEqHo/NyoMc0pNQ==",
       "dev": true,
-      "license": "Apache-2.0",
-      "workspaces": [
-        "vscode-extension",
-        "website"
-      ],
       "dependencies": {
         "braces": "^3.0.2",
         "chokidar": "^3.5.3",

--- a/package.json
+++ b/package.json
@@ -243,7 +243,7 @@
     "rollup-plugin-terser": "^7.0.2",
     "typescript": "~5.2.0",
     "uvu": "^0.5.6",
-    "wireit": "^0.9.5"
+    "wireit": "^0.11.0"
   },
   "lint-staged": {
     "**/*.{cjs,html,js,json,md,ts}": "prettier --write",


### PR DESCRIPTION
Addressing feedback in https://github.com/google/wireit/pull/850 but I think this is an improvement as is