### PR TITLE
chore: sync package-lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26321,6 +26321,7 @@
       }
     },
     "packages/context": {
+      "name": "@lit/context",
       "version": "0.0.0",
       "license": "BSD-3-Clause",
       "dependencies": {


### PR DESCRIPTION
Adds one line, the name of the new context package.

This PR was created by running `npm install`.