### PR TITLE
feat(labs): support elements with no reactive props

### DIFF
--- a/.changeset/shaggy-phones-behave.md
+++ b/.changeset/shaggy-phones-behave.md
@@ -1,0 +1,6 @@
+---
+'@lit-labs/gen-wrapper-angular': patch
+'@lit-labs/gen-wrapper-vue': patch
+---
+
+Generate valid wrappers for elements without reactive properties

--- a/packages/labs/gen-manifest/goldens/test-element-a/custom-elements.json
+++ b/packages/labs/gen-manifest/goldens/test-element-a/custom-elements.json
@@ -696,6 +696,52 @@
     },
     {
       "kind": "javascript-module",
+      "path": "element-without-props.js",
+      "declarations": [
+        {
+          "kind": "class",
+          "name": "ElementWithoutProps",
+          "description": "My awesome element",
+          "superclass": {"name": "LitElement", "package": "lit"},
+          "members": [
+            {
+              "kind": "method",
+              "name": "render",
+              "privacy": "public",
+              "return": {
+                "type": {
+                  "text": "TemplateResult<1>",
+                  "references": [
+                    {
+                      "name": "TemplateResult",
+                      "package": "lit-html",
+                      "start": 0,
+                      "end": 14
+                    }
+                  ]
+                }
+              }
+            }
+          ],
+          "tagName": "element-without-props",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "ElementWithoutProps",
+          "declaration": {"name": "ElementWithoutProps"}
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "element-without-props",
+          "declaration": {"name": "ElementWithoutProps"}
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
       "path": "package-stuff.js",
       "declarations": [
         {

--- a/packages/labs/gen-wrapper-angular/goldens/test-element-a/.gitignore
+++ b/packages/labs/gen-wrapper-angular/goldens/test-element-a/.gitignore
@@ -2,4 +2,5 @@ element-a.js
 element-events.js
 element-props.js
 element-slots.js
+element-without-props.js
 sub/element-sub.js

--- a/packages/labs/gen-wrapper-angular/goldens/test-element-a/package.json
+++ b/packages/labs/gen-wrapper-angular/goldens/test-element-a/package.json
@@ -21,6 +21,7 @@
     "element-events.js",
     "element-props.js",
     "element-slots.js",
+    "element-without-props.js",
     "sub/element-sub.js"
   ]
 }

--- a/packages/labs/gen-wrapper-angular/goldens/test-element-a/src/element-a.ts
+++ b/packages/labs/gen-wrapper-angular/goldens/test-element-a/src/element-a.ts
@@ -18,7 +18,7 @@ export class ElementA {
   private _el: ElementAElement;
   private _ngZone: NgZone;
 
-  constructor(e: ElementRef, ngZone: NgZone) {
+  constructor(e: ElementRef<ElementAElement>, ngZone: NgZone) {
     this._el = e.nativeElement;
     this._ngZone = ngZone;
 

--- a/packages/labs/gen-wrapper-angular/goldens/test-element-a/src/element-events.ts
+++ b/packages/labs/gen-wrapper-angular/goldens/test-element-a/src/element-events.ts
@@ -18,7 +18,7 @@ export class ElementEvents {
   private _el: ElementEventsElement;
   private _ngZone: NgZone;
 
-  constructor(e: ElementRef, ngZone: NgZone) {
+  constructor(e: ElementRef<ElementEventsElement>, ngZone: NgZone) {
     this._el = e.nativeElement;
     this._ngZone = ngZone;
 

--- a/packages/labs/gen-wrapper-angular/goldens/test-element-a/src/element-props.ts
+++ b/packages/labs/gen-wrapper-angular/goldens/test-element-a/src/element-props.ts
@@ -19,7 +19,7 @@ export class ElementProps {
   private _el: ElementPropsElement;
   private _ngZone: NgZone;
 
-  constructor(e: ElementRef, ngZone: NgZone) {
+  constructor(e: ElementRef<ElementPropsElement>, ngZone: NgZone) {
     this._el = e.nativeElement;
     this._ngZone = ngZone;
 

--- a/packages/labs/gen-wrapper-angular/goldens/test-element-a/src/element-slots.ts
+++ b/packages/labs/gen-wrapper-angular/goldens/test-element-a/src/element-slots.ts
@@ -11,7 +11,7 @@ export class ElementSlots {
   private _el: ElementSlotsElement;
   private _ngZone: NgZone;
 
-  constructor(e: ElementRef, ngZone: NgZone) {
+  constructor(e: ElementRef<ElementSlotsElement>, ngZone: NgZone) {
     this._el = e.nativeElement;
     this._ngZone = ngZone;
   }

--- a/packages/labs/gen-wrapper-angular/goldens/test-element-a/src/element-without-props.ts
+++ b/packages/labs/gen-wrapper-angular/goldens/test-element-a/src/element-without-props.ts
@@ -1,0 +1,12 @@
+import {Component, ElementRef, NgZone} from '@angular/core';
+
+import type {ElementWithoutProps as ElementWithoutPropsElement} from '@lit-internal/test-element-a/element-without-props.js';
+import '@lit-internal/test-element-a/element-without-props.js';
+
+@Component({
+  selector: 'element-without-props',
+  template: '<ng-content></ng-content>',
+})
+export class ElementWithoutProps {
+  constructor(_e: ElementRef<ElementWithoutPropsElement>, _ngZone: NgZone) {}
+}

--- a/packages/labs/gen-wrapper-angular/goldens/test-element-a/src/sub/element-sub.ts
+++ b/packages/labs/gen-wrapper-angular/goldens/test-element-a/src/sub/element-sub.ts
@@ -18,7 +18,7 @@ export class ElementSub {
   private _el: ElementSubElement;
   private _ngZone: NgZone;
 
-  constructor(e: ElementRef, ngZone: NgZone) {
+  constructor(e: ElementRef<ElementSubElement>, ngZone: NgZone) {
     this._el = e.nativeElement;
     this._ngZone = ngZone;
 

--- a/packages/labs/gen-wrapper-angular/src/lib/wrapper-module-template.ts
+++ b/packages/labs/gen-wrapper-angular/src/lib/wrapper-module-template.ts
@@ -71,17 +71,22 @@ ${elements.map((element) => wrapperTemplate(element))}
 
 const wrapperTemplate = (element: LitElementDeclaration) => {
   const {name, tagname, events, reactiveProperties} = element;
+  const requiresNgZone = reactiveProperties.size > 0;
+  const requiresEl = reactiveProperties.size > 0 || events.size > 0;
   return javascript`@Component({
   selector: '${tagname}',
   template: '<ng-content></ng-content>',
 })
 export class ${name} {
-  private _el: ${name}Element;
-  private _ngZone: NgZone;
+  ${requiresEl ? javascript`private _el: ${name}Element;` : ''}
+  ${requiresNgZone ? javascript`private _ngZone: NgZone;` : ''}
 
-  constructor(e: ElementRef, ngZone: NgZone) {
-    this._el = e.nativeElement;
-    this._ngZone = ngZone;
+  constructor(
+    ${requiresEl ? 'e' : '_e'}: ElementRef<${name}Element>,
+    ${requiresNgZone ? 'ngZone' : '_ngZone'}: NgZone
+  ) {
+    ${requiresEl ? javascript`this._el = e.nativeElement;` : ''}
+    ${requiresNgZone ? javascript`this._ngZone = ngZone;` : ''}
     ${Array.from(events.keys()).map(
       (eventName) => javascript`
     this._el.addEventListener('${eventName}', (e: Event) => {

--- a/packages/labs/gen-wrapper-react/goldens/test-element-a/.gitignore
+++ b/packages/labs/gen-wrapper-react/goldens/test-element-a/.gitignore
@@ -2,4 +2,5 @@ element-a.js
 element-events.js
 element-props.js
 element-slots.js
+element-without-props.js
 sub/element-sub.js

--- a/packages/labs/gen-wrapper-react/goldens/test-element-a/package.json
+++ b/packages/labs/gen-wrapper-react/goldens/test-element-a/package.json
@@ -22,6 +22,7 @@
     "element-events.{js,js.map,d.ts,d.ts.map}",
     "element-props.{js,js.map,d.ts,d.ts.map}",
     "element-slots.{js,js.map,d.ts,d.ts.map}",
+    "element-without-props.{js,js.map,d.ts,d.ts.map}",
     "sub/element-sub.{js,js.map,d.ts,d.ts.map}"
   ]
 }

--- a/packages/labs/gen-wrapper-react/goldens/test-element-a/src/element-without-props.ts
+++ b/packages/labs/gen-wrapper-react/goldens/test-element-a/src/element-without-props.ts
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import {createComponent} from '@lit/react';
+
+import {ElementWithoutProps as ElementWithoutPropsElement} from '@lit-internal/test-element-a/element-without-props.js';
+
+export const ElementWithoutProps = createComponent({
+  react: React,
+  tagName: 'element-without-props',
+  elementClass: ElementWithoutPropsElement,
+  events: {},
+});

--- a/packages/labs/gen-wrapper-vue/goldens/test-element-a/.gitignore
+++ b/packages/labs/gen-wrapper-vue/goldens/test-element-a/.gitignore
@@ -2,4 +2,5 @@
 /ElementEvents.*
 /ElementProps.*
 /ElementSlots.*
+/ElementWithoutProps.*
 /sub/ElementSub.*

--- a/packages/labs/gen-wrapper-vue/goldens/test-element-a/package.json
+++ b/packages/labs/gen-wrapper-vue/goldens/test-element-a/package.json
@@ -26,6 +26,7 @@
     "ElementEvents.*",
     "ElementProps.*",
     "ElementSlots.*",
+    "ElementWithoutProps.*",
     "sub/ElementSub.*"
   ]
 }

--- a/packages/labs/gen-wrapper-vue/goldens/test-element-a/src/ElementA.vue
+++ b/packages/labs/gen-wrapper-vue/goldens/test-element-a/src/ElementA.vue
@@ -31,8 +31,8 @@ const render = () => {
     onAChanged: (event: CustomEvent<unknown>) =>
       emit('a-changed', event as CustomEvent<unknown>),
   };
-
   const props = eventProps as typeof eventProps & Props;
+
   for (const p in vueProps) {
     const v = vueProps[p as keyof Props];
     if (v !== undefined || hasRendered) {

--- a/packages/labs/gen-wrapper-vue/goldens/test-element-a/src/ElementEvents.vue
+++ b/packages/labs/gen-wrapper-vue/goldens/test-element-a/src/ElementEvents.vue
@@ -62,8 +62,8 @@ const render = () => {
         event as CustomEvent<TemplateResult>
       ),
   };
-
   const props = eventProps as typeof eventProps & Props;
+
   for (const p in vueProps) {
     const v = vueProps[p as keyof Props];
     if (v !== undefined || hasRendered) {

--- a/packages/labs/gen-wrapper-vue/goldens/test-element-a/src/ElementProps.vue
+++ b/packages/labs/gen-wrapper-vue/goldens/test-element-a/src/ElementProps.vue
@@ -39,8 +39,8 @@ const render = () => {
     onAChanged: (event: CustomEvent<unknown>) =>
       emit('a-changed', event as CustomEvent<unknown>),
   };
-
   const props = eventProps as typeof eventProps & Props;
+
   for (const p in vueProps) {
     const v = vueProps[p as keyof Props];
     if (v !== undefined || hasRendered) {

--- a/packages/labs/gen-wrapper-vue/goldens/test-element-a/src/ElementSlots.vue
+++ b/packages/labs/gen-wrapper-vue/goldens/test-element-a/src/ElementSlots.vue
@@ -24,8 +24,8 @@ const slots = useSlots();
 
 const render = () => {
   const eventProps = {};
-
   const props = eventProps as typeof eventProps & Props;
+
   for (const p in vueProps) {
     const v = vueProps[p as keyof Props];
     if (v !== undefined || hasRendered) {

--- a/packages/labs/gen-wrapper-vue/goldens/test-element-a/src/ElementWithoutProps.vue
+++ b/packages/labs/gen-wrapper-vue/goldens/test-element-a/src/ElementWithoutProps.vue
@@ -1,31 +1,14 @@
 <script setup lang="ts">
-import {h, useSlots, reactive} from 'vue';
+import {h, useSlots} from 'vue';
 import {assignSlotNodes, Slots} from '@lit-labs/vue-utils/wrapper-utils.js';
 import '@lit-internal/test-element-a/element-without-props.js';
 
 export interface Props {}
 
-const vueProps = defineProps<Props>();
-
-const defaults = reactive({} as Props);
-const vDefaults = {};
-
-let hasRendered = false;
-
 const slots = useSlots();
 
 const render = () => {
-  const eventProps = {};
-
-  const props = eventProps as typeof eventProps & Props;
-  for (const p in vueProps) {
-    const v = vueProps[p as keyof Props];
-    if (v !== undefined || hasRendered) {
-      (props[p as keyof Props] as unknown) = v ?? defaults[p as keyof Props];
-    }
-  }
-
-  hasRendered = true;
+  const props = {} as Props;
 
   return h('element-without-props', props, assignSlotNodes(slots as Slots));
 };

--- a/packages/labs/gen-wrapper-vue/goldens/test-element-a/src/ElementWithoutProps.vue
+++ b/packages/labs/gen-wrapper-vue/goldens/test-element-a/src/ElementWithoutProps.vue
@@ -8,9 +8,10 @@ export interface Props {}
 const slots = useSlots();
 
 const render = () => {
-  const props = {} as Props;
+  const eventProps = {};
+  const props = eventProps as typeof eventProps & Props;
 
   return h('element-without-props', props, assignSlotNodes(slots as Slots));
 };
 </script>
-<template><render v-defaults /></template>
+<template><render /></template>

--- a/packages/labs/gen-wrapper-vue/goldens/test-element-a/src/ElementWithoutProps.vue
+++ b/packages/labs/gen-wrapper-vue/goldens/test-element-a/src/ElementWithoutProps.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import {h, useSlots, reactive} from 'vue';
+import {assignSlotNodes, Slots} from '@lit-labs/vue-utils/wrapper-utils.js';
+import '@lit-internal/test-element-a/element-without-props.js';
+
+export interface Props {}
+
+const vueProps = defineProps<Props>();
+
+const defaults = reactive({} as Props);
+const vDefaults = {};
+
+let hasRendered = false;
+
+const slots = useSlots();
+
+const render = () => {
+  const eventProps = {};
+
+  const props = eventProps as typeof eventProps & Props;
+  for (const p in vueProps) {
+    const v = vueProps[p as keyof Props];
+    if (v !== undefined || hasRendered) {
+      (props[p as keyof Props] as unknown) = v ?? defaults[p as keyof Props];
+    }
+  }
+
+  hasRendered = true;
+
+  return h('element-without-props', props, assignSlotNodes(slots as Slots));
+};
+</script>
+<template><render v-defaults /></template>

--- a/packages/labs/gen-wrapper-vue/goldens/test-element-a/src/sub/ElementSub.vue
+++ b/packages/labs/gen-wrapper-vue/goldens/test-element-a/src/sub/ElementSub.vue
@@ -31,8 +31,8 @@ const render = () => {
     onSubChanged: (event: CustomEvent<unknown>) =>
       emit('sub-changed', event as CustomEvent<unknown>),
   };
-
   const props = eventProps as typeof eventProps & Props;
+
   for (const p in vueProps) {
     const v = vueProps[p as keyof Props];
     if (v !== undefined || hasRendered) {

--- a/packages/labs/gen-wrapper-vue/goldens/test-element-a/vite.config.ts
+++ b/packages/labs/gen-wrapper-vue/goldens/test-element-a/vite.config.ts
@@ -14,6 +14,7 @@ export default {
         './src/ElementEvents.vue',
         './src/ElementProps.vue',
         './src/ElementSlots.vue',
+        './src/ElementWithoutProps.vue',
         './src/sub/ElementSub.vue',
       ],
       preserveModules: true,

--- a/packages/labs/gen-wrapper-vue/src/lib/wrapper-module-template-sfc.ts
+++ b/packages/labs/gen-wrapper-vue/src/lib/wrapper-module-template-sfc.ts
@@ -120,10 +120,15 @@ const wrapperTemplate = (
 
       const defaults = reactive({} as Props);
       const vDefaults = {
+        ${
+          reactiveProperties.size
+            ? javascript`
         created(el: any) {
           for (const p in vueProps) {
             defaults[p as keyof Props] = el[p];
           }
+        }`
+            : ''
         }
       };
 

--- a/packages/labs/gen-wrapper-vue/src/lib/wrapper-module-template-sfc.ts
+++ b/packages/labs/gen-wrapper-vue/src/lib/wrapper-module-template-sfc.ts
@@ -106,16 +106,10 @@ const getElementTypeImports = (declaration: LitElementDeclaration) => {
 const getElementTypeExportsFromImports = (imports: string) =>
   imports.replace(/(?:^import)/gm, 'export type');
 
-const renderPropsParam = (
-  reactiveProperties: Map<string, ModelProperty>,
-  events: Map<string, EventModel>
-) => {
+const renderPropsParam = (reactiveProperties: Map<string, ModelProperty>) => {
   const hasProps = reactiveProperties.size > 0;
   if (hasProps) {
     return javascript`
-      const eventProps = ${renderEvents(events)};
-
-      const props = eventProps as (typeof eventProps & Props);
       for (const p in vueProps) {
         const v = vueProps[p as keyof Props];
         if ((v !== undefined) || hasRendered) {
@@ -127,9 +121,7 @@ const renderPropsParam = (
     `;
   }
 
-  return javascript`
-    const props = {} as Props;
-  `;
+  return '';
 };
 
 // TODO(sorvell): Add support for `v-bind`.
@@ -173,7 +165,10 @@ const wrapperTemplate = (
       const slots = useSlots();
 
       const render = () => {
-        ${renderPropsParam(reactiveProperties, events)}
+        const eventProps = ${renderEvents(events)};
+        const props = eventProps as (typeof eventProps & Props);
+
+        ${renderPropsParam(reactiveProperties)}
 
         return h(
           '${tagname}',
@@ -182,5 +177,5 @@ const wrapperTemplate = (
         );
       };
     </script>
-    <template><render v-defaults /></template>`;
+    <template><render${hasProps ? ' v-defaults' : ''} /></template>`;
 };

--- a/packages/labs/gen-wrapper-vue/src/lib/wrapper-module-template-sfc.ts
+++ b/packages/labs/gen-wrapper-vue/src/lib/wrapper-module-template-sfc.ts
@@ -50,6 +50,23 @@ const renderPropsInterface = (props: Map<string, ModelProperty>) =>
        .join(';\n     ')}
    }`;
 
+const renderVueProps = (props: Map<string, ModelProperty>) =>
+  props.size > 0
+    ? javascript`
+  const vueProps = defineProps<Props>();
+
+  const defaults = reactive({} as Props);
+  const vDefaults = {
+    created(el: any) {
+      for (const p in vueProps) {
+        defaults[p as keyof Props] = el[p];
+      }
+    }
+  };
+
+  let hasRendered = false;`
+    : ``;
+
 const wrapEvents = (events: Map<string, EventModel>) =>
   Array.from(events.values())
     .map((event) => {
@@ -89,6 +106,32 @@ const getElementTypeImports = (declaration: LitElementDeclaration) => {
 const getElementTypeExportsFromImports = (imports: string) =>
   imports.replace(/(?:^import)/gm, 'export type');
 
+const renderPropsParam = (
+  reactiveProperties: Map<string, ModelProperty>,
+  events: Map<string, EventModel>
+) => {
+  const hasProps = reactiveProperties.size > 0;
+  if (hasProps) {
+    return javascript`
+      const eventProps = ${renderEvents(events)};
+
+      const props = eventProps as (typeof eventProps & Props);
+      for (const p in vueProps) {
+        const v = vueProps[p as keyof Props];
+        if ((v !== undefined) || hasRendered) {
+          (props[p as keyof Props] as unknown) = v ?? defaults[p as keyof Props];
+        }
+      }
+
+      hasRendered = true;
+    `;
+  }
+
+  return javascript`
+    const props = {} as Props;
+  `;
+};
+
 // TODO(sorvell): Add support for `v-bind`.
 // TODO(sorvell): Investigate if it's possible to save the ~15 lines related to
 // handling defaults by factoring the defaults directive and associated code
@@ -100,6 +143,7 @@ const wrapperTemplate = (
   const {tagname, events, reactiveProperties} = declaration;
   const typeImports = getElementTypeImports(declaration);
   const typeExports = getElementTypeExportsFromImports(typeImports);
+  const hasProps = reactiveProperties.size > 0;
   return javascript`${
     typeExports
       ? javascript`
@@ -109,30 +153,14 @@ const wrapperTemplate = (
       : ''
   }
     <script setup lang="ts">
-      import { h, useSlots, reactive } from "vue";
+      import { h, useSlots${hasProps ? `, reactive` : ``} } from "vue";
       import { assignSlotNodes, Slots } from "@lit-labs/vue-utils/wrapper-utils.js";
       import '${wcPath}';
       ${typeImports}
 
       ${renderPropsInterface(reactiveProperties)}
 
-      const vueProps = defineProps<Props>();
-
-      const defaults = reactive({} as Props);
-      const vDefaults = {
-        ${
-          reactiveProperties.size
-            ? javascript`
-        created(el: any) {
-          for (const p in vueProps) {
-            defaults[p as keyof Props] = el[p];
-          }
-        }`
-            : ''
-        }
-      };
-
-      let hasRendered = false;
+      ${renderVueProps(reactiveProperties)}
 
       ${
         events.size
@@ -145,17 +173,7 @@ const wrapperTemplate = (
       const slots = useSlots();
 
       const render = () => {
-        const eventProps = ${renderEvents(events)};
-
-        const props = eventProps as (typeof eventProps & Props);
-        for (const p in vueProps) {
-          const v = vueProps[p as keyof Props];
-          if ((v !== undefined) || hasRendered) {
-            (props[p as keyof Props] as unknown) = v ?? defaults[p as keyof Props];
-          }
-        }
-
-        hasRendered = true;
+        ${renderPropsParam(reactiveProperties, events)}
 
         return h(
           '${tagname}',

--- a/packages/labs/test-projects/test-element-a/src/element-without-props.ts
+++ b/packages/labs/test-projects/test-element-a/src/element-without-props.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {LitElement, html} from 'lit';
+import {customElement} from 'lit/decorators.js';
+
+/**
+ * My awesome element
+ */
+@customElement('element-without-props')
+export class ElementWithoutProps extends LitElement {
+  override render() {
+    return html`foo`;
+  }
+}


### PR DESCRIPTION
For each of the wrapper generators, this adds support for elements with no reactive props.

For example:

```ts
class Foo extends LitElement {
  render() {
    return html`no props!`;
  }
}
```

We basically conditionally output the code any reactive property related logic depends on, rather than always outputting it.

## Vue

When generating vue wrappers, we produce two relevant things:

- a `Props` interface (**empty when no properties exist**)
- a `vDefaults.created` function for setting the defaults of these props

If no props exist, we end up with an empty interface (`{}`), which means `keyof Props` is now `never`, leading to various type problems in `vDefaults.created` (which tries to key into props).

For example:

```ts
      interface Props {}
      const vueProps = defineProps<Props>();
      const defaults = reactive({} as Props);
      const vDefaults = {
        created(el: any) {
          for (const p in vueProps) {
            defaults[p as keyof Props] = el[p]; // ERROR: `never` can't be used to key into `defaults`
          }
        }
      };
```

I have changed this to conditionally output `vDefaults.created` if there are props. So without props we will now get:

```ts
      interface Props {}
      const vueProps = defineProps<Props>();
      const defaults = reactive({} as Props);
      const vDefaults = {};
```

## Angular

When generating angular wrappers, we produce a constructor and some properties like so:

```ts
private _el: FooElement;
private _ngZone: NgZone;
constructor(e: ElementRef, ngZone: NgZone) {
  this._el = e.nativeElement;
  this.ngZone = ngZone;
  // ...
}
```

When no props exist, this constructor is basically empty other than the assignments. Which leads to type errors in strict mode, since `_el` and `_ngZone` are unused.

I have changed this to do the following:

- Only output `_el` if we have properties _or_ events (existence of one of these results in code which uses `_el`)
- Only output `_ngZone` if we have properties (only property setters use `_ngZone`)
- Prefix unused parameters with `_` in the constructor (e.g. `constructor(_e: ElementRef)`)

## Open questions/feedback

As you can see, this has resulted in fiddlier code. I wonder if we should slightly refactor how we build up these templates to make such conditional logic a lot easier.

Do we want to think about doing that in this PR instead of the approach i've taken?

Also, in the vue code, i don't fully understand how `vDefaults` gets consumed. Can we skip it entirely? is it ok to have just cut out `created`? etc. 