### PR TITLE
[repro] Next.js dynamic ref is broken

### DIFF
--- a/examples/nextjs/pages/index.tsx
+++ b/examples/nextjs/pages/index.tsx
@@ -1,33 +1,33 @@
 import Head from 'next/head';
 import styles from '../styles/Home.module.css';
 import '../src/simple-greeter';
+import {SimpleGreeter as SimpleGreeterWC} from '../src/simple-greeter';
 import SimpleGreeter from '../src/simple-greeter-react';
 
-export default function Home() {
-  return (
-    <div className={styles.container}>
-      <Head>
-        <title>Lit in Next.js</title>
-        <link rel="icon" href="/flame-favicon.svg" />
-      </Head>
+import React from "react";
+import dynamic from "next/dynamic";
 
-      <main className={styles.main}>
-        <h1 className={styles.title}>
-          Welcome to <a href="https://lit.dev">Lit</a> and{' '}
-          <a href="https://nextjs.org">Next.js!</a>
-        </h1>
-        <p className={styles.description}>
-          The component below is a web component #builtWithLit
-        </p>
-        <simple-greeter name="Friend"></simple-greeter>
-        <p className={styles.description}>
-          The component below is a component wrapped with{' '}
-          <a href="https://github.com/lit/lit/tree/main/packages/labs/react">
-            <code>@lit-labs/react</code>
-          </a>
-        </p>
-        <SimpleGreeter name="React" />
-      </main>
-    </div>
+const MySimpleGreeter = dynamic(() => import('../src/simple-greeter-react').then((el) => {
+  console.log('got el', el);
+  return el;
+}), {ssr: false});
+
+console.log(MySimpleGreeter);
+
+const Page = () => {
+  const ref = React.useRef();
+
+  // The primary issue is this ref issue.
+  const focusEl = () => ref.current.focus();
+
+  return (
+    <>
+      {/* <input ref={ref} /> */}
+      <MySimpleGreeter ref={ref} />
+      {/* <SimpleGreeter ref={ref} /> */}
+      <button onClick={focusEl}>Click me</button>
+    </>
   );
 }
+
+export default Page;


### PR DESCRIPTION
Reproduces https://github.com/lit/lit/issues/2951

The only issue that still reproduces seems to be `ref` behavior with the dynamically imported component.

Repro by running `npm run dev`, and pressing btn to see `ref` fail. It works if the react component is imported normally (not via `dynamic`).
