### PR TITLE
fix (labs/analyzer): use analyzer typescript instead of import

### DIFF
--- a/.changeset/hot-apricots-type.md
+++ b/.changeset/hot-apricots-type.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/analyzer': patch
+---
+
+Always use consumer's typescript rather than analyzer's dependency to avoid version mismatches

--- a/packages/labs/analyzer/src/lib/lit-element/lit-element.ts
+++ b/packages/labs/analyzer/src/lib/lit-element/lit-element.ts
@@ -34,7 +34,7 @@ export const getLitElementDeclaration = (
   analyzer: AnalyzerInterface
 ): LitElementDeclaration => {
   return new LitElementDeclaration({
-    tagname: getTagName(analyzer.typescript, declaration),
+    tagname: getTagName(declaration, analyzer),
     // TODO(kschaaf): support anonymous class expressions when assigned to a const
     name: declaration.name?.text ?? '',
     node: declaration,
@@ -127,19 +127,23 @@ export const isLitElementSubclass = (
  * @returns
  */
 export const getTagName = (
-  ts: TypeScript,
-  declaration: LitClassDeclaration
+  declaration: LitClassDeclaration,
+  analyzer: AnalyzerInterface
 ) => {
-  const customElementDecorator = ts
+  const customElementDecorator = analyzer.typescript
     .getDecorators(declaration)
-    ?.find((d): d is CustomElementDecorator => isCustomElementDecorator(ts, d));
+    ?.find((d): d is CustomElementDecorator =>
+      isCustomElementDecorator(analyzer.typescript, d)
+    );
   if (
     customElementDecorator !== undefined &&
     customElementDecorator.expression.arguments.length === 1 &&
-    ts.isStringLiteral(customElementDecorator.expression.arguments[0])
+    analyzer.typescript.isStringLiteral(
+      customElementDecorator.expression.arguments[0]
+    )
   ) {
     // Get tag from decorator: `@customElement('x-foo')`
     return customElementDecorator.expression.arguments[0].text;
   }
-  return getCustomElementTagName(declaration);
+  return getCustomElementTagName(declaration, analyzer);
 };


### PR DESCRIPTION
There are still some places where we use methods available on our imported `ts` rather than from the analyzer's reference (`analyzer.typescript`). This causes various problems with version mismatches and bundling.

These have now been updated to use the analyzer's typescript.

### Related question

While doing this change, I noticed we generally follow two common signatures for our functions:

- `(node, analyzer)`
- `(ts, node)`

For the latter, it does make a sense from a purist point of view... type guards and what not which operate purely on a given AST node don't need the analyzer in theory, so they accept a typescript lib ref instead.

But it does mean we switch back and forth inconsistently sometimes between these signatures. maybe we want to _always_ pass an analyzer and just pull the typescript from that?