### PR TITLE
chore (labs/compiler, labs/ssr, localize-tools): update parse5/tools

### DIFF
--- a/.changeset/swift-badgers-suffer.md
+++ b/.changeset/swift-badgers-suffer.md
@@ -1,0 +1,7 @@
+---
+'@lit/localize-tools': patch
+'@lit-labs/compiler': patch
+'@lit-labs/ssr': patch
+---
+
+Update parse5/tools to simplify importing of node types from the default tree adapter

--- a/package-lock.json
+++ b/package-lock.json
@@ -4494,9 +4494,9 @@
       }
     },
     "node_modules/@parse5/tools": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@parse5/tools/-/tools-0.1.0.tgz",
-      "integrity": "sha512-VB9+4BsFoS+4HdB/Ph9jD4FHQt7GyiWESVNfBSh8Eu54LujWyy+NySGLjg8GZFWSZcESG72F67LjgmKZDZCvPg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@parse5/tools/-/tools-0.3.0.tgz",
+      "integrity": "sha512-zxRyTHkqb7WQMV8kTNBKWb1BeOFUKXBXTBWuxg9H9hfvQB3IwP6Iw2U75Ia5eyRxPNltmY7E8YAlz6zWwUnjKg==",
       "dependencies": {
         "parse5": "^7.0.0"
       }
@@ -29241,7 +29241,7 @@
       "version": "0.0.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@parse5/tools": "^0.2.0",
+        "@parse5/tools": "^0.3.0",
         "lit-html": "^2.7.5",
         "parse5": "^7.1.2",
         "typescript": "~5.2.0"
