### PR TITLE
[labs/virtualizer] Update version range for lit

### DIFF
--- a/.changeset/metal-cougars-brake.md
+++ b/.changeset/metal-cougars-brake.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/virtualizer': patch
+---
+
+Update version range for lit dependency to include Lit 2 and 3

--- a/packages/labs/virtualizer/package.json
+++ b/packages/labs/virtualizer/package.json
@@ -159,7 +159,7 @@
     "tachometer": "^0.7.0"
   },
   "dependencies": {
-    "lit": "^3.0.0",
+    "lit": "^2 || ^3",
     "tslib": "^2.0.3"
   }
 }


### PR DESCRIPTION
Virtualizer should work with both Lit 2 and Lit 3; update `package.json` to reflect this.