### PR TITLE
fix(labs/ssr): Include template and doc reference in partIndex errors

### DIFF
--- a/.changeset/sharp-pans-sip.md
+++ b/.changeset/sharp-pans-sip.md
@@ -2,4 +2,4 @@
 '@lit-labs/ssr': patch
 ---
 
-Include the offending template, details about common causes, and a link to the docs to the "partIndex" mismatch error message
+Improve "partIndex" error message to include the offending template, details about common causes, and a link to the docs.

--- a/.changeset/sharp-pans-sip.md
+++ b/.changeset/sharp-pans-sip.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/ssr': patch
+---
+
+Include the offending template, details about common causes, and a link to the docs to the "partIndex" mismatch error message

--- a/packages/labs/ssr/src/lib/render-value.ts
+++ b/packages/labs/ssr/src/lib/render-value.ts
@@ -767,15 +767,12 @@ function throwErrorForPartIndexMismatch(
   partIndex: number,
   result: TemplateResult
 ) {
-  let template = result.strings[0];
-  for (let i = 0; i < result.values.length; i++) {
-    template += result.values[i] + result.strings[i + 1];
-  }
-
   const errorMsg = `
-    Unexpected final partIndex: ${partIndex} !== ${result.values.length} while processing the following template:
+    Unexpected final partIndex: ${partIndex} !== ${
+    result.values.length
+  } while processing the following template:
 
-    ${template}
+    ${result.strings.join('${...}')}
 
     This could be because you're attempting to render an expression in an invalid location. See
     https://lit.dev/docs/templates/expressions/#invalid-locations for more information about invalid expression

--- a/packages/labs/ssr/src/lib/render-value.ts
+++ b/packages/labs/ssr/src/lib/render-value.ts
@@ -759,10 +759,30 @@ function* renderTemplateResult(
   }
 
   if (partIndex !== result.values.length) {
-    throw new Error(
-      `unexpected final partIndex: ${partIndex} !== ${result.values.length}`
-    );
+    throwErrorForPartIndexMismatch(partIndex, result);
   }
+}
+
+function throwErrorForPartIndexMismatch(
+  partIndex: number,
+  result: TemplateResult
+) {
+  let template = result.strings[0];
+  for (let i = 0; i < result.values.length; i++) {
+    template += result.values[i] + result.strings[i + 1];
+  }
+
+  const errorMsg = `
+    Unexpected final partIndex: ${partIndex} !== ${result.values.length} while processing the following template:
+
+    ${template}
+
+    This could be because you're attempting to render an expression in an invalid location. See
+    https://lit.dev/docs/templates/expressions/#invalid-locations for more information about invalid expression
+    locations.
+  `;
+
+  throw new Error(errorMsg);
 }
 
 function* renderPropertyPart(

--- a/packages/labs/ssr/src/test/lib/render-lit_test.ts
+++ b/packages/labs/ssr/src/test/lib/render-lit_test.ts
@@ -519,7 +519,7 @@ for (const global of [emptyVmGlobal, shimmedVmGlobal]) {
       );
       assert.match(
         (err as Error).message,
-        '<template><div>Invalid expression location</div></template>'
+        '<template><div>${...}</div></template>'
       );
       assert.match(
         (err as Error).message,

--- a/packages/labs/ssr/src/test/lib/render-lit_test.ts
+++ b/packages/labs/ssr/src/test/lib/render-lit_test.ts
@@ -505,6 +505,28 @@ for (const global of [emptyVmGlobal, shimmedVmGlobal]) {
   });
 
   test('calls customElementRendered', () => {});
+
+  /* Invalid Expression Locations */
+
+  test('throws a descriptive error for invalid expression locations', async () => {
+    const {render, templateUsingAnInvalidExpressLocation} = await setup();
+    try {
+      render(templateUsingAnInvalidExpressLocation());
+    } catch (err: unknown) {
+      assert.match(
+        (err as Error).message,
+        'Unexpected final partIndex: 0 !== 1 while processing the following template:'
+      );
+      assert.match(
+        (err as Error).message,
+        '<template><div>Invalid expression location</div></template>'
+      );
+      assert.match(
+        (err as Error).message,
+        'https://lit.dev/docs/templates/expressions/#invalid-locations'
+      );
+    }
+  });
 }
 
 test.run();

--- a/packages/labs/ssr/src/test/test-files/render-test-module.ts
+++ b/packages/labs/ssr/src/test/test-files/render-test-module.ts
@@ -277,3 +277,9 @@ export class TestShadowrootdelegatesfocus extends LitElement {
 }
 
 export const shadowrootdelegatesfocus = html`<test-shadowrootdelegatesfocus></test-shadowrootdelegatesfocus>`;
+
+/* Invalid Expression Locations */
+export const templateUsingAnInvalidExpressLocation = () => {
+  const value = 'Invalid expression location';
+  return html`<template><div>${value}</div></template>`;
+};


### PR DESCRIPTION
Fixes #4012

This PR adds the template causing the problem as well as some additional information about why the error might be occurring.