### PR TITLE
Align renderRoot type change with PatchableElement

### DIFF
--- a/packages/labs/ssr-client/src/lit-element-hydrate-support.ts
+++ b/packages/labs/ssr-client/src/lit-element-hydrate-support.ts
@@ -21,7 +21,7 @@ interface PatchableLitElement extends HTMLElement {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-misused-new
   new (...args: any[]): PatchableLitElement;
   enableUpdating(requestedUpdate?: boolean): void;
-  createRenderRoot(): Element | ShadowRoot;
+  createRenderRoot(): HTMLElement | DocumentFragment;
   renderRoot: HTMLElement | DocumentFragment;
   render(): unknown;
   renderOptions: RenderOptions;

--- a/packages/lit-element/src/polyfill-support.ts
+++ b/packages/lit-element/src/polyfill-support.ts
@@ -38,7 +38,7 @@ interface PatchableLitElement extends HTMLElement {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-misused-new
   new (...args: any[]): PatchableLitElement;
   constructor: PatchableLitElementConstructor;
-  createRenderRoot(): Element | ShadowRoot;
+  createRenderRoot(): HTMLElement | DocumentFragment;
   renderOptions: RenderOptions;
 }
 

--- a/packages/reactive-element/src/polyfill-support.ts
+++ b/packages/reactive-element/src/polyfill-support.ts
@@ -41,7 +41,7 @@ interface PatchableReactiveElement extends HTMLElement {
   connectedCallback(): void;
   hasUpdated: boolean;
   _$didUpdate(changedProperties: unknown): void;
-  createRenderRoot(): Element | ShadowRoot;
+  createRenderRoot(): HTMLElement | DocumentFragment;
   renderOptions: RenderOptions;
 }
 


### PR DESCRIPTION

### Context

I was looking into the `renderRoot`, and `createRenderRoot` type change in 3.0. We possibly missed some locations:

 - `PatchableLitElement`: In Lit element hydration support
 - `PatchableReactiveElement`: In polyfill support

### Test plan

Unit tests. I don't have a good grasp of who consumes these types and what sort of testing would be best.
