### PR TITLE
Put types on Map, Set, etc constructor calls

### DIFF
--- a/.changeset/nine-buttons-give.md
+++ b/.changeset/nine-buttons-give.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/ssr': patch
+---
+
+Fix an obscure potential memory leak, only keeping weak references to directive classes.

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -46,7 +46,8 @@
           "packages/labs/react/**"
         ]
       }
-    ]
+    ],
+    "@typescript-eslint/consistent-generic-constructors": "error"
   },
   "overrides": [
     {

--- a/package.json
+++ b/package.json
@@ -220,7 +220,9 @@
       "files": [
         "**/*.{js,ts}",
         ".eslintignore",
-        ".eslintrc.json"
+        ".eslintrc.json",
+        "!**/examples/**/*.{js,ts}",
+        "!node_modules/"
       ],
       "output": [],
       "command": "eslint --ignore-pattern=examples/ \"**/*.{js,ts}\""

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "format:check": "prettier \"**/*.{cjs,html,js,json,md,ts}\" --check",
     "format:fix": "prettier \"**/*.{cjs,html,js,json,md,ts}\" --write",
     "ignore-sync": "ignore-sync .",
-    "lint": "npm run lint:check",
-    "lint:check": "eslint --ignore-pattern=examples/ \"**/*.{js,ts}\"",
+    "lint": "wireit",
+    "lint:check": "wireit",
     "lint:fix": "eslint --ignore-pattern=examples/ --fix \"**/*.{js,ts}\"",
     "test": "npm run test:not-starter-kits && npm run test:lit-starter-js && npm run test:lit-starter-ts",
     "test:not-starter-kits": "wireit",
@@ -210,6 +210,20 @@
         "scripts/check-size-out.md"
       ],
       "command": "node scripts/check-size.js"
+    },
+    "lint": {
+      "dependencies": [
+        "lint:check"
+      ]
+    },
+    "lint:check": {
+      "files": [
+        "**/*.{js,ts}",
+        ".eslintignore",
+        ".eslintrc.json"
+      ],
+      "output": [],
+      "command": "eslint --ignore-pattern=examples/ \"**/*.{js,ts}\""
     }
   },
   "devDependencies": {

--- a/packages/benchmarks/generator/src/index.ts
+++ b/packages/benchmarks/generator/src/index.ts
@@ -48,7 +48,7 @@ const generateBenchmark = (
   console.log(`Generating variant ${name}`);
 
   const renderer = rendererForName(parseRenderer(opts.renderers).base)!;
-  const generatedTemplates = new Set();
+  const generatedTemplates = new Set<string>();
 
   // Generates a template for a given level
   const generateTemplate = (s = '', templateLevel = '', tag = 'div') => {

--- a/packages/benchmarks/generator/src/utils.ts
+++ b/packages/benchmarks/generator/src/utils.ts
@@ -48,7 +48,16 @@ export const nextLevel = (level: string, n: number): string => {
   return level ? `${level}_${n}` : String(n);
 };
 
-const rendererInfoMap = new Map();
+interface Info {
+  base: string;
+  query: string;
+  packageVersions: null | {
+    label: string;
+    dependencies: Record<string, string>;
+  };
+}
+
+const rendererInfoMap = new Map<string, Info>();
 export const parseRenderer = (renderer: string) => {
   if (rendererInfoMap.has(renderer)) {
     return rendererInfoMap.get(renderer);
@@ -77,7 +86,7 @@ export const parseRenderer = (renderer: string) => {
       };
     }
   }
-  const info = {
+  const info: Info = {
     base: parts[1],
     query: parts[2],
     packageVersions,

--- a/packages/labs/cli/src/lib/lit-cli.ts
+++ b/packages/labs/cli/src/lib/lit-cli.ts
@@ -31,7 +31,7 @@ export interface Options {
 }
 
 export class LitCli {
-  readonly commands: Map<string, Command> = new Map();
+  readonly commands = new Map<string, Command>();
   readonly args: readonly string[];
   readonly console: LitConsole;
   /** The current working directory. */

--- a/packages/labs/context/src/lib/decorators/provide.ts
+++ b/packages/labs/context/src/lib/decorators/provide.ts
@@ -52,7 +52,10 @@ export function provide<ValueType>({
     nameOrContext: PropertyKey | ClassAccessorDecoratorContext<C, V>
   ) => {
     // Map of instances to controllers
-    const controllerMap = new WeakMap();
+    const controllerMap = new WeakMap<
+      ReactiveElement,
+      ContextProvider<Context<unknown, ValueType>>
+    >();
     if (typeof nameOrContext === 'object') {
       // Standard decorators branch
       nameOrContext.addInitializer(function (this: C) {

--- a/packages/labs/context/src/lib/value-notifier.ts
+++ b/packages/labs/context/src/lib/value-notifier.ts
@@ -25,8 +25,10 @@ interface CallbackInfo {
  * likely work for a number of use cases.
  */
 export class ValueNotifier<T> {
-  protected readonly subscriptions: Map<ContextCallback<T>, CallbackInfo> =
-    new Map();
+  protected readonly subscriptions = new Map<
+    ContextCallback<T>,
+    CallbackInfo
+  >();
   private _value!: T;
   get value(): T {
     return this._value;

--- a/packages/labs/motion/src/animate-controller.ts
+++ b/packages/labs/motion/src/animate-controller.ts
@@ -6,8 +6,10 @@
 import {ReactiveControllerHost} from 'lit';
 import {Animate, Options} from './animate.js';
 
-export const controllerMap: WeakMap<ReactiveControllerHost, AnimateController> =
-  new WeakMap();
+export const controllerMap = new WeakMap<
+  ReactiveControllerHost,
+  AnimateController
+>();
 
 /**
  * AnimateController can be used to provide default configuration options to all
@@ -43,7 +45,7 @@ export class AnimateController {
   /**
    * Set of active `animate()` directives in the host component
    */
-  clients: Set<Animate> = new Set();
+  clients = new Set<Animate>();
 
   protected pendingComplete = false;
 

--- a/packages/labs/motion/src/animate.ts
+++ b/packages/labs/motion/src/animate.ts
@@ -19,8 +19,8 @@ export type CSSPropertiesList = string[];
 // zIndex for "in" animations
 let z = 0;
 
-const disconnectedProps: Map<unknown, CSSValues> = new Map();
-const renderedHosts: WeakSet<ReactiveControllerHost> = new WeakSet();
+const disconnectedProps = new Map<unknown, CSSValues>();
+const renderedHosts = new WeakSet<ReactiveControllerHost>();
 
 export type Options = {
   // Options used for the animation
@@ -165,7 +165,7 @@ const isDirty = (value: unknown, previous: unknown) => {
 // Mapping of node on which the `animate` directive is used to the `animate` directive.
 // Used to get the ancestor `animate` animations (which are used to modify
 // `animate` transforms), done by ascending the DOM.
-const nodeToAnimateMap: WeakMap<Node, Animate> = new WeakMap();
+const nodeToAnimateMap = new WeakMap<Node, Animate>();
 
 /**
  * `animate` directive class. Animates a node's position between renders.

--- a/packages/labs/observers/src/intersection-controller.ts
+++ b/packages/labs/observers/src/intersection-controller.ts
@@ -62,7 +62,7 @@ export interface IntersectionControllerConfig<T = unknown> {
  */
 export class IntersectionController<T = unknown> implements ReactiveController {
   private _host: ReactiveControllerHost;
-  private _targets: Set<Element> = new Set();
+  private _targets = new Set<Element>();
   private _observer!: IntersectionObserver;
   private _skipInitial = false;
   /**

--- a/packages/labs/observers/src/mutation-controller.ts
+++ b/packages/labs/observers/src/mutation-controller.ts
@@ -61,7 +61,7 @@ export interface MutationControllerConfig<T = unknown> {
  */
 export class MutationController<T = unknown> implements ReactiveController {
   private _host: ReactiveControllerHost;
-  private _targets: Set<Element> = new Set();
+  private _targets = new Set<Element>();
   private _config: MutationObserverInit;
   private _observer!: MutationObserver;
   private _skipInitial = false;

--- a/packages/labs/observers/src/resize-controller.ts
+++ b/packages/labs/observers/src/resize-controller.ts
@@ -60,7 +60,7 @@ export interface ResizeControllerConfig<T = unknown> {
  */
 export class ResizeController<T = unknown> implements ReactiveController {
   private _host: ReactiveControllerHost;
-  private _targets: Set<Element> = new Set();
+  private _targets = new Set<Element>();
   private _config?: ResizeObserverOptions;
   private _observer!: ResizeObserver;
   private _skipInitial = false;

--- a/packages/labs/react/src/create-component.ts
+++ b/packages/labs/react/src/create-component.ts
@@ -120,10 +120,7 @@ const reservedReactProperties = new Set([
   'className',
 ]);
 
-const listenedEvents: WeakMap<
-  Element,
-  Map<string, EventListenerObject>
-> = new WeakMap();
+const listenedEvents = new WeakMap<Element, Map<string, EventListenerObject>>();
 
 /**
  * Adds an event listener for the specified event to the given node. In the

--- a/packages/labs/ssr-dom-shim/src/index.ts
+++ b/packages/labs/ssr-dom-shim/src/index.ts
@@ -11,10 +11,10 @@ export {
   HYDRATE_INTERNALS_ATTR_PREFIX,
 } from './lib/element-internals.js';
 
-const attributes: WeakMap<
+const attributes = new WeakMap<
   InstanceType<typeof HTMLElementShim>,
   Map<string, string>
-> = new WeakMap();
+>();
 const attributesForElement = (
   element: InstanceType<typeof HTMLElementShim>
 ) => {

--- a/packages/labs/ssr/src/lib/render-value.ts
+++ b/packages/labs/ssr/src/lib/render-value.ts
@@ -63,8 +63,7 @@ declare module 'parse5/dist/tree-adapters/default.js' {
   }
 }
 
-const patchedDirectiveCache: WeakMap<DirectiveClass, DirectiveClass> =
-  new Map();
+const patchedDirectiveCache = new WeakMap<DirectiveClass, DirectiveClass>();
 
 /**
  * Looks for values of type `DirectiveResult` and replaces its Directive class

--- a/packages/labs/virtualizer/src/Virtualizer.ts
+++ b/packages/labs/virtualizer/src/Virtualizer.ts
@@ -126,7 +126,7 @@ export class Virtualizer {
   // TODO: (graynorton): type
   private _childMeasurements: ChildMeasurements | null = null;
 
-  private _toBeMeasured: Map<HTMLElement, unknown> = new Map();
+  private _toBeMeasured = new Map<HTMLElement, unknown>();
 
   private _rangeChanged = true;
 
@@ -203,7 +203,7 @@ export class Virtualizer {
    */
   private _lastVisible = -1;
 
-  protected _scheduled = new WeakSet();
+  protected _scheduled = new WeakSet<Function>();
 
   /**
    * Invoked at the end of each render cycle: children in the range are

--- a/packages/labs/virtualizer/src/layouts/flexWrap.ts
+++ b/packages/labs/virtualizer/src/layouts/flexWrap.ts
@@ -84,7 +84,7 @@ export class FlexWrapLayout extends SizeGapPaddingBaseLayout<FlexWrapLayoutConfi
   private _chunkSizeCache = new SizeCache();
   private _rolumnSizeCache = new SizeCache();
   private _rolumnLengthCache = new SizeCache({roundAverageSize: false});
-  // private _rolumnStartPositions: Map<number, number> = new Map();
+  // private _rolumnStartPositions = new Map<number, number>();
   private _aspectRatios: AspectRatios = {};
   private _numberOfAspectRatiosMeasured = 0;
   // protected _config: FlexWrapLayoutConfig = {};

--- a/packages/labs/virtualizer/src/layouts/flow.ts
+++ b/packages/labs/virtualizer/src/layouts/flow.ts
@@ -64,10 +64,10 @@ function collapseMargins(a: number, b: number): number {
 class MetricsCache {
   private _childSizeCache = new SizeCache();
   private _marginSizeCache = new SizeCache();
-  private _metricsCache: Map<number, Size & Margins> = new Map();
+  private _metricsCache = new Map<number, Size & Margins>();
 
   update(metrics: {[key: number]: Size & Margins}, direction: ScrollDirection) {
-    const marginsToUpdate: Set<number> = new Set();
+    const marginsToUpdate = new Set<number>();
     Object.keys(metrics).forEach((key) => {
       const k = Number(key);
       this._metricsCache.set(k, metrics[k]);
@@ -127,13 +127,13 @@ export class FlowLayout extends BaseLayout<BaseLayoutConfig> {
    * Indices of children mapped to their (position and length) in the scrolling
    * direction. Used to keep track of children that are in range.
    */
-  _physicalItems: Map<number, ItemBounds> = new Map();
+  _physicalItems = new Map<number, ItemBounds>();
 
   /**
    * Used in tandem with _physicalItems to track children in range across
    * reflows.
    */
-  _newPhysicalItems: Map<number, ItemBounds> = new Map();
+  _newPhysicalItems = new Map<number, ItemBounds>();
 
   /**
    * Width and height of children by their index.

--- a/packages/labs/virtualizer/src/layouts/masonry.ts
+++ b/packages/labs/virtualizer/src/layouts/masonry.ts
@@ -46,8 +46,8 @@ type MinOrMax = 'MIN' | 'MAX';
 
 export class MasonryLayout extends GridBaseLayout<MasonryLayoutConfig> {
   private _RANGE_MAP_GRANULARITY = 100;
-  private _positions: Map<number, Positions> = new Map();
-  private _rangeMap: Map<number, RangeMapEntry> = new Map();
+  private _positions = new Map<number, Positions>();
+  private _rangeMap = new Map<number, RangeMapEntry>();
   private _getAspectRatio?: GetAspectRatio;
 
   protected _getDefaultConfig(): MasonryLayoutConfig {

--- a/packages/labs/virtualizer/src/layouts/shared/SizeCache.ts
+++ b/packages/labs/virtualizer/src/layouts/shared/SizeCache.ts
@@ -9,7 +9,7 @@ export interface SizeCacheConfig {
 }
 
 export class SizeCache {
-  private _map: Map<number | string, number> = new Map();
+  private _map = new Map<number | string, number>();
   private _roundAverageSize = false;
   totalSize = 0;
 

--- a/packages/labs/virtualizer/src/test/scenarios/element-and-directive-parity.test.ts
+++ b/packages/labs/virtualizer/src/test/scenarios/element-and-directive-parity.test.ts
@@ -22,7 +22,7 @@ abstract class TestElement extends LitElement {
   `;
 
   @property({type: Object, attribute: false})
-  public selected: Set<number> = new Set();
+  public selected = new Set<number>();
 
   @property({type: Array, attribute: false})
   public items: Array<number> = [];

--- a/packages/lit-html/src/directives/ref.ts
+++ b/packages/lit-html/src/directives/ref.ts
@@ -33,10 +33,10 @@ interface RefInternal {
 // has already been rendered to a new spot. It is double-keyed on both the
 // context (`options.host`) and the callback, since we auto-bind class methods
 // to `options.host`.
-const lastElementForContextAndCallback: WeakMap<
+const lastElementForContextAndCallback = new WeakMap<
   object,
   WeakMap<Function, Element | undefined>
-> = new WeakMap();
+>();
 
 export type RefOrCallback<T = Element> = Ref<T> | ((el: T | undefined) => void);
 

--- a/packages/lit-html/src/polyfill-support.ts
+++ b/packages/lit-html/src/polyfill-support.ts
@@ -80,10 +80,10 @@ interface PatchableTemplateInstance {
 
 // Scopes that have had styling prepared. Note, must only be done once per
 // scope.
-const styledScopes: Set<string> = new Set();
+const styledScopes = new Set<string>();
 // Map of css per scope. This is collected during first scope render, used when
 // styling is prepared, and then discarded.
-const scopeCssStore: Map<string, string[]> = new Map();
+const scopeCssStore = new Map<string, string[]>();
 
 const ENABLE_SHADYDOM_NOPATCH = true;
 

--- a/packages/lit-html/src/test/directives/test-async-iterable.ts
+++ b/packages/lit-html/src/test/directives/test-async-iterable.ts
@@ -16,7 +16,7 @@ export class TestAsyncIterable<T> implements AsyncIterable<T> {
    * A Promise that resolves with the next value to be returned by the
    * async iterable returned from iterable()
    */
-  private _nextValue: Promise<T> = new Promise(
+  private _nextValue = new Promise<T>(
     (resolve) => (this._resolveNextValue = resolve)
   );
   private _resolveNextValue!: (value: T) => void;

--- a/packages/lit-html/src/test/directives/until_test.ts
+++ b/packages/lit-html/src/test/directives/until_test.ts
@@ -843,7 +843,7 @@ suite('until directive', () => {
       const heap = performance.memory.usedJSHeapSize;
       for (let i = 0; i < 1000; i++) {
         // Promise passed to until that will never resolve
-        const promise: Promise<void> = new Promise((r) => resolvers.push(r));
+        const promise = new Promise<void>((r) => resolvers.push(r));
         // Render the until into a `<span>` with a 10kb expando, to exaggerate
         // when DOM is not being gc'ed
         render(

--- a/packages/reactive-element/src/reactive-element.ts
+++ b/packages/reactive-element/src/reactive-element.ts
@@ -1047,7 +1047,7 @@ export abstract class ReactiveElement
    * the native platform default).
    */
   private __saveInstanceProperties() {
-    const instanceProperties = new Map();
+    const instanceProperties = new Map<PropertyKey, unknown>();
     const elementProperties = (this.constructor as typeof ReactiveElement)
       .elementProperties;
     for (const p of elementProperties.keys() as IterableIterator<keyof this>) {
@@ -1057,7 +1057,7 @@ export abstract class ReactiveElement
       }
     }
     if (instanceProperties.size > 0) {
-      this.__instanceProperties = instanceProperties as PropertyValues<this>;
+      this.__instanceProperties = instanceProperties;
     }
   }
 
@@ -1282,7 +1282,10 @@ export abstract class ReactiveElement
     // property to `_reflectingProperties`. This ensures setting
     // attribute + property reflects correctly.
     if (options.reflect === true && this.__reflectingProperty !== name) {
-      (this.__reflectingProperties ??= new Map()).set(name, options);
+      (this.__reflectingProperties ??= new Map<
+        PropertyKey,
+        PropertyDeclaration<unknown, unknown>
+      >()).set(name, options);
     }
   }
 

--- a/packages/reactive-element/src/test/reactive-element_test.ts
+++ b/packages/reactive-element/src/test/reactive-element_test.ts
@@ -1354,7 +1354,7 @@ suite('ReactiveElement', () => {
     const el = new E();
     container.appendChild(el);
     await el.updateComplete;
-    const testMap = new Map();
+    const testMap = new Map<string, unknown>();
     testMap.set('foo', undefined);
     assert.deepEqual(el.changedProperties, testMap);
     assert.equal(el.wasUpdatedCount, 1);
@@ -1404,7 +1404,7 @@ suite('ReactiveElement', () => {
     assert.equal(el.wasFirstUpdated, 0);
     el.requestUpdate();
     await el.updateComplete;
-    const testMap = new Map();
+    const testMap = new Map<never, never>();
     assert.deepEqual(el.changedProperties, testMap);
     assert.equal(el.triedToUpdatedCount, 2);
     assert.equal(el.wasUpdatedCount, 1);
@@ -1547,7 +1547,7 @@ suite('ReactiveElement', () => {
     const el = new E() as any;
     container.appendChild(el);
     await el.updateComplete;
-    const testMap = new Map();
+    const testMap = new Map<string, unknown>();
     testMap.set('zot', undefined);
     assert.deepEqual(el.changedProperties, testMap);
     assert.isNaN(el.zot);
@@ -2866,7 +2866,7 @@ suite('ReactiveElement', () => {
       await a.updateComplete;
       assert.equal(a.updatedFoo, 5);
       shouldThrow = true;
-      a.changedProps = new Map();
+      a.changedProps = new Map<never, never>();
       a.foo = 10;
       let threw = false;
       try {


### PR DESCRIPTION
These default to overbroad types like `any` and `object`.

Didn't change all tests, nor cases where we're assigning to an existing thing that has a type.