### PR TITLE
[infra] sync 3.0 package-lock after second pre-release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,16 +58,16 @@
     },
     "examples/nextjs": {
       "name": "@lit-examples/nextjs",
-      "version": "0.1.0",
+      "version": "0.1.1-pre.0",
       "dependencies": {
-        "@lit-labs/nextjs": "*",
-        "@lit/react": "*",
+        "@lit-labs/nextjs": "0.1.2-pre.1",
+        "@lit/react": "1.0.0-pre.0",
         "@types/node": "^18.11.11",
         "@types/react": "^18.0.26",
         "@types/react-dom": "^18.0.9",
         "eslint": "^8.29.0",
         "eslint-config-next": "^13.0.6",
-        "lit": "*",
+        "lit": "3.0.0-pre.1",
         "next": "^13.0.6",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -80,9 +80,9 @@
     },
     "examples/preact": {
       "name": "@lit-examples/preact",
-      "version": "0.0.0",
+      "version": "0.0.1-pre.0",
       "dependencies": {
-        "@lit-internal/test-elements-react": "*",
+        "@lit-internal/test-elements-react": "1.0.1-pre.0",
         "preact": "^10.15.1"
       },
       "devDependencies": {
@@ -26039,12 +26039,12 @@
     },
     "packages/benchmarks": {
       "name": "@lit-internal/benchmarks",
-      "version": "1.0.4",
+      "version": "1.0.5-pre.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit/reactive-element": "^2.0.0-pre.0",
-        "lit-element": "^4.0.0-pre.0",
-        "lit-html": "^3.0.0-pre.0",
+        "@lit/reactive-element": "^2.0.0-pre.1",
+        "lit-element": "^4.0.0-pre.1",
+        "lit-html": "^3.0.0-pre.1",
         "tachometer": "^0.7.0"
       },
       "devDependencies": {
@@ -26053,11 +26053,11 @@
     },
     "packages/context": {
       "name": "@lit/context",
-      "version": "0.0.0",
+      "version": "1.0.0-pre.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit/reactive-element": "^2.0.0-pre.0",
-        "lit": "^3.0.0-pre.0"
+        "@lit/reactive-element": "^2.0.0-pre.1",
+        "lit": "^3.0.0-pre.1"
       },
       "devDependencies": {
         "@esm-bundle/chai": "^4.3.4-fix.0",
@@ -26068,7 +26068,7 @@
     },
     "packages/internal-scripts": {
       "name": "@lit-internal/scripts",
-      "version": "1.0.1-pre.0",
+      "version": "1.0.1-pre.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@types/node": "^16.7.8",
@@ -26093,7 +26093,7 @@
     },
     "packages/labs/analyzer": {
       "name": "@lit-labs/analyzer",
-      "version": "0.9.2",
+      "version": "0.10.0-pre.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "package-json-type": "^1.0.3",
@@ -26102,12 +26102,12 @@
     },
     "packages/labs/cli": {
       "name": "@lit-labs/cli",
-      "version": "0.6.0",
+      "version": "0.6.1-pre.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/analyzer": "^0.9.0",
-        "@lit-labs/gen-utils": "^0.2.0",
-        "@lit/localize-tools": "^0.7.0-pre.0",
+        "@lit-labs/analyzer": "^0.10.0-pre.0",
+        "@lit-labs/gen-utils": "^0.3.0-pre.0",
+        "@lit/localize-tools": "^0.7.0-pre.1",
         "chalk": "^5.0.1",
         "command-line-args": "^5.2.1",
         "command-line-commands": "^3.0.2",
@@ -26130,10 +26130,10 @@
     },
     "packages/labs/cli-localize": {
       "name": "@lit-labs/cli-localize",
-      "version": "0.1.1-pre.0",
+      "version": "0.2.0-pre.1",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit/localize-tools": "^0.7.0-pre.0"
+        "@lit/localize-tools": "^0.7.0-pre.1"
       },
       "devDependencies": {
         "typescript": "~5.2.0"
@@ -26154,11 +26154,11 @@
     },
     "packages/labs/compiler": {
       "name": "@lit-labs/compiler",
-      "version": "0.0.0",
+      "version": "1.0.0-pre.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@parse5/tools": "^0.3.0",
-        "lit-html": "^3.0.0-pre.0",
+        "lit-html": "^3.0.0-pre.1",
         "parse5": "^7.1.2",
         "typescript": "~5.2.0"
       },
@@ -26245,10 +26245,10 @@
     },
     "packages/labs/context": {
       "name": "@lit-labs/context",
-      "version": "0.4.1",
+      "version": "0.5.0-pre.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit/context": "<2.0.0"
+        "@lit/context": "1.0.0-pre.0"
       },
       "devDependencies": {
         "@esm-bundle/chai": "^4.3.4-fix.0",
@@ -26259,11 +26259,11 @@
     },
     "packages/labs/eleventy-plugin-lit": {
       "name": "@lit-labs/eleventy-plugin-lit",
-      "version": "1.0.2-pre.0",
+      "version": "1.0.2-pre.1",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/ssr": "^3.1.3-pre.0",
-        "lit": "^3.0.0-pre.0"
+        "@lit-labs/ssr": "^3.1.8-pre.0",
+        "lit": "^3.0.0-pre.1"
       },
       "devDependencies": {
         "@11ty/eleventy": "^1.0.0",
@@ -26281,11 +26281,11 @@
     },
     "packages/labs/gen-manifest": {
       "name": "@lit-labs/gen-manifest",
-      "version": "0.2.5",
+      "version": "0.3.0-pre.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/analyzer": "^0.9.0",
-        "@lit-labs/gen-utils": "^0.2.0",
+        "@lit-labs/analyzer": "^0.10.0-pre.0",
+        "@lit-labs/gen-utils": "^0.3.0-pre.0",
         "custom-elements-manifest": "^2.0.0"
       },
       "devDependencies": {
@@ -26304,10 +26304,10 @@
     },
     "packages/labs/gen-utils": {
       "name": "@lit-labs/gen-utils",
-      "version": "0.2.4",
+      "version": "0.3.0-pre.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/analyzer": "^0.9.0"
+        "@lit-labs/analyzer": "^0.10.0-pre.0"
       },
       "devDependencies": {
         "@lit-internal/tests": "^0.0.1-pre.0"
@@ -26318,15 +26318,15 @@
     },
     "packages/labs/gen-wrapper-angular": {
       "name": "@lit-labs/gen-wrapper-angular",
-      "version": "0.0.9",
+      "version": "0.1.0-pre.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/analyzer": "^0.9.0",
-        "@lit-labs/gen-utils": "^0.2.0"
+        "@lit-labs/analyzer": "^0.10.0-pre.0",
+        "@lit-labs/gen-utils": "^0.3.0-pre.0"
       },
       "devDependencies": {
         "@esm-bundle/chai": "^4.3.4-fix.0",
-        "@lit-internal/tests": "0.0.1-pre.0",
+        "@lit-internal/tests": "0.0.1-pre.1",
         "@types/chai": "^4.0.1",
         "@types/mocha": "^9.0.0"
       },
@@ -26336,11 +26336,11 @@
     },
     "packages/labs/gen-wrapper-react": {
       "name": "@lit-labs/gen-wrapper-react",
-      "version": "0.2.7",
+      "version": "0.3.0-pre.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/analyzer": "^0.9.0",
-        "@lit-labs/gen-utils": "^0.2.0"
+        "@lit-labs/analyzer": "^0.10.0-pre.0",
+        "@lit-labs/gen-utils": "^0.3.0-pre.0"
       },
       "devDependencies": {
         "@lit-internal/tests": "^0.0.1-pre.0"
@@ -26351,11 +26351,11 @@
     },
     "packages/labs/gen-wrapper-vue": {
       "name": "@lit-labs/gen-wrapper-vue",
-      "version": "0.2.7",
+      "version": "0.3.0-pre.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/analyzer": "^0.9.0",
-        "@lit-labs/gen-utils": "^0.2.0",
+        "@lit-labs/analyzer": "^0.10.0-pre.0",
+        "@lit-labs/gen-utils": "^0.3.0-pre.0",
         "@lit-labs/vue-utils": "^0.1.1-pre.0"
       },
       "devDependencies": {
@@ -26367,10 +26367,10 @@
     },
     "packages/labs/motion": {
       "name": "@lit-labs/motion",
-      "version": "1.0.4",
+      "version": "1.0.5-pre.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "lit": "^3.0.0-pre.0"
+        "lit": "^3.0.0-pre.1"
       },
       "devDependencies": {
         "@lit-internal/scripts": "^1.0.1-pre.0",
@@ -26379,10 +26379,10 @@
     },
     "packages/labs/nextjs": {
       "name": "@lit-labs/nextjs",
-      "version": "0.1.2-pre.0",
+      "version": "0.1.2-pre.1",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/ssr-react": "^0.2.0",
+        "@lit-labs/ssr-react": "^0.2.1-pre.0",
         "imports-loader": "^4.0.1"
       },
       "peerDependencies": {
@@ -26391,10 +26391,10 @@
     },
     "packages/labs/observers": {
       "name": "@lit-labs/observers",
-      "version": "2.0.1-pre.0",
+      "version": "2.0.1-pre.1",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit/reactive-element": "^2.0.0-pre.0"
+        "@lit/reactive-element": "^2.0.0-pre.1"
       },
       "devDependencies": {
         "@lit-internal/scripts": "^1.0.1-pre.0",
@@ -26403,11 +26403,11 @@
     },
     "packages/labs/preact-signals": {
       "name": "@lit-labs/preact-signals",
-      "version": "0.0.0",
+      "version": "1.0.0-pre.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@preact/signals-core": "^1.3.0",
-        "lit": "^3.0.0-pre.0"
+        "lit": "^3.0.0-pre.1"
       },
       "devDependencies": {
         "@lit-internal/scripts": "^1.0.1-pre.0"
@@ -26415,10 +26415,10 @@
     },
     "packages/labs/react": {
       "name": "@lit-labs/react",
-      "version": "2.0.3",
+      "version": "2.1.1-pre.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit/react": "<2.0.0"
+        "@lit/react": "1.0.0-pre.0"
       },
       "devDependencies": {
         "@lit-internal/scripts": "^1.0.1-pre.0",
@@ -26996,10 +26996,10 @@
     },
     "packages/labs/router": {
       "name": "@lit-labs/router",
-      "version": "0.1.2-pre.0",
+      "version": "0.1.2-pre.1",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "lit": "^3.0.0-pre.0"
+        "lit": "^3.0.0-pre.1"
       },
       "devDependencies": {
         "@lit-internal/scripts": "^1.0.1-pre.0",
@@ -27015,11 +27015,11 @@
     },
     "packages/labs/scoped-registry-mixin": {
       "name": "@lit-labs/scoped-registry-mixin",
-      "version": "1.0.2-pre.0",
+      "version": "1.0.2-pre.1",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit/reactive-element": "^2.0.0-pre.0",
-        "lit": "^3.0.0-pre.0"
+        "@lit/reactive-element": "^2.0.0-pre.1",
+        "lit": "^3.0.0-pre.1"
       },
       "devDependencies": {
         "@lit-internal/scripts": "^1.0.1-pre.0",
@@ -27029,18 +27029,18 @@
     },
     "packages/labs/ssr": {
       "name": "@lit-labs/ssr",
-      "version": "3.1.6",
+      "version": "3.1.8-pre.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit-labs/ssr-client": "^1.1.4-pre.0",
         "@lit-labs/ssr-dom-shim": "^1.1.2-pre.0",
-        "@lit/reactive-element": "^2.0.0-pre.0",
+        "@lit/reactive-element": "^2.0.0-pre.1",
         "@parse5/tools": "^0.3.0",
         "@types/node": "^16.0.0",
         "enhanced-resolve": "^5.10.0",
-        "lit": "^3.0.0-pre.0",
-        "lit-element": "^4.0.0-pre.0",
-        "lit-html": "^3.0.0-pre.0",
+        "lit": "^3.0.0-pre.1",
+        "lit-element": "^4.0.0-pre.1",
+        "lit-html": "^3.0.0-pre.1",
         "node-fetch": "^3.2.8",
         "parse5": "^7.1.1"
       },
