### PR TITLE
[reactive-element] fix superclass properties being lost if subclass is decorated

### DIFF
--- a/.changeset/chilly-gifts-heal.md
+++ b/.changeset/chilly-gifts-heal.md
@@ -1,0 +1,5 @@
+---
+'@lit/reactive-element': patch
+---
+
+Fix superclass with a standard decorator not inheriting reactive properties.

--- a/packages/reactive-element/src/reactive-element.ts
+++ b/packages/reactive-element/src/reactive-element.ts
@@ -619,7 +619,6 @@ export abstract class ReactiveElement
   static get observedAttributes() {
     // note: piggy backing on this to ensure we're finalized.
     this.finalize();
-    this.__collectMetadata();
     const attributes: string[] = [];
     for (const [p, v] of this.elementProperties) {
       const attr = this.__attributeNameForProperty(p, v);
@@ -817,6 +816,7 @@ export abstract class ReactiveElement
       this._initializers = [...superCtor._initializers];
     }
     this.elementProperties = new Map(superCtor.elementProperties);
+    this.__collectMetadata();
     // initialize Map populated in observedAttributes
     this.__attributeToPropertyMap = new Map();
     // make any properties

--- a/packages/reactive-element/src/test/decorators/property_test.ts
+++ b/packages/reactive-element/src/test/decorators/property_test.ts
@@ -525,16 +525,24 @@ suite('@property', () => {
     }
 
     @customElement(elName)
-    class SubClass extends BaseTest {}
+    class SubClass extends BaseTest {
+      @property() second = 'second';
+    }
 
-    container.innerHTML = `<${elName} first="overrideFirst"></${elName}>`;
-    const el: SubClass = container.querySelector(elName)!;
+    container.innerHTML = `<${elName} first="overrideFirst" second="overrideSecond"></${elName}>`;
+
     // Check initialization
+    const el: SubClass = container.querySelector(elName)!;
     assert.equal(el.first, 'overrideFirst');
+    assert.equal(el.second, 'overrideSecond');
 
     // Property can be set from attribute
     el.setAttribute('first', 'first updated');
+    el.setAttribute('second', 'second updated');
+
     await el.updateComplete;
+
     assert.equal(el.first, 'first updated');
+    assert.equal(el.second, 'second updated');
   });
 });

--- a/packages/reactive-element/src/test/std-decorators/property_test.ts
+++ b/packages/reactive-element/src/test/std-decorators/property_test.ts
@@ -423,7 +423,6 @@ suite('@property', () => {
     }
 
     class SubClass extends BaseTest {
-      // The presence of this decorator should not cause `first` to break.
       @property() accessor second = 'second';
     }
 
@@ -433,7 +432,7 @@ suite('@property', () => {
 
     // Check initialization
     const el: SubClass = container.querySelector(elName)!;
-    assert.equal(el.first, 'first'); // BUG: Expected "overrideFirst"
+    assert.equal(el.first, 'overrideFirst');
     assert.equal(el.second, 'overrideSecond');
 
     // Property can be set from attribute
@@ -442,7 +441,7 @@ suite('@property', () => {
 
     await el.updateComplete;
 
-    assert.equal(el.first, 'first'); // BUG: Expected "first updated".
+    assert.equal(el.first, 'first updated');
     assert.equal(el.second, 'second updated');
   });
 
@@ -458,11 +457,11 @@ suite('@property', () => {
     container.innerHTML = `<${elName} first="overrideFirst"></${elName}>`;
     const el: SubClass = container.querySelector(elName)!;
     // Check initialization
-    assert.equal(el.first, 'first'); // BUG: Expected "overrideFirst"
+    assert.equal(el.first, 'overrideFirst');
 
     // Property can be set from attribute
     el.setAttribute('first', 'first updated');
     await el.updateComplete;
-    assert.equal(el.first, 'first'); // BUG: Expected "first updated"
+    assert.equal(el.first, 'first updated');
   });
 });

--- a/packages/reactive-element/src/test/std-decorators/property_test.ts
+++ b/packages/reactive-element/src/test/std-decorators/property_test.ts
@@ -451,17 +451,28 @@ suite('@property', () => {
       @property() accessor first = 'first';
     }
 
+    // This test is subtly different because it uses a customElement decorator,
+    // which calls `finalize` earlier than if `customElements.define()` was
+    // used.
     @customElement(elName)
-    class SubClass extends BaseTest {}
+    class SubClass extends BaseTest {
+      @property() accessor second = 'second';
+    }
 
-    container.innerHTML = `<${elName} first="overrideFirst"></${elName}>`;
-    const el: SubClass = container.querySelector(elName)!;
+    container.innerHTML = `<${elName} first="overrideFirst" second="overrideSecond"></${elName}>`;
+
     // Check initialization
+    const el: SubClass = container.querySelector(elName)!;
     assert.equal(el.first, 'overrideFirst');
+    assert.equal(el.second, 'overrideSecond');
 
     // Property can be set from attribute
     el.setAttribute('first', 'first updated');
+    el.setAttribute('second', 'second updated');
+
     await el.updateComplete;
+
     assert.equal(el.first, 'first updated');
+    assert.equal(el.second, 'second updated');
   });
 });


### PR DESCRIPTION
# Context

Found this issue when migrating Material Web Components to use standard decorators.

They have a common pattern which is to have an _implementation_ base class, and then wrap it with a class that defines it with the custom element registry.

E.g.

```ts
class Button extends LitElement {
  // Lots of implementation
}

@customElement('md-button')
class MdButton extends Button { }
```

However, this would result in broken reactive properties.

I was able to shrink this to a reproducible test case which is checked into this PR.

# Fix

The fix is to change where `__collectMetadata` is called. Before this change the order of calls looked like this:

```
Finalize BaseClass
Finalize SubClass
CollectMetadata SubClass
CollectMetadata BaseClass
```

After this change, the order is now:

```
FinalizeBaseClass
CollectMetadata BaseClass
FinalizeSubClass
CollectMetadata SubClass
```

Why is this order important? `this.elementProperties = new Map(superCtor.elementProperties);` occurs in `finalize`, and is where the subclass lifts the base classes reactive properties. If collect metadata has not yet run, then there are no properties to lift, and the property is no longer tracked in the superclass.

This results in `MdButton` class having no reactive properties.

With the fixed order, the properties can be applied from the metadata before the subclass finalizes, and thus it collects the reactive properties correctly.

# Risk

There is some risk in this change because `collect metadata` now happens more eagerly, and it can also occur earlier if a finalize is triggered earlier by something like `addInitializer` etc.