### PR TITLE
Format the README of labs/motion

### DIFF
--- a/packages/labs/motion/README.md
+++ b/packages/labs/motion/README.md
@@ -20,20 +20,20 @@ are removed.
 
 The directive supports a number of options:
 
-| Option          | Usage                                                                                                          |
-| --------------- | -------------------------------------------------------------------------------------------------------------- |
-| keyframeOptions | configure animation via the [KeyframeEffect Options](https://developer.mozilla.org/en-US/docs/Web/API/KeyframeEffect/KeyframeEffect#parameters) from the Web Animation API.  |
-| properties      | list of properties to animate, defaults to ['left', 'top','width', 'height', 'opacity', 'color', 'background'] |
-| disabled        | disables animation                                                                                             |
-| guard           | function producing values that must change for the `animate` to run                                            |
-| in              | keyframes to use when animating in                                                                             |
-| out             | keyframes to use when animating out                                                                            |
-| skipInitial     | skip animating in the first time                                                                               |
-| id              | used to link to other `animate`'s via `inId`                                                                   |
-| inId            | id of the `animate` to render from when animating in                                                           |
-| onStart         | run when the `animate` starts                                                                                  |
-| onComplete      | run when the `animate` completes                                                                               |
-| onFrames        | run when the frames are produced, use to modify frames                                                         |
+| Option          | Usage                                                                                                                                                                       |
+| --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| keyframeOptions | configure animation via the [KeyframeEffect Options](https://developer.mozilla.org/en-US/docs/Web/API/KeyframeEffect/KeyframeEffect#parameters) from the Web Animation API. |
+| properties      | list of properties to animate, defaults to ['left', 'top','width', 'height', 'opacity', 'color', 'background']                                                              |
+| disabled        | disables animation                                                                                                                                                          |
+| guard           | function producing values that must change for the `animate` to run                                                                                                         |
+| in              | keyframes to use when animating in                                                                                                                                          |
+| out             | keyframes to use when animating out                                                                                                                                         |
+| skipInitial     | skip animating in the first time                                                                                                                                            |
+| id              | used to link to other `animate`'s via `inId`                                                                                                                                |
+| inId            | id of the `animate` to render from when animating in                                                                                                                        |
+| onStart         | run when the `animate` starts                                                                                                                                               |
+| onComplete      | run when the `animate` completes                                                                                                                                            |
+| onFrames        | run when the frames are produced, use to modify frames                                                                                                                      |
 
 ### How it works
 

--- a/packages/labs/motion/README.md
+++ b/packages/labs/motion/README.md
@@ -22,7 +22,7 @@ The directive supports a number of options:
 
 | Option          | Usage                                                                                                          |
 | --------------- | -------------------------------------------------------------------------------------------------------------- |
-| keyframeOptions | configure animation via standard KeyframeAnimationOptions                                                      |
+| keyframeOptions | configure animation via the [KeyframeEffect Options](https://developer.mozilla.org/en-US/docs/Web/API/KeyframeEffect/KeyframeEffect#parameters) from the Web Animation API.  |
 | properties      | list of properties to animate, defaults to ['left', 'top','width', 'height', 'opacity', 'color', 'background'] |
 | disabled        | disables animation                                                                                             |
 | guard           | function producing values that must change for the `animate` to run                                            |


### PR DESCRIPTION
I forgot to run prettier in #4234. This PR fixes the format of README file in labs/motion.