@@ -29254,14 +29254,6 @@
       },
       "engines": {
         "node": ">=14.17"
-      }
-    },
-    "packages/labs/compiler/node_modules/@parse5/tools": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@parse5/tools/-/tools-0.2.0.tgz",
-      "integrity": "sha512-nM6yoh+fBw+RCnk8XscJmV+V9fUuS89dYqwR3vYazNMmMvMsJbA0jsWhHeaqnPsMUp/Yt10NZArkHK6tv0lAew==",
-      "dependencies": {
-        "parse5": "^7.0.0"
       }
     },
     "packages/labs/compiler/node_modules/@rollup/plugin-typescript": {
@@ -30204,7 +30196,7 @@
         "@lit-labs/ssr-client": "^1.1.0",
         "@lit-labs/ssr-dom-shim": "^1.1.0",
         "@lit/reactive-element": "^1.6.0",
-        "@parse5/tools": "^0.1.0",
+        "@parse5/tools": "^0.3.0",
         "@types/node": "^16.0.0",
         "enhanced-resolve": "^5.10.0",
         "lit": "^2.7.0",
@@ -30491,6 +30483,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit/localize": "^0.11.0",
+        "@parse5/tools": "^0.3.0",
         "@xmldom/xmldom": "^0.8.2",
         "fast-glob": "^3.2.7",
         "fs-extra": "^10.0.0",
@@ -33130,7 +33123,7 @@
     "@lit-labs/compiler": {
       "version": "file:packages/labs/compiler",
       "requires": {
-        "@parse5/tools": "^0.2.0",
+        "@parse5/tools": "^0.3.0",
         "@rollup/plugin-typescript": "11.1.2",
         "lit-html": "^2.7.5",
         "parse5": "^7.1.2",
@@ -33140,14 +33133,6 @@
         "uvu": "^0.5.6"
       },
       "dependencies": {
-        "@parse5/tools": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/@parse5/tools/-/tools-0.2.0.tgz",
-          "integrity": "sha512-nM6yoh+fBw+RCnk8XscJmV+V9fUuS89dYqwR3vYazNMmMvMsJbA0jsWhHeaqnPsMUp/Yt10NZArkHK6tv0lAew==",
-          "requires": {
-            "parse5": "^7.0.0"
-          }
-        },
         "@rollup/plugin-typescript": {
           "version": "11.1.2",
           "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-11.1.2.tgz",
@@ -33797,7 +33782,7 @@
         "@lit/reactive-element": "^1.6.0",
         "@open-wc/testing": "^3.0.0-next.1",
         "@open-wc/testing-karma": "^4.0.9",
-        "@parse5/tools": "^0.1.0",
+        "@parse5/tools": "^0.3.0",
         "@types/command-line-args": "^5.0.0",
         "@types/koa": "^2.0.49",
         "@types/koa__router": "^8.0.2",
@@ -33962,6 +33947,7 @@
         "@lit-labs/ssr": "^3.1.0",
         "@lit/localize": "^0.11.0",
         "@lit/ts-transformers": "^1.1.0",
+        "@parse5/tools": "^0.3.0",
         "@types/fs-extra": "^9.0.1",
         "@types/minimist": "^1.2.0",
         "@types/prettier": "^2.0.1",
@@ -34808,9 +34794,9 @@
       }
     },
     "@parse5/tools": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@parse5/tools/-/tools-0.1.0.tgz",
-      "integrity": "sha512-VB9+4BsFoS+4HdB/Ph9jD4FHQt7GyiWESVNfBSh8Eu54LujWyy+NySGLjg8GZFWSZcESG72F67LjgmKZDZCvPg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@parse5/tools/-/tools-0.3.0.tgz",
+      "integrity": "sha512-zxRyTHkqb7WQMV8kTNBKWb1BeOFUKXBXTBWuxg9H9hfvQB3IwP6Iw2U75Ia5eyRxPNltmY7E8YAlz6zWwUnjKg==",
       "requires": {
         "parse5": "^7.0.0"
       },

--- a/packages/labs/compiler/package.json
+++ b/packages/labs/compiler/package.json
@@ -103,7 +103,7 @@
     }
   },
   "dependencies": {
-    "@parse5/tools": "^0.2.0",
+    "@parse5/tools": "^0.3.0",
     "lit-html": "^2.7.5",
     "parse5": "^7.1.2",
     "typescript": "~5.2.0"

--- a/packages/labs/ssr/package.json
+++ b/packages/labs/ssr/package.json
@@ -209,7 +209,7 @@
     "@lit-labs/ssr-client": "^1.1.0",
     "@lit-labs/ssr-dom-shim": "^1.1.0",
     "@lit/reactive-element": "^1.6.0",
-    "@parse5/tools": "^0.1.0",
+    "@parse5/tools": "^0.3.0",
     "@types/node": "^16.0.0",
     "enhanced-resolve": "^5.10.0",
     "lit": "^2.7.0",

--- a/packages/labs/ssr/src/lib/util/parse5-utils.ts
+++ b/packages/labs/ssr/src/lib/util/parse5-utils.ts
@@ -4,11 +4,16 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {DefaultTreeAdapterMap} from 'parse5';
-import {traverse, replaceWith, isElementNode} from '@parse5/tools';
+import {
+  traverse,
+  replaceWith,
+  isElementNode,
+  Element as p5Element,
+  Node as p5Node,
+} from '@parse5/tools';
 
-export function removeFakeRootElements(node: DefaultTreeAdapterMap['node']) {
-  const fakeRootElements: DefaultTreeAdapterMap['element'][] = [];
+export function removeFakeRootElements(node: p5Node) {
+  const fakeRootElements: p5Element[] = [];
 
   traverse(node, {
     'pre:node': (node) => {

--- a/packages/labs/ssr/src/lib/util/parse5-utils.ts
+++ b/packages/labs/ssr/src/lib/util/parse5-utils.ts
@@ -8,12 +8,12 @@ import {
   traverse,
   replaceWith,
   isElementNode,
-  Element as p5Element,
-  Node as p5Node,
+  Element,
+  Node,
 } from '@parse5/tools';
 
-export function removeFakeRootElements(node: p5Node) {
-  const fakeRootElements: p5Element[] = [];
+export function removeFakeRootElements(node: Node) {
+  const fakeRootElements: Element[] = [];
 
   traverse(node, {
     'pre:node': (node) => {

--- a/packages/localize-tools/package.json
+++ b/packages/localize-tools/package.json
@@ -137,6 +137,7 @@
     "jsonschema": "^1.4.0",
     "lit": "^2.7.0",
     "minimist": "^1.2.5",
+    "@parse5/tools": "^0.3.0",
     "parse5": "^7.1.1",
     "source-map-support": "^0.5.19",
     "typescript": "^4.7.4"

--- a/packages/localize-tools/src/program-analysis.ts
+++ b/packages/localize-tools/src/program-analysis.ts
@@ -6,11 +6,7 @@
 
 import ts from 'typescript';
 import * as parse5 from 'parse5';
-import {
-  Node as p5Node,
-  ChildNode as p5ChildNode,
-  ParentNode as p5ParentNode,
-} from '@parse5/tools';
+import {ChildNode, ParentNode, TextNode, CommentNode} from '@parse5/tools';
 import {ProgramMessage, Placeholder} from './messages.js';
 import {createDiagnostic} from './typescript.js';
 import {
@@ -519,13 +515,13 @@ function replaceHtmlWithPlaceholders(
 ): Array<string | Omit<Placeholder, 'index'>> {
   const components: Array<string | Omit<Placeholder, 'index'>> = [];
 
-  const traverse = (node: p5ChildNode): void => {
+  const traverse = (node: ChildNode): void => {
     if (node.nodeName === '#text') {
-      const text = (node as p5TextNode).value;
+      const text = (node as TextNode).value;
       components.push(text);
     } else if (node.nodeName === '#comment') {
       components.push({
-        untranslatable: serializeComment(node as p5CommentNode),
+        untranslatable: serializeComment(node as CommentNode),
       });
     } else {
       const {open, close} = serializeOpenCloseTags(node);
@@ -554,17 +550,17 @@ function replaceHtmlWithPlaceholders(
  *
  *   <b class="red">foo</b> --> {open: '<b class="red">, close: '</b>'}
  */
-function serializeOpenCloseTags(node: p5ChildNode): {
+function serializeOpenCloseTags(node: ChildNode): {
   open: string;
   close: string;
 } {
-  const withoutChildren: p5ChildNode = {
+  const withoutChildren: ChildNode = {
     ...node,
     childNodes: [],
   };
   const fakeParent = {
     childNodes: [withoutChildren],
-  } as p5ParentNode;
+  } as ParentNode;
   const serialized = parse5.serialize(fakeParent);
   const lastLt = serialized.lastIndexOf('<');
   const open = serialized.slice(0, lastLt);
@@ -579,10 +575,10 @@ function serializeOpenCloseTags(node: p5ChildNode): {
  *
  *   {data: "foo"} --> "<!-- foo -->"
  */
-function serializeComment(comment: p5CommentNode): string {
+function serializeComment(comment: CommentNode): string {
   return parse5.serialize({
     childNodes: [comment],
-  } as p5ParentNode);
+  } as ParentNode);
 }
 
 /**


### PR DESCRIPTION
Bumping `@parse5/tools` up so we can benefit from this easier import:

```ts
// new...

import {Element} from '@parse5/tools';

// previously...

import {DefaultTreeAdapterMap} from 'parse5';
type Element = DefaultTreeAdapterMap['element'];
```

FYI i chose to alias the names just for sake of readability, i.e. a knowing that we're referencing a parse5 `Element` rather than a DOM `Element`