@@ -27070,12 +27070,12 @@
     },
     "packages/labs/ssr-client": {
       "name": "@lit-labs/ssr-client",
-      "version": "1.1.4-pre.0",
+      "version": "1.1.4-pre.1",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit/reactive-element": "^2.0.0-pre.0",
-        "lit": "^3.0.0-pre.0",
-        "lit-html": "^3.0.0-pre.0"
+        "@lit/reactive-element": "^2.0.0-pre.1",
+        "lit": "^3.0.0-pre.1",
+        "lit-html": "^3.0.0-pre.1"
       },
       "devDependencies": {
         "@lit-internal/scripts": "^1.0.1-pre.0"
@@ -27083,20 +27083,20 @@
     },
     "packages/labs/ssr-dom-shim": {
       "name": "@lit-labs/ssr-dom-shim",
-      "version": "1.1.2-pre.0",
+      "version": "1.1.2-pre.1",
       "license": "BSD-3-Clause"
     },
     "packages/labs/ssr-react": {
       "name": "@lit-labs/ssr-react",
-      "version": "0.2.0",
+      "version": "0.2.1-pre.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/ssr": "^3.1.3-pre.0",
+        "@lit-labs/ssr": "^3.1.8-pre.0",
         "@lit-labs/ssr-client": "^1.1.4-pre.0",
-        "lit": "^3.0.0-pre.0"
+        "lit": "^3.0.0-pre.1"
       },
       "devDependencies": {
-        "@lit/react": "<2.0.0",
+        "@lit/react": "1.0.0-pre.0",
         "@types/react": "^18.0.27",
         "@types/react-dom": "^18.0.10",
         "react": "^18.2.0",
@@ -27120,22 +27120,22 @@
     },
     "packages/labs/task": {
       "name": "@lit-labs/task",
-      "version": "3.0.2",
+      "version": "3.1.0-pre.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit/task": "<2.0.0"
+        "@lit/task": "1.0.0-pre.0"
       },
       "devDependencies": {
         "@lit-internal/scripts": "^1.0.1-pre.0",
         "@types/trusted-types": "^2.0.2",
-        "lit": "^3.0.0-pre.0"
+        "lit": "^3.0.0-pre.1"
       }
     },
     "packages/labs/test-projects/test-element-a": {
       "name": "@lit-internal/test-element-a",
-      "version": "1.0.1-pre.0",
+      "version": "1.0.1-pre.1",
       "dependencies": {
-        "lit": "^3.0.0-pre.0"
+        "lit": "^3.0.0-pre.1"
       },
       "devDependencies": {
         "typescript": "~5.2.0"
@@ -27143,10 +27143,10 @@
     },
     "packages/labs/test-projects/test-elements-react": {
       "name": "@lit-internal/test-elements-react",
-      "version": "1.0.0",
+      "version": "1.0.1-pre.0",
       "dependencies": {
-        "@lit-internal/test-element-a": "*",
-        "@lit/react": "*"
+        "@lit-internal/test-element-a": "1.0.1-pre.1",
+        "@lit/react": "1.0.0-pre.0"
       },
       "peerDependencies": {
         "@types/react": "^17 || ^18",
@@ -27159,14 +27159,14 @@
     },
     "packages/labs/testing": {
       "name": "@lit-labs/testing",
-      "version": "0.2.2-pre.0",
+      "version": "0.2.2-pre.1",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/ssr": "^3.1.3-pre.0",
+        "@lit-labs/ssr": "^3.1.8-pre.0",
         "@lit-labs/ssr-client": "^1.1.4-pre.0",
         "@web/test-runner-commands": "^0.6.1",
         "@webcomponents/template-shadowroot": "^0.1.0",
-        "lit": "^3.0.0-pre.0"
+        "lit": "^3.0.0-pre.1"
       },
       "devDependencies": {
         "@open-wc/testing": "^3.1.5"
@@ -27174,10 +27174,10 @@
     },
     "packages/labs/virtualizer": {
       "name": "@lit-labs/virtualizer",
-      "version": "2.0.7",
+      "version": "2.0.8-pre.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "lit": "^3.0.0-pre.0",
+        "lit": "^3.0.0-pre.1",
         "tslib": "^2.0.3"
       },
       "devDependencies": {
@@ -27188,7 +27188,7 @@
     },
     "packages/labs/vue-utils": {
       "name": "@lit-labs/vue-utils",
-      "version": "0.1.1-pre.0",
+      "version": "0.1.1-pre.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "vue": "^3.2.25"
@@ -27199,12 +27199,12 @@
       }
     },
     "packages/lit": {
-      "version": "3.0.0-pre.0",
+      "version": "3.0.0-pre.1",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit/reactive-element": "^2.0.0-pre.0",
-        "lit-element": "^4.0.0-pre.0",
-        "lit-html": "^3.0.0-pre.0"
+        "@lit/reactive-element": "^2.0.0-pre.1",
+        "lit-element": "^4.0.0-pre.1",
+        "lit-html": "^3.0.0-pre.1"
       },
       "devDependencies": {
         "@lit-internal/scripts": "^1.0.1-pre.0",
@@ -27215,12 +27215,12 @@
       }
     },
     "packages/lit-element": {
-      "version": "4.0.0-pre.0",
+      "version": "4.0.0-pre.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.1.2-pre.0",
-        "@lit/reactive-element": "^2.0.0-pre.0",
-        "lit-html": "^3.0.0-pre.0"
+        "@lit/reactive-element": "^2.0.0-pre.1",
+        "lit-html": "^3.0.0-pre.1"
       },
       "devDependencies": {
         "@lit-internal/scripts": "^1.0.1-pre.0",
@@ -27232,7 +27232,7 @@
       }
     },
     "packages/lit-html": {
-      "version": "3.0.0-pre.0",
+      "version": "3.0.0-pre.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
@@ -27247,10 +27247,10 @@
     },
     "packages/lit-starter-js": {
       "name": "@lit/lit-starter-js",
-      "version": "2.0.0-pre.0",
+      "version": "2.0.0-pre.1",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "lit": "^3.0.0-pre.0"
+        "lit": "^3.0.0-pre.1"
       },
       "devDependencies": {
         "@11ty/eleventy": "^1.0.1",
@@ -27276,10 +27276,10 @@
     },
     "packages/lit-starter-ts": {
       "name": "@lit/lit-starter-ts",
-      "version": "2.0.0-pre.0",
+      "version": "2.0.0-pre.1",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "lit": "^3.0.0-pre.0"
+        "lit": "^3.0.0-pre.1"
       },
       "devDependencies": {
         "@11ty/eleventy": "^1.0.1",
@@ -27533,25 +27533,25 @@
     },
     "packages/localize": {
       "name": "@lit/localize",
-      "version": "0.11.5-pre.0",
+      "version": "0.12.0-pre.1",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit/reactive-element": "^2.0.0-pre.0",
-        "lit": "^3.0.0-pre.0"
+        "@lit/reactive-element": "^2.0.0-pre.1",
+        "lit": "^3.0.0-pre.1"
       }
     },
     "packages/localize-tools": {
       "name": "@lit/localize-tools",
-      "version": "0.7.0-pre.0",
+      "version": "0.7.0-pre.1",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit/localize": "^0.11.5-pre.0",
+        "@lit/localize": "^0.12.0-pre.1",
         "@parse5/tools": "^0.3.0",
         "@xmldom/xmldom": "^0.8.2",
         "fast-glob": "^3.2.7",
         "fs-extra": "^10.0.0",
         "jsonschema": "^1.4.0",
-        "lit": "^3.0.0-pre.0",
+        "lit": "^3.0.0-pre.1",
         "minimist": "^1.2.5",
         "parse5": "^7.1.1",
         "source-map-support": "^0.5.19",
@@ -27561,9 +27561,9 @@
         "lit-localize": "bin/lit-localize.js"
       },
       "devDependencies": {
-        "@lit-internal/tests": "0.0.1-pre.0",
-        "@lit-labs/ssr": "^3.1.3-pre.0",
-        "@lit/ts-transformers": "^2.0.0-pre.0",
+        "@lit-internal/tests": "0.0.1-pre.1",
+        "@lit-labs/ssr": "^3.1.8-pre.0",
+        "@lit/ts-transformers": "^2.0.0-pre.1",
         "@types/fs-extra": "^9.0.1",
         "@types/minimist": "^1.2.0",
         "@types/prettier": "^2.0.1",
@@ -27612,39 +27612,39 @@
     },
     "packages/localize/examples/runtime-js": {
       "name": "@lit-internal/localize-examples-runtime-js",
-      "version": "1.0.2-pre.0",
+      "version": "1.0.2-pre.1",
       "dependencies": {
-        "@lit/localize": "^0.11.5-pre.0",
+        "@lit/localize": "^0.12.0-pre.1",
         "@material/mwc-circular-progress": "^0.26.1",
-        "lit": "^3.0.0-pre.0"
+        "lit": "^3.0.0-pre.1"
       },
       "devDependencies": {
-        "@lit/localize-tools": "^0.7.0-pre.0",
+        "@lit/localize-tools": "^0.7.0-pre.1",
         "@web/dev-server": "^0.1.22"
       }
     },
     "packages/localize/examples/runtime-ts": {
       "name": "@lit-internal/localize-examples-runtime-ts",
-      "version": "1.0.2-pre.0",
+      "version": "1.0.2-pre.1",
       "dependencies": {
-        "@lit/localize": "^0.11.5-pre.0",
+        "@lit/localize": "^0.12.0-pre.1",
         "@material/mwc-circular-progress": "^0.26.1",
-        "lit": "^3.0.0-pre.0"
+        "lit": "^3.0.0-pre.1"
       },
       "devDependencies": {
-        "@lit/localize-tools": "^0.7.0-pre.0",
+        "@lit/localize-tools": "^0.7.0-pre.1",
         "@web/dev-server": "^0.1.22"
       }
     },
     "packages/localize/examples/transform-js": {
       "name": "@lit-internal/localize-examples-transform-js",
-      "version": "1.0.2-pre.0",
+      "version": "1.0.2-pre.1",
       "dependencies": {
-        "@lit/localize": "^0.11.5-pre.0",
-        "lit": "^3.0.0-pre.0"
+        "@lit/localize": "^0.12.0-pre.1",
+        "lit": "^3.0.0-pre.1"
       },
       "devDependencies": {
-        "@lit/localize-tools": "^0.7.0-pre.0",
+        "@lit/localize-tools": "^0.7.0-pre.1",
         "@rollup/plugin-node-resolve": "^13.0.4",
         "@rollup/plugin-typescript": "^8.2.0",
         "@web/dev-server": "^0.1.22",
@@ -27656,13 +27656,13 @@
     },
     "packages/localize/examples/transform-ts": {
       "name": "@lit-internal/localize-examples-transform-ts",
-      "version": "1.0.2-pre.0",
+      "version": "1.0.2-pre.1",
       "dependencies": {
-        "@lit/localize": "^0.11.5-pre.0",
-        "lit": "^3.0.0-pre.0"
+        "@lit/localize": "^0.12.0-pre.1",
+        "lit": "^3.0.0-pre.1"
       },
       "devDependencies": {
-        "@lit/localize-tools": "^0.7.0-pre.0",
+        "@lit/localize-tools": "^0.7.0-pre.1",
         "@rollup/plugin-node-resolve": "^13.0.4",
         "@rollup/plugin-typescript": "^8.2.0",
         "@web/dev-server": "^0.1.22",
@@ -27674,11 +27674,11 @@
     },
     "packages/react": {
       "name": "@lit/react",
-      "version": "0.0.0",
+      "version": "1.0.0-pre.0",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@lit-internal/scripts": "^1.0.1-pre.0",
-        "@lit/reactive-element": "^2.0.0-pre.0",
+        "@lit/reactive-element": "^2.0.0-pre.1",
         "@types/react-dom": "^18.2.6",
         "@types/trusted-types": "^2.0.2",
         "@web/dev-server-rollup": "^0.5.2",
@@ -27691,7 +27691,7 @@
     },
     "packages/reactive-element": {
       "name": "@lit/reactive-element",
-      "version": "2.0.0-pre.0",
+      "version": "2.0.0-pre.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.1.2-pre.0"
@@ -27711,20 +27711,20 @@
     },
     "packages/task": {
       "name": "@lit/task",
-      "version": "0.1.0",
+      "version": "1.0.0-pre.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit/reactive-element": "^2.0.0-pre.0"
+        "@lit/reactive-element": "^2.0.0-pre.1"
       },
       "devDependencies": {
         "@lit-internal/scripts": "^1.0.1-pre.0",
         "@types/trusted-types": "^2.0.2",
-        "lit": "^3.0.0-pre.0"
+        "lit": "^3.0.0-pre.1"
       }
     },
     "packages/tests": {
       "name": "@lit-internal/tests",
-      "version": "0.0.1-pre.0",
+      "version": "0.0.1-pre.1",
       "devDependencies": {
         "@types/diff": "^5.0.0",
         "@types/fs-extra": "^9.0.1",
@@ -27737,18 +27737,18 @@
     },
     "packages/ts-transformers": {
       "name": "@lit/ts-transformers",
-      "version": "2.0.0-pre.0",
+      "version": "2.0.0-pre.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "ts-clone-node": "^3.0.0",
         "typescript": "~5.2.0"
       },
       "devDependencies": {
-        "@lit/localize": "^0.11.5-pre.0",
-        "@lit/reactive-element": "^2.0.0-pre.0",
+        "@lit/localize": "^0.12.0-pre.1",
+        "@lit/reactive-element": "^2.0.0-pre.1",
         "@types/prettier": "^2.2.3",
-        "lit": "^3.0.0-pre.0",
-        "lit-element": "^4.0.0-pre.0",
+        "lit": "^3.0.0-pre.1",
+        "lit-element": "^4.0.0-pre.1",
         "prettier": "^2.3.2",
         "rimraf": "^3.0.2"
       }

--- a/scripts/check-size.js
+++ b/scripts/check-size.js
@@ -9,7 +9,7 @@ import * as fs from 'fs';
 // it's likely that we'll ask you to investigate ways to reduce the size.
 //
 // In either case, update the size here and push a new commit to your PR.
-const expectedLitCoreSize = 15403;
+const expectedLitCoreSize = 15425;
 const expectedLitHtmlSize = 7256;
 
 const litCoreSrc = fs.readFileSync('packages/lit/lit-core.min.js', 'utf8');


### PR DESCRIPTION
After second pre-release, need to sync package-lock as changeset doesn't do it for us.

Note: prior to this change, Node 20 install fails. I used Node 18 to update package-lock. Then verified that it works with Node 20.
