### PR TITLE
chore: remove private labs/compiler package from release notes

### DIFF
--- a/.changeset/swift-badgers-suffer.md
+++ b/.changeset/swift-badgers-suffer.md
@@ -1,6 +1,5 @@
 ---
 '@lit/localize-tools': patch
-'@lit-labs/compiler': patch
 '@lit-labs/ssr': patch
 ---
 


### PR DESCRIPTION
### Context

During release (https://github.com/lit/lit/pull/4189), noticed that there was a compiler version bump. That isn't required yet for a private package.

This change means the compiler will not get version bumped.


Low risk change.