### PR TITLE
[infra] Add wireit build dep for labs/react test scripts

### DIFF
--- a/packages/labs/react/package.json
+++ b/packages/labs/react/package.json
@@ -128,6 +128,7 @@
       "#comment": "Test files must also be specified in web-test-runner.config.js rollup config",
       "command": "node ../../tests/run-web-tests.js \"development/**/*_test.js\" --config web-test-runner.config.js",
       "dependencies": [
+        "../../react:build",
         "build:ts",
         "../../reactive-element:build",
         "../../tests:build"
@@ -147,6 +148,7 @@
       "#comment": "Test files must also be specified in web-test-runner.config.js rollup config",
       "command": "node ../../tests/run-web-tests.js \"development/**/*_test.js\" --config web-test-runner.config.js",
       "dependencies": [
+        "../../react:build",
         "build:ts",
         "build:rollup",
         "../../reactive-element:build",
@@ -166,6 +168,7 @@
     "test:node": {
       "command": "node development/test/node-render.js",
       "dependencies": [
+        "../../react:build",
         "build:ts",
         "build:rollup",
         "../../reactive-element:build"

--- a/packages/labs/react/package.json
+++ b/packages/labs/react/package.json
@@ -60,7 +60,8 @@
       "dependencies": [
         "build:rollup",
         "build:ts",
-        "build:ts:types"
+        "build:ts:types",
+        "../../react:build"
       ]
     },
     "build:ts": {
@@ -128,8 +129,7 @@
       "#comment": "Test files must also be specified in web-test-runner.config.js rollup config",
       "command": "node ../../tests/run-web-tests.js \"development/**/*_test.js\" --config web-test-runner.config.js",
       "dependencies": [
-        "../../react:build",
-        "build:ts",
+        "build",
         "../../reactive-element:build",
         "../../tests:build"
       ],
@@ -148,9 +148,7 @@
       "#comment": "Test files must also be specified in web-test-runner.config.js rollup config",
       "command": "node ../../tests/run-web-tests.js \"development/**/*_test.js\" --config web-test-runner.config.js",
       "dependencies": [
-        "../../react:build",
-        "build:ts",
-        "build:rollup",
+        "build",
         "../../reactive-element:build",
         "../../tests:build"
       ],
@@ -168,9 +166,7 @@
     "test:node": {
       "command": "node development/test/node-render.js",
       "dependencies": [
-        "../../react:build",
-        "build:ts",
-        "build:rollup",
+        "build",
         "../../reactive-element:build"
       ],
       "files": [],


### PR DESCRIPTION
The labs/react tests can fail due to missing dependency on the `@lit/react` builds that's necessary for imports to resolve.

This is a bit of a shotgun fix by adding wireit dependency on `packages/react:build` for all labs/react test scripts.