### PR TITLE
Make @query not cache null results before first render ( #4237)

### DIFF
--- a/packages/reactive-element/src/decorators/query.ts
+++ b/packages/reactive-element/src/decorators/query.ts
@@ -98,15 +98,14 @@ export function query(selector: string, cache?: boolean): QueryDecorator {
             })();
       return desc(protoOrTarget, nameOrContext, {
         get(this: ReactiveElement): V {
-          if (cache) {
-            let result: V = get!.call(this);
-            if (result === undefined) {
-              result = doQuery(this);
+          let result: V = get!.call(this);
+          if (result === undefined) {
+            result = doQuery(this);
+            if (result || this.hasUpdated) {
               set!.call(this, result);
             }
-            return result;
           }
-          return doQuery(this);
+          return result;
         },
       });
     } else {

--- a/packages/reactive-element/src/test/decorators-modern/query_test.ts
+++ b/packages/reactive-element/src/test/decorators-modern/query_test.ts
@@ -95,11 +95,11 @@ import {assert} from '@esm-bundle/chai';
     assert.notEqual(el.span, el.renderRoot.querySelector('span'));
   });
 
-  test('returns cached value when accessed before first update', async () => {
+  test('does not cache null values when accessed before first update', async () => {
     const notYetUpdatedEl = new C();
     assert.equal(notYetUpdatedEl.divCached, null);
     container.appendChild(notYetUpdatedEl);
     await notYetUpdatedEl.updateComplete;
-    assert.equal(notYetUpdatedEl.divCached, null);
+    assert.instanceOf(notYetUpdatedEl.divCached, HTMLDivElement);
   });
 });

--- a/packages/reactive-element/src/test/decorators/query_test.ts
+++ b/packages/reactive-element/src/test/decorators/query_test.ts
@@ -90,12 +90,12 @@ import {assert} from '@esm-bundle/chai';
     assert.notEqual(el.span, el.renderRoot.querySelector('span'));
   });
 
-  test('returns cached value when accessed before first update', async () => {
+  test('does not cache null values when accessed before first update', async () => {
     const notYetUpdatedEl = new C();
     assert.equal(notYetUpdatedEl.divCached, null);
     container.appendChild(notYetUpdatedEl);
     await notYetUpdatedEl.updateComplete;
-    assert.equal(notYetUpdatedEl.divCached, null);
+    assert.instanceOf(notYetUpdatedEl.divCached, HTMLDivElement);
   });
 
   test('works with an old and busted Reflect.decorate', async () => {

--- a/scripts/check-size.js
+++ b/scripts/check-size.js
@@ -9,7 +9,7 @@ import * as fs from 'fs';
 // it's likely that we'll ask you to investigate ways to reduce the size.
 //
 // In either case, update the size here and push a new commit to your PR.
-const expectedLitCoreSize = 15403;
+const expectedLitCoreSize = 15425;
 const expectedLitHtmlSize = 7256;
 
 const litCoreSrc = fs.readFileSync('packages/lit/lit-core.min.js', 'utf8');


### PR DESCRIPTION
This change makes the `@query` decorator not cache the result if it's `null` and before the first render.
The result might be not null in case of a Declarative Shadow DOM.

Might follow a PR for lit.dev repo to state the new behavior.