### PR TITLE
Support @provide with experimental decorators on a property

### DIFF
--- a/.changeset/wild-rats-wave.md
+++ b/.changeset/wild-rats-wave.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/context': patch
+---
+
+Support @provide with experimental decorators on a property. Previously we only supported it on an accessor, which happened automatically if used with @state or @property.

--- a/packages/labs/context/src/lib/decorators/provide.ts
+++ b/packages/labs/context/src/lib/decorators/provide.ts
@@ -86,17 +86,14 @@ export function provide<ValueType>({
       );
       let newDescriptor;
       if (descriptor === undefined) {
-        const symbol = Symbol();
+        const valueMap = new WeakMap<ReactiveElement, ValueType>();
         newDescriptor = {
-          get: function (this: ReactiveElement & {[symbol]: ValueType}) {
-            return this[symbol];
+          get: function (this: ReactiveElement) {
+            return valueMap.get(this);
           },
-          set: function (
-            this: ReactiveElement & {[symbol]: ValueType},
-            value: ValueType
-          ) {
-            controllerMap.get(this)?.setValue(value);
-            this[symbol] = value;
+          set: function (this: ReactiveElement, value: ValueType) {
+            controllerMap.get(this)!.setValue(value);
+            valueMap.set(this, value);
           },
         };
       } else {
@@ -105,9 +102,7 @@ export function provide<ValueType>({
           ...descriptor,
           set: function (this: ReactiveElement, value: ValueType) {
             controllerMap.get(this)?.setValue(value);
-            if (oldSetter) {
-              oldSetter.call(this, value);
-            }
+            oldSetter?.call(this, value);
           },
         };
       }

--- a/packages/labs/context/src/test/decorators/provide_test.ts
+++ b/packages/labs/context/src/test/decorators/provide_test.ts
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {Context, consume, provide} from '@lit-labs/context';
+import {assert} from 'chai';
+import {LitElement, TemplateResult, html} from 'lit';
+
+const simpleContext = 'simple-context' as Context<'simple-context', number>;
+
+test(`@provide on a property, not an accessor`, async () => {
+  class ProviderWithoutAccessorElement extends LitElement {
+    // Note that value doesn't use `accessor`, or `@property()`, or `@state`
+    @provide({context: simpleContext})
+    value = 0;
+
+    override render(): TemplateResult {
+      return html`<simple-consumer></simple-consumer>`;
+    }
+  }
+  customElements.define(
+    'provider-without-accessor',
+    ProviderWithoutAccessorElement
+  );
+  class SimpleConsumer extends LitElement {
+    @consume({context: simpleContext, subscribe: true})
+    value = -1;
+
+    override render(): TemplateResult {
+      return html``;
+    }
+  }
+  customElements.define('simple-consumer', SimpleConsumer);
+
+  const provider = document.createElement(
+    'provider-without-accessor'
+  ) as ProviderWithoutAccessorElement;
+  document.body.appendChild(provider);
+  // The field's value is written with its initial value.
+  assert.equal(provider.value, 0);
+  await provider.updateComplete;
+  const consumer = provider.shadowRoot?.querySelector(
+    'simple-consumer'
+  ) as SimpleConsumer;
+  // The consumer's value is written with the provider's initial value.
+  assert.equal(provider.value, 0);
+  assert.equal(consumer.value, 0);
+
+  // Updating the provider also updates the subscribing consumer.
+  provider.value = 1;
+  await provider.updateComplete;
+  assert.equal(provider.value, 1);
+  assert.equal(consumer.value, 1);
+});

--- a/packages/labs/context/src/test/decorators/provide_test.ts
+++ b/packages/labs/context/src/test/decorators/provide_test.ts
@@ -5,7 +5,7 @@
  */
 
 import {Context, consume, provide} from '@lit-labs/context';
-import {assert} from 'chai';
+import {assert} from '@esm-bundle/chai';
 import {LitElement, TemplateResult, html} from 'lit';
 
 const simpleContext = 'simple-context' as Context<'simple-context', number>;

--- a/packages/labs/context/src/test/provider-consumer_test.ts
+++ b/packages/labs/context/src/test/provider-consumer_test.ts
@@ -7,13 +7,7 @@
 import {LitElement, html, TemplateResult} from 'lit';
 import {property} from 'lit/decorators/property.js';
 
-import {
-  ContextProvider,
-  Context,
-  ContextConsumer,
-  provide,
-  consume,
-} from '@lit-labs/context';
+import {ContextProvider, Context, ContextConsumer} from '@lit-labs/context';
 import {assert} from '@esm-bundle/chai';
 
 const simpleContext = 'simple-context' as Context<'simple-context', number>;
@@ -142,50 +136,5 @@ suite('context-provider', () => {
     provider.setValue(500);
     assert.strictEqual(consumer.value, 500);
     assert.strictEqual(consumer2.value, 1000); // one-time consumer still has old value
-  });
-
-  test(`@provide on a property, not an accessor`, async () => {
-    class ProviderWithoutAccessorElement extends LitElement {
-      // Note that value doesn't use `accessor`, or `@property()`, or `@state`
-      @provide({context: simpleContext})
-      value = 0;
-
-      override render(): TemplateResult {
-        return html`<simple-consumer></simple-consumer>`;
-      }
-    }
-    customElements.define(
-      'provider-without-accessor',
-      ProviderWithoutAccessorElement
-    );
-    class SimpleConsumer extends LitElement {
-      @consume({context: simpleContext, subscribe: true})
-      value = -1;
-
-      override render(): TemplateResult {
-        return html``;
-      }
-    }
-    customElements.define('simple-consumer', SimpleConsumer);
-
-    const provider = document.createElement(
-      'provider-without-accessor'
-    ) as ProviderWithoutAccessorElement;
-    document.body.appendChild(provider);
-    // The field's value is written with its initial value.
-    assert.equal(provider.value, 0);
-    await provider.updateComplete;
-    const consumer = provider.shadowRoot?.querySelector(
-      'simple-consumer'
-    ) as SimpleConsumer;
-    // The consumer's value is written with the provider's initial value.
-    assert.equal(provider.value, 0);
-    assert.equal(consumer.value, 0);
-
-    // Updating the provider also updates the subscribing consumer.
-    provider.value = 1;
-    await provider.updateComplete;
-    assert.equal(provider.value, 1);
-    assert.equal(consumer.value, 1);
   });
 });

--- a/packages/labs/context/src/test/provider-consumer_test.ts
+++ b/packages/labs/context/src/test/provider-consumer_test.ts
@@ -7,7 +7,13 @@
 import {LitElement, html, TemplateResult} from 'lit';
 import {property} from 'lit/decorators/property.js';
 
-import {ContextProvider, Context, ContextConsumer} from '@lit-labs/context';
+import {
+  ContextProvider,
+  Context,
+  ContextConsumer,
+  provide,
+  consume,
+} from '@lit-labs/context';
 import {assert} from '@esm-bundle/chai';
 
 const simpleContext = 'simple-context' as Context<'simple-context', number>;
@@ -136,5 +142,50 @@ suite('context-provider', () => {
     provider.setValue(500);
     assert.strictEqual(consumer.value, 500);
     assert.strictEqual(consumer2.value, 1000); // one-time consumer still has old value
+  });
+
+  test(`@provide on a property, not an accessor`, async () => {
+    class ProviderWithoutAccessorElement extends LitElement {
+      // Note that value doesn't use `accessor`, or `@property()`, or `@state`
+      @provide({context: simpleContext})
+      value = 0;
+
+      override render(): TemplateResult {
+        return html`<simple-consumer></simple-consumer>`;
+      }
+    }
+    customElements.define(
+      'provider-without-accessor',
+      ProviderWithoutAccessorElement
+    );
+    class SimpleConsumer extends LitElement {
+      @consume({context: simpleContext, subscribe: true})
+      value = -1;
+
+      override render(): TemplateResult {
+        return html``;
+      }
+    }
+    customElements.define('simple-consumer', SimpleConsumer);
+
+    const provider = document.createElement(
+      'provider-without-accessor'
+    ) as ProviderWithoutAccessorElement;
+    document.body.appendChild(provider);
+    // The field's value is written with its initial value.
+    assert.equal(provider.value, 0);
+    await provider.updateComplete;
+    const consumer = provider.shadowRoot?.querySelector(
+      'simple-consumer'
+    ) as SimpleConsumer;
+    // The consumer's value is written with the provider's initial value.
+    assert.equal(provider.value, 0);
+    assert.equal(consumer.value, 0);
+
+    // Updating the provider also updates the subscribing consumer.
+    provider.value = 1;
+    await provider.updateComplete;
+    assert.equal(provider.value, 1);
+    assert.equal(consumer.value, 1);
   });
 });


### PR DESCRIPTION
It might feel like this is working at cross purposes to our standard decorators work, because those all require accessors, but I don't think so. With standard decorators we can use the type system to error out if they're used on a property instead of an accessor. With experimental decorators, they sorta work with properties, in that they do provide values and update them, but reading the value back off the field would always give undefined because we were defining it without a getter.