### PR TITLE
Clarify keyframeOptions in motion

### DIFF
--- a/packages/labs/motion/README.md
+++ b/packages/labs/motion/README.md
@@ -22,7 +22,7 @@ The directive supports a number of options:
 
 | Option          | Usage                                                                                                          |
 | --------------- | -------------------------------------------------------------------------------------------------------------- |
-| keyframeOptions | configure animation via standard KeyframeAnimationOptions                                                      |
+| keyframeOptions | configure animation via the [KeyframeEffect Options](https://developer.mozilla.org/en-US/docs/Web/API/KeyframeEffect/KeyframeEffect#parameters) from the Web Animation API.  |
 | properties      | list of properties to animate, defaults to ['left', 'top','width', 'height', 'opacity', 'color', 'background'] |
 | disabled        | disables animation                                                                                             |
 | guard           | function producing values that must change for the `animate` to run                                            |


### PR DESCRIPTION
Thanks for creating lit motion! It's super helpful!!

When I read the documentation (README), I found the phrase "standard KeyframeAnimationOptions" confusing. The top Google search result is Apple's iOS UIKit developer guide.

Based on the [source code](https://github.com/lit/lit/blob/7175d11aa17abfda4adb75757abae1a6ee5b04ad/packages/labs/motion/src/animate.ts#L374C34-L374C50), I believe the parameter `keyframeOptions` is used as the KeyframeEffect Options to construct `animate()`.  Therefore, I slightly modify the README to point users to the API documentation.