### PR TITLE
[labs/gen-wrapper-react] Don't include pre version of `@lit/react`

### DIFF
--- a/.changeset/fresh-jobs-admire.md
+++ b/.changeset/fresh-jobs-admire.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/gen-wrapper-react': patch
+---
+
+No longer include prerelease version of `@lit/react` in generated package.json.

--- a/packages/labs/gen-wrapper-react/goldens/test-element-a/package.json
+++ b/packages/labs/gen-wrapper-react/goldens/test-element-a/package.json
@@ -8,7 +8,7 @@
   "version": "1.0.1",
   "dependencies": {
     "@lit-internal/test-element-a": "^1.0.1",
-    "@lit/react": "^1.0.0 || 1.0.0-pre.0"
+    "@lit/react": "^1.0.0"
   },
   "peerDependencies": {
     "react": "^17 || ^18",

--- a/packages/labs/gen-wrapper-react/src/index.ts
+++ b/packages/labs/gen-wrapper-react/src/index.ts
@@ -92,7 +92,7 @@ const packageJsonTemplate = (
         // TODO(kschaaf): make component version range configurable?
         [pkgJson.name!]: '^' + pkgJson.version!,
         // TODO(kschaaf): make @lit/react version configurable?
-        '@lit/react': '^1.0.0 || 1.0.0-pre.0',
+        '@lit/react': '^1.0.0',
       },
       peerDependencies: {
         // TODO(kschaaf): make react version(s) configurable?


### PR DESCRIPTION
Pre version was added before stable release to make self install tests pass. There's no reason to include this in generated output.