### PR TITLE
chore: sync package-lock post release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29345,7 +29345,7 @@
     },
     "packages/labs/context": {
       "name": "@lit-labs/context",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit/reactive-element": "^1.5.0",
@@ -29504,7 +29504,7 @@
     },
     "packages/labs/react": {
       "name": "@lit-labs/react",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@lit-internal/scripts": "^1.0.0",
@@ -30190,7 +30190,7 @@
     },
     "packages/labs/ssr": {
       "name": "@lit-labs/ssr",
-      "version": "3.1.5",
+      "version": "3.1.6",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit-labs/ssr-client": "^1.1.0",
@@ -30479,7 +30479,7 @@
     },
     "packages/localize-tools": {
       "name": "@lit/localize-tools",
-      "version": "0.6.9",
+      "version": "0.6.10",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit/localize": "^0.11.0",


### PR DESCRIPTION
### Context

After release we have a manual step to sync our package-lock.

### Process

`npm install` from root, and then generate this PR.
