### PR TITLE
Allow @query() decorated fields to be null

### DIFF
--- a/.changeset/lemon-lamps-shave.md
+++ b/.changeset/lemon-lamps-shave.md
@@ -4,4 +4,4 @@
 'lit': patch
 ---
 
-Allow null to be in the type of @query() decorated fields
+Allow `null` to be in the type of `@query()` decorated fields

--- a/.changeset/lemon-lamps-shave.md
+++ b/.changeset/lemon-lamps-shave.md
@@ -1,0 +1,7 @@
+---
+'@lit/reactive-element': patch
+'lit-element': patch
+'lit': patch
+---
+
+Allow null to be in the type of @query() decorated fields

--- a/packages/reactive-element/src/decorators/query.ts
+++ b/packages/reactive-element/src/decorators/query.ts
@@ -58,7 +58,7 @@ export type QueryDecorator = {
  * @category Decorator
  */
 export function query(selector: string, cache?: boolean): QueryDecorator {
-  return (<C extends Interface<ReactiveElement>, V extends Element>(
+  return (<C extends Interface<ReactiveElement>, V extends Element | null>(
     protoOrTarget: ClassAccessorDecoratorTarget<C, V>,
     nameOrContext: PropertyKey | ClassAccessorDecoratorContext<C, V>,
     descriptor?: PropertyDescriptor

--- a/packages/reactive-element/src/decorators/query.ts
+++ b/packages/reactive-element/src/decorators/query.ts
@@ -26,7 +26,7 @@ export type QueryDecorator = {
   ): void | any;
 
   // standard
-  <C extends Interface<ReactiveElement>, V extends Element>(
+  <C extends Interface<ReactiveElement>, V extends Element | null>(
     value: ClassAccessorDecoratorTarget<C, V>,
     context: ClassAccessorDecoratorContext<C, V>
   ): ClassAccessorDecoratorResult<C, V>;

--- a/packages/reactive-element/src/test/decorators-modern/query_test.ts
+++ b/packages/reactive-element/src/test/decorators-modern/query_test.ts
@@ -24,8 +24,9 @@ import {assert} from '@esm-bundle/chai';
     @query('#blah', true)
     accessor divCached!: HTMLDivElement;
 
+    // The span is conditional, so this query could return null
     @query('span', true)
-    accessor span!: HTMLSpanElement;
+    accessor span!: HTMLSpanElement | null;
 
     static override properties = {condition: {}};
 


### PR DESCRIPTION
Fixes a user-reported issue on Discord where this kind of field produced an error:

```ts
  @query('dt-dialog') private accessor dialogDce: DtDialog | undefined;
```

because `DtDialog | undefined` is not assignable to `Element`.

`@query()` can return `null`, not `undefined`, so this PR adds `null` to the field type and the error can be fixed by writing the field like:

```ts
  @query('dt-dialog') private accessor dialogDce!: DtDialog | null;
```

Note that the non-null assertion `!` is necessary.