### PR TITLE
feat(labs-react): export Options interface

### DIFF
--- a/.changeset/yellow-waves-pay.md
+++ b/.changeset/yellow-waves-pay.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/react': minor
+---
+
+export Options interface

--- a/packages/labs/react/src/create-component.ts
+++ b/packages/labs/react/src/create-component.ts
@@ -76,7 +76,7 @@ type ComponentProps<I, E extends EventNames = {}> = Omit<
  * Example:
  *
  * ```ts
- * const FooComponent = createCompoennt({
+ * const FooComponent = createComponent({
  *   ...
  *   events: {
  *     onfoo: 'foo' as EventName<FooEvent>,
@@ -100,7 +100,7 @@ type EventListeners<R extends EventNames> = {
     : (e: Event) => void;
 };
 
-interface Options<I extends HTMLElement, E extends EventNames = {}> {
+export interface Options<I extends HTMLElement, E extends EventNames = {}> {
   react: typeof React;
   tagName: string;
   elementClass: Constructor<I>;


### PR DESCRIPTION
I have the following code to avoid repeating passing React on every `createComponent` call.

```ts
import * as React from 'react';
import { createComponent as createReactComponent } from '@lit-labs/react';
import type { EventName } from '@lit-labs/react';

type EventNames = Record<string, EventName | string>;

type Constructor<T> = new () => T;

export const createComponent = <
	I extends HTMLElement,
	E extends EventNames = {},
>(options: {
	tagName: string;
	elementClass: Constructor<I>;
	events?: E;
	displayName?: string;
}) => {
	return createReactComponent<I, E>({ react: React, ...options });
};
```

I want to be able to

```ts
import * as React from 'react';
import { createComponent as createReactComponent } from '@lit-labs/react';
import type { EventName, Options } from '@lit-labs/react';

type EventNames = Record<string, EventName | string>;

export const createComponent = <
	I extends HTMLElement,
	E extends EventNames = {},
>(options: Omit<Options<I, E>, 'react'> ) => {
	return createReactComponent<I, E>({ react: React, ...options });
};
```

This PR fixes `createCompoennt` typo and exports the `Options` interface.