### PR TITLE
Fix dependencies to use stable instead of pre-release vesrions

### DIFF
--- a/.changeset/friendly-rabbits-arrive.md
+++ b/.changeset/friendly-rabbits-arrive.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/testing': patch
+---
+
+Update version range for `lit` dependency to include v2. This allows projects still on lit v2 to use this package without being forced to install lit v3.

--- a/.changeset/tender-snakes-marry.md
+++ b/.changeset/tender-snakes-marry.md
@@ -3,6 +3,7 @@
 '@lit/reactive-element': patch
 '@lit-labs/testing': patch
 '@lit-labs/nextjs': patch
+'lit-element': patch
 ---
 
 Update dependency version to refer to stable versions, rather than pre-release versions of our own packages.

--- a/.changeset/tender-snakes-marry.md
+++ b/.changeset/tender-snakes-marry.md
@@ -1,0 +1,8 @@
+---
+'@lit-labs/gen-wrapper-vue': patch
+'@lit/reactive-element': patch
+'@lit-labs/testing': patch
+'@lit-labs/nextjs': patch
+---
+
+Update dependency version to refer to stable versions, rather than pre-release versions of our own packages.

--- a/packages/labs/gen-wrapper-vue/package.json
+++ b/packages/labs/gen-wrapper-vue/package.json
@@ -63,10 +63,10 @@
   "dependencies": {
     "@lit-labs/analyzer": "^0.10.0",
     "@lit-labs/gen-utils": "^0.3.0",
-    "@lit-labs/vue-utils": "^0.1.1-pre.0"
+    "@lit-labs/vue-utils": "^0.1.1"
   },
   "devDependencies": {
-    "@lit-internal/tests": "^0.0.1-pre.0"
+    "@lit-internal/tests": "^0.0.1"
   },
   "engines": {
     "node": ">=14.8.0"

--- a/packages/labs/nextjs/package.json
+++ b/packages/labs/nextjs/package.json
@@ -19,7 +19,7 @@
     "/index.{d.ts,d.ts.map,js,js.map}"
   ],
   "dependencies": {
-    "@lit-labs/ssr-react": "^0.2.1-pre.0",
+    "@lit-labs/ssr-react": "^0.2.1",
     "imports-loader": "^4.0.1"
   },
   "peerDependencies": {

--- a/packages/labs/testing/package.json
+++ b/packages/labs/testing/package.json
@@ -106,11 +106,11 @@
     "lib/**/*.{d.ts,d.ts.map,js,js.map}"
   ],
   "dependencies": {
-    "@lit-labs/ssr": "^3.1.8-pre.0",
-    "@lit-labs/ssr-client": "^1.1.4-pre.0",
+    "@lit-labs/ssr": "^3.1.8",
+    "@lit-labs/ssr-client": "^1.1.4",
     "@web/test-runner-commands": "^0.6.1",
     "@webcomponents/template-shadowroot": "^0.1.0",
-    "lit": "^3.0.0"
+    "lit": "^2.0.0 || ^3.0.0"
   },
   "devDependencies": {
     "@open-wc/testing": "^3.1.5"

--- a/packages/lit-element/package.json
+++ b/packages/lit-element/package.json
@@ -248,7 +248,7 @@
     "!/development/test/"
   ],
   "dependencies": {
-    "@lit-labs/ssr-dom-shim": "^1.1.2-pre.0",
+    "@lit-labs/ssr-dom-shim": "^1.1.2",
     "@lit/reactive-element": "^2.0.0",
     "lit-html": "^3.0.0"
   },

--- a/packages/reactive-element/package.json
+++ b/packages/reactive-element/package.json
@@ -381,7 +381,7 @@
     "/node/"
   ],
   "dependencies": {
-    "@lit-labs/ssr-dom-shim": "^1.1.2-pre.0"
+    "@lit-labs/ssr-dom-shim": "^1.1.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.22.10",


### PR DESCRIPTION
Affected packages:

- '@lit-labs/gen-wrapper-vue': patch
- '@lit/reactive-element': patch
- '@lit-labs/testing': patch
- '@lit-labs/nextjs': patch
- 'lit-element': patch

These packages still had -pre versions as production dependencies seemingly missed by changeset during release. Did them separately from https://github.com/lit/lit/pull/4300 as these would require a version bump so downstream users don't install the prerelease versions.

`@lit-labs/testing` was also missed from https://github.com/lit/lit/pull/4299 in upping the version range.