### PR TITLE
feat(lit-html/directives/when.ts): improve typing

### DIFF
--- a/.changeset/kind-insects-shake.md
+++ b/.changeset/kind-insects-shake.md
@@ -1,0 +1,6 @@
+---
+"lit-html": patch
+"lit": patch
+---
+
+feat(lit-html/directives/when.ts): improve typing

--- a/.changeset/kind-insects-shake.md
+++ b/.changeset/kind-insects-shake.md
@@ -3,4 +3,4 @@
 'lit': patch
 ---
 
-Improve typing for the `when` directive.
+The `when()` directive now calls the case functions with the provided condition value as an argument. This allows the narrowing of types for the condition value based on its truthiness when used as a parameter for the case function.

--- a/.changeset/kind-insects-shake.md
+++ b/.changeset/kind-insects-shake.md
@@ -1,6 +1,6 @@
 ---
-"lit-html": patch
-"lit": patch
+'lit-html': patch
+'lit': patch
 ---
 
-feat(lit-html/directives/when.ts): improve typing
+Improve typing for the `when` directive.

--- a/packages/lit-html/src/directives/when.ts
+++ b/packages/lit-html/src/directives/when.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+type Falsy = null | undefined | false | 0 | -0 | 0n | '';
+
 /**
  * When `condition` is true, returns the result of calling `trueCase()`, else
  * returns the result of calling `falseCase()` if `falseCase` is defined.
@@ -21,25 +23,25 @@
  * }
  * ```
  */
-export function when<T, F>(
-  condition: true,
-  trueCase: () => T,
-  falseCase?: () => F
-): T;
-export function when<T, F = undefined>(
-  condition: false,
-  trueCase: () => T,
-  falseCase?: () => F
+export function when<C extends Falsy, T, F = undefined>(
+  condition: C,
+  trueCase: (c: C) => T,
+  falseCase?: (c: C) => F
 ): F;
-export function when<T, F = undefined>(
-  condition: unknown,
-  trueCase: () => T,
-  falseCase?: () => F
-): T | F;
+export function when<C, T, F>(
+  condition: C extends Falsy ? never : C,
+  trueCase: (c: C) => T,
+  falseCase?: (c: C) => F
+): T;
+export function when<C, T, F = undefined>(
+  condition: C,
+  trueCase: (c: Exclude<C, Falsy>) => T,
+  falseCase?: (c: Extract<C, Falsy>) => F
+): C extends Falsy ? F : T;
 export function when(
   condition: unknown,
-  trueCase: () => unknown,
-  falseCase?: () => unknown
+  trueCase: (c: unknown) => unknown,
+  falseCase?: (c: unknown) => unknown
 ): unknown {
-  return condition ? trueCase() : falseCase?.();
+  return condition ? trueCase(condition) : falseCase?.(condition);
 }


### PR DESCRIPTION
Improve typing for the `when` directive making it more dynamic.

```ts
let user = {name: string} | undefined;

when(
  user,
  (user) => user.name
)
```

In the trueCase and falseCase functions the condition is correctly type
and we no longer need a non-null assertion.


Fixes #4085