### PR TITLE
Update dependency version range to accept Lit v2

### DIFF
--- a/.changeset/thick-colts-smile.md
+++ b/.changeset/thick-colts-smile.md
@@ -1,0 +1,11 @@
+---
+'@lit-labs/scoped-registry-mixin': patch
+'@lit-labs/preact-signals': patch
+'@lit-labs/observers': patch
+'@lit/localize-tools': patch
+'@lit-labs/motion': patch
+'@lit-labs/router': patch
+'@lit/localize': patch
+---
+
+Update version range for `lit` dependency to include v2 (and/or `@lit/reactive-element` v1). This allows projects still on lit v2 to use this package without being forced to install lit v3.

--- a/package-lock.json
+++ b/package-lock.json
@@ -26371,10 +26371,10 @@
       "version": "1.0.5",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "lit": "^3.0.0"
+        "lit": "^2.0.0 || ^3.0.0"
       },
       "devDependencies": {
-        "@lit-internal/scripts": "^1.0.1-pre.0",
+        "@lit-internal/scripts": "^1.0.1",
         "@types/trusted-types": "^2.0.2"
       }
     },
@@ -26395,10 +26395,10 @@
       "version": "2.0.1",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit/reactive-element": "^2.0.0"
+        "@lit/reactive-element": "^1.0.0 || ^2.0.0"
       },
       "devDependencies": {
-        "@lit-internal/scripts": "^1.0.1-pre.0",
+        "@lit-internal/scripts": "^1.0.1",
         "@types/trusted-types": "^2.0.2"
       }
     },
@@ -26408,10 +26408,10 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@preact/signals-core": "^1.3.0",
-        "lit": "^3.0.0"
+        "lit": "^2.0.0 || ^3.0.0"
       },
       "devDependencies": {
-        "@lit-internal/scripts": "^1.0.1-pre.0"
+        "@lit-internal/scripts": "^1.0.1"
       }
     },
     "packages/labs/react": {
@@ -27000,11 +27000,11 @@
       "version": "0.1.2",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "lit": "^3.0.0"
+        "lit": "^2.0.0 || ^3.0.0"
       },
       "devDependencies": {
-        "@lit-internal/scripts": "^1.0.1-pre.0",
-        "@lit-labs/testing": "^0.2.2-pre.0",
+        "@lit-internal/scripts": "^1.0.1",
+        "@lit-labs/testing": "^0.2.2",
         "@types/trusted-types": "^2.0.2",
         "urlpattern-polyfill": "^5.0.5"
       }
@@ -27019,11 +27019,11 @@
       "version": "1.0.2",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit/reactive-element": "^2.0.0",
-        "lit": "^3.0.0"
+        "@lit/reactive-element": "^1.0.0 || ^2.0.0",
+        "lit": "^2.0.0 || ^3.0.0"
       },
       "devDependencies": {
-        "@lit-internal/scripts": "^1.0.1-pre.0",
+        "@lit-internal/scripts": "^1.0.1",
         "@types/trusted-types": "^2.0.2",
         "@webcomponents/scoped-custom-element-registry": "^0.0.5"
       }
@@ -27538,7 +27538,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit/reactive-element": "^2.0.0",
-        "lit": "^3.0.0"
+        "lit": "^2.0.0 || ^3.0.0"
       }
     },
     "packages/localize-tools": {
@@ -27552,7 +27552,7 @@
         "fast-glob": "^3.2.7",
         "fs-extra": "^10.0.0",
         "jsonschema": "^1.4.0",
-        "lit": "^3.0.0",
+        "lit": "^2.0.0 || ^3.0.0",
         "minimist": "^1.2.5",
         "parse5": "^7.1.1",
         "source-map-support": "^0.5.19",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27537,7 +27537,7 @@
       "version": "0.12.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit/reactive-element": "^2.0.0",
+        "@lit/reactive-element": "^1.0.0 || ^2.0.0",
         "lit": "^2.0.0 || ^3.0.0"
       }
     },

--- a/packages/labs/motion/package.json
+++ b/packages/labs/motion/package.json
@@ -153,11 +153,11 @@
   },
   "author": "Google LLC",
   "devDependencies": {
-    "@types/trusted-types": "^2.0.2",
-    "@lit-internal/scripts": "^1.0.1-pre.0"
+    "@lit-internal/scripts": "^1.0.1",
+    "@types/trusted-types": "^2.0.2"
   },
   "dependencies": {
-    "lit": "^3.0.0"
+    "lit": "^2.0.0 || ^3.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/labs/observers/package.json
+++ b/packages/labs/observers/package.json
@@ -164,11 +164,11 @@
   },
   "author": "Google LLC",
   "devDependencies": {
-    "@types/trusted-types": "^2.0.2",
-    "@lit-internal/scripts": "^1.0.1-pre.0"
+    "@lit-internal/scripts": "^1.0.1",
+    "@types/trusted-types": "^2.0.2"
   },
   "dependencies": {
-    "@lit/reactive-element": "^2.0.0"
+    "@lit/reactive-element": "^1.0.0 || ^2.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/labs/preact-signals/package.json
+++ b/packages/labs/preact-signals/package.json
@@ -128,13 +128,13 @@
   },
   "author": "Google LLC",
   "devDependencies": {
-    "@lit-internal/scripts": "^1.0.1-pre.0"
+    "@lit-internal/scripts": "^1.0.1"
   },
   "publishConfig": {
     "access": "public"
   },
   "dependencies": {
-    "lit": "^3.0.0",
-    "@preact/signals-core": "^1.3.0"
+    "@preact/signals-core": "^1.3.0",
+    "lit": "^2.0.0 || ^3.0.0"
   }
 }

--- a/packages/labs/router/package.json
+++ b/packages/labs/router/package.json
@@ -158,12 +158,12 @@
   },
   "author": "Google LLC",
   "devDependencies": {
-    "@lit-internal/scripts": "^1.0.1-pre.0",
-    "@lit-labs/testing": "^0.2.2-pre.0",
+    "@lit-internal/scripts": "^1.0.1",
+    "@lit-labs/testing": "^0.2.2",
     "@types/trusted-types": "^2.0.2",
     "urlpattern-polyfill": "^5.0.5"
   },
   "dependencies": {
-    "lit": "^3.0.0"
+    "lit": "^2.0.0 || ^3.0.0"
   }
 }

--- a/packages/labs/scoped-registry-mixin/package.json
+++ b/packages/labs/scoped-registry-mixin/package.json
@@ -145,13 +145,13 @@
   },
   "author": "Google LLC",
   "dependencies": {
-    "@lit/reactive-element": "^2.0.0",
-    "lit": "^3.0.0"
+    "@lit/reactive-element": "^1.0.0 || ^2.0.0",
+    "lit": "^2.0.0 || ^3.0.0"
   },
   "devDependencies": {
+    "@lit-internal/scripts": "^1.0.1",
     "@types/trusted-types": "^2.0.2",
-    "@webcomponents/scoped-custom-element-registry": "^0.0.5",
-    "@lit-internal/scripts": "^1.0.1-pre.0"
+    "@webcomponents/scoped-custom-element-registry": "^0.0.5"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/localize-tools/package.json
+++ b/packages/localize-tools/package.json
@@ -131,13 +131,13 @@
   ],
   "dependencies": {
     "@lit/localize": "^0.12.0",
+    "@parse5/tools": "^0.3.0",
     "@xmldom/xmldom": "^0.8.2",
     "fast-glob": "^3.2.7",
     "fs-extra": "^10.0.0",
     "jsonschema": "^1.4.0",
-    "lit": "^3.0.0",
+    "lit": "^2.0.0 || ^3.0.0",
     "minimist": "^1.2.5",
-    "@parse5/tools": "^0.3.0",
     "parse5": "^7.1.1",
     "source-map-support": "^0.5.19",
     "typescript": "~5.2.0"

--- a/packages/localize/package.json
+++ b/packages/localize/package.json
@@ -89,7 +89,7 @@
     "/init/"
   ],
   "dependencies": {
-    "@lit/reactive-element": "^2.0.0",
+    "@lit/reactive-element": "^1.0.0 || ^2.0.0",
     "lit": "^2.0.0 || ^3.0.0"
   }
 }

--- a/packages/localize/package.json
+++ b/packages/localize/package.json
@@ -90,6 +90,6 @@
   ],
   "dependencies": {
     "@lit/reactive-element": "^2.0.0",
-    "lit": "^3.0.0"
+    "lit": "^2.0.0 || ^3.0.0"
   }
 }


### PR DESCRIPTION
Affected packages:

- '@lit-labs/scoped-registry-mixin': patch
- '@lit-labs/preact-signals': patch
- '@lit-labs/observers': patch
- '@lit/localize-tools': patch
- '@lit-labs/motion': patch
- '@lit-labs/router': patch
- '@lit/localize': patch

I haven't touched SSR and related packages yet as they'll require a more specific range of v2 to work.

I tested that these packages work with the lower version by manually installing `lit@2.0.0` or `@lit/reactive-element@1.0.0` within the package directory and running their tests.