### PR TITLE
Update dependency versions for labs/ssr and related packages

### DIFF
--- a/.changeset/clever-jobs-float.md
+++ b/.changeset/clever-jobs-float.md
@@ -1,0 +1,7 @@
+---
+'@lit-labs/eleventy-plugin-lit': patch
+'@lit-labs/ssr': patch
+'@lit-labs/ssr-client': patch
+---
+
+Update version range for `lit` dependency to include v2. This allows projects still on lit v2 to use this package without being forced to install lit v3.

--- a/.changeset/silver-pears-poke.md
+++ b/.changeset/silver-pears-poke.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/ssr-react': patch
+---
+
+Removed `lit` package from dependency. It is now listed as a dev dependency since it is only used for testing.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3331,7 +3331,7 @@
       "license": "MIT"
     },
     "node_modules/@open-wc/dedupe-mixin": {
-      "version": "1.3.1",
+      "version": "1.4.0",
       "dev": true,
       "license": "MIT"
     },
@@ -3391,18 +3391,13 @@
       }
     },
     "node_modules/@open-wc/scoped-elements": {
-      "version": "2.1.4",
+      "version": "2.2.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lit/reactive-element": "^1.0.0",
-        "@open-wc/dedupe-mixin": "^1.3.0"
+        "@open-wc/dedupe-mixin": "^1.4.0"
       }
-    },
-    "node_modules/@open-wc/scoped-elements/node_modules/@lit-labs/ssr-dom-shim": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "BSD-3-Clause"
     },
     "node_modules/@open-wc/scoped-elements/node_modules/@lit/reactive-element": {
       "version": "1.6.3",
@@ -3413,43 +3408,166 @@
       }
     },
     "node_modules/@open-wc/semantic-dom-diff": {
-      "version": "0.19.9",
+      "version": "0.20.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/chai": "^4.3.1",
-        "@web/test-runner-commands": "^0.6.5"
+        "@web/test-runner-commands": "^0.7.0"
+      }
+    },
+    "node_modules/@open-wc/semantic-dom-diff/node_modules/@types/convert-source-map": {
+      "version": "2.0.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-wc/semantic-dom-diff/node_modules/@web/browser-logs": {
+      "version": "0.3.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "errorstacks": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@open-wc/semantic-dom-diff/node_modules/@web/dev-server-core": {
+      "version": "0.6.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/koa": "^2.11.6",
+        "@types/ws": "^7.4.0",
+        "@web/parse5-utils": "^2.0.2",
+        "chokidar": "^3.4.3",
+        "clone": "^2.1.2",
+        "es-module-lexer": "^1.0.0",
+        "get-stream": "^6.0.0",
+        "is-stream": "^2.0.0",
+        "isbinaryfile": "^5.0.0",
+        "koa": "^2.13.0",
+        "koa-etag": "^4.0.0",
+        "koa-send": "^5.0.1",
+        "koa-static": "^5.0.0",
+        "lru-cache": "^8.0.4",
+        "mime-types": "^2.1.27",
+        "parse5": "^6.0.1",
+        "picomatch": "^2.2.2",
+        "ws": "^7.4.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@open-wc/semantic-dom-diff/node_modules/@web/parse5-utils": {
+      "version": "2.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/parse5": "^6.0.1",
+        "parse5": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@open-wc/semantic-dom-diff/node_modules/@web/test-runner-commands": {
+      "version": "0.7.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@web/test-runner-core": "^0.11.0",
+        "mkdirp": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@open-wc/semantic-dom-diff/node_modules/@web/test-runner-core": {
+      "version": "0.11.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.12.11",
+        "@types/babel__code-frame": "^7.0.2",
+        "@types/co-body": "^6.1.0",
+        "@types/convert-source-map": "^2.0.0",
+        "@types/debounce": "^1.2.0",
+        "@types/istanbul-lib-coverage": "^2.0.3",
+        "@types/istanbul-reports": "^3.0.0",
+        "@web/browser-logs": "^0.3.4",
+        "@web/dev-server-core": "^0.6.2",
+        "chokidar": "^3.4.3",
+        "cli-cursor": "^3.1.0",
+        "co-body": "^6.1.0",
+        "convert-source-map": "^2.0.0",
+        "debounce": "^1.2.0",
+        "dependency-graph": "^0.11.0",
+        "globby": "^11.0.1",
+        "ip": "^1.1.5",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.0.2",
+        "log-update": "^4.0.0",
+        "nanocolors": "^0.2.1",
+        "nanoid": "^3.1.25",
+        "open": "^8.0.2",
+        "picomatch": "^2.2.2",
+        "source-map": "^0.7.3"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@open-wc/semantic-dom-diff/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-wc/semantic-dom-diff/node_modules/isbinaryfile": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/gjtorikian/"
+      }
+    },
+    "node_modules/@open-wc/semantic-dom-diff/node_modules/lru-cache": {
+      "version": "8.0.5",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16.14"
       }
     },
     "node_modules/@open-wc/testing": {
-      "version": "3.1.7",
+      "version": "3.2.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@esm-bundle/chai": "^4.3.4-fix.0",
         "@open-wc/chai-dom-equals": "^0.12.36",
-        "@open-wc/semantic-dom-diff": "^0.19.7",
-        "@open-wc/testing-helpers": "^2.1.4",
+        "@open-wc/semantic-dom-diff": "^0.20.0",
+        "@open-wc/testing-helpers": "^2.3.0",
         "@types/chai": "^4.2.11",
-        "@types/chai-dom": "^0.0.12",
+        "@types/chai-dom": "^1.11.0",
         "@types/sinon-chai": "^3.2.3",
-        "chai-a11y-axe": "^1.3.2"
+        "chai-a11y-axe": "^1.5.0"
       }
     },
     "node_modules/@open-wc/testing-helpers": {
-      "version": "2.1.4",
+      "version": "2.3.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@open-wc/scoped-elements": "^2.1.3",
+        "@open-wc/scoped-elements": "^2.2.0",
         "lit": "^2.0.0",
         "lit-html": "^2.0.0"
       }
-    },
-    "node_modules/@open-wc/testing-helpers/node_modules/@lit-labs/ssr-dom-shim": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "BSD-3-Clause"
     },
     "node_modules/@open-wc/testing-helpers/node_modules/@lit/reactive-element": {
       "version": "1.6.3",
@@ -4308,7 +4426,7 @@
       "license": "MIT"
     },
     "node_modules/@types/chai-dom": {
-      "version": "0.0.12",
+      "version": "1.11.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8148,7 +8266,7 @@
       }
     },
     "node_modules/chai-a11y-axe": {
-      "version": "1.4.0",
+      "version": "1.5.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15209,15 +15327,15 @@
       }
     },
     "node_modules/istanbul-lib-report": {
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "istanbul-lib-coverage": "^3.0.0",
-        "make-dir": "^3.0.0",
+        "make-dir": "^4.0.0",
         "supports-color": "^7.1.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
       }
     },
     "node_modules/istanbul-lib-report/node_modules/has-flag": {
@@ -15225,6 +15343,42 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/make-dir": {
+      "version": "4.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/semver": {
+      "version": "7.5.4",
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/istanbul-lib-report/node_modules/supports-color": {
@@ -15236,6 +15390,10 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/istanbul-lib-report/node_modules/yallist": {
+      "version": "4.0.0",
+      "license": "ISC"
     },
     "node_modules/istanbul-lib-source-maps": {
       "version": "4.0.1",
@@ -17247,6 +17405,7 @@
     },
     "node_modules/make-dir": {
       "version": "3.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "semver": "^6.0.0"
@@ -26262,8 +26421,8 @@
       "version": "1.0.2",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/ssr": "^3.1.8-pre.0",
-        "lit": "^3.0.0"
+        "@lit-labs/ssr": "^3.1.8",
+        "lit": "^2.7.0 || ^3.0.0"
       },
       "devDependencies": {
         "@11ty/eleventy": "^1.0.0",
@@ -26357,10 +26516,10 @@
       "dependencies": {
         "@lit-labs/analyzer": "^0.10.0",
         "@lit-labs/gen-utils": "^0.3.0",
-        "@lit-labs/vue-utils": "^0.1.1-pre.0"
+        "@lit-labs/vue-utils": "^0.1.1"
       },
       "devDependencies": {
-        "@lit-internal/tests": "^0.0.1-pre.0"
+        "@lit-internal/tests": "^0.0.1"
       },
       "engines": {
         "node": ">=14.8.0"
@@ -26383,7 +26542,7 @@
       "version": "0.1.2",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/ssr-react": "^0.2.1-pre.0",
+        "@lit-labs/ssr-react": "^0.2.1",
         "imports-loader": "^4.0.1"
       },
       "peerDependencies": {
@@ -27033,21 +27192,21 @@
       "version": "3.1.8",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/ssr-client": "^1.1.4-pre.0",
-        "@lit-labs/ssr-dom-shim": "^1.1.2-pre.0",
-        "@lit/reactive-element": "^2.0.0",
+        "@lit-labs/ssr-client": "^1.1.4",
+        "@lit-labs/ssr-dom-shim": "^1.1.2",
+        "@lit/reactive-element": "^1.6.1 || ^2.0.0",
         "@parse5/tools": "^0.3.0",
         "@types/node": "^16.0.0",
         "enhanced-resolve": "^5.10.0",
-        "lit": "^3.0.0",
-        "lit-element": "^4.0.0",
-        "lit-html": "^3.0.0",
+        "lit": "^2.7.0 || ^3.0.0",
+        "lit-element": "^3.3.0 || ^4.0.0",
+        "lit-html": "^2.7.0 || ^3.0.0",
         "node-fetch": "^3.2.8",
         "parse5": "^7.1.1"
       },
       "devDependencies": {
         "@koa/router": "^12.0.0",
-        "@open-wc/testing": "^3.0.0-next.1",
+        "@open-wc/testing": "^3.2.0",
         "@open-wc/testing-karma": "^4.0.9",
         "@types/command-line-args": "^5.0.0",
         "@types/koa": "^2.0.49",
@@ -27074,9 +27233,9 @@
       "version": "1.1.4",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit/reactive-element": "^2.0.0",
-        "lit": "^3.0.0",
-        "lit-html": "^3.0.0"
+        "@lit/reactive-element": "^1.6.1 || ^2.0.0",
+        "lit": "^2.7.0 || ^3.0.0",
+        "lit-html": "^2.7.0 || ^3.0.0"
       },
       "devDependencies": {
         "@lit-internal/scripts": "^1.0.1"
@@ -27092,14 +27251,14 @@
       "version": "0.2.1",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/ssr": "^3.1.8-pre.0",
-        "@lit-labs/ssr-client": "^1.1.4-pre.0",
-        "lit": "^3.0.0"
+        "@lit-labs/ssr": "^3.1.8",
+        "@lit-labs/ssr-client": "^1.1.4"
       },
       "devDependencies": {
         "@lit/react": "1.0.0",
         "@types/react": "^18.0.27",
         "@types/react-dom": "^18.0.10",
+        "lit": "^3.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "uvu": "^0.5.6"
@@ -27127,7 +27286,7 @@
         "@lit/task": "^1.0.0"
       },
       "devDependencies": {
-        "@lit-internal/scripts": "^1.0.1-pre.0",
+        "@lit-internal/scripts": "^1.0.1",
         "@types/trusted-types": "^2.0.2",
         "lit": "^3.0.0"
       }
@@ -27163,11 +27322,11 @@
       "version": "0.2.2",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/ssr": "^3.1.8-pre.0",
-        "@lit-labs/ssr-client": "^1.1.4-pre.0",
+        "@lit-labs/ssr": "^3.1.8",
+        "@lit-labs/ssr-client": "^1.1.4",
         "@web/test-runner-commands": "^0.6.1",
         "@webcomponents/template-shadowroot": "^0.1.0",
-        "lit": "^3.0.0"
+        "lit": "^2.0.0 || ^3.0.0"
       },
       "devDependencies": {
         "@open-wc/testing": "^3.1.5"
@@ -27219,7 +27378,7 @@
       "version": "4.0.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.1.2-pre.0",
+        "@lit-labs/ssr-dom-shim": "^1.1.2",
         "@lit/reactive-element": "^2.0.0",
         "lit-html": "^3.0.0"
       },
@@ -27695,7 +27854,7 @@
       "version": "2.0.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.1.2-pre.0"
+        "@lit-labs/ssr-dom-shim": "^1.1.2"
       },
       "devDependencies": {
         "@babel/cli": "^7.22.10",

--- a/packages/labs/eleventy-plugin-lit/package.json
+++ b/packages/labs/eleventy-plugin-lit/package.json
@@ -90,8 +90,8 @@
     }
   },
   "dependencies": {
-    "@lit-labs/ssr": "^3.1.8-pre.0",
-    "lit": "^3.0.0"
+    "@lit-labs/ssr": "^3.1.8",
+    "lit": "^2.7.0 || ^3.0.0"
   },
   "devDependencies": {
     "@11ty/eleventy": "^1.0.0",

--- a/packages/labs/ssr-client/package.json
+++ b/packages/labs/ssr-client/package.json
@@ -128,9 +128,9 @@
     "@lit-internal/scripts": "^1.0.1"
   },
   "dependencies": {
-    "@lit/reactive-element": "^2.0.0",
-    "lit": "^3.0.0",
-    "lit-html": "^3.0.0"
+    "@lit/reactive-element": "^1.6.1 || ^2.0.0",
+    "lit": "^2.7.0 || ^3.0.0",
+    "lit-html": "^2.7.0 || ^3.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/labs/ssr-react/package.json
+++ b/packages/labs/ssr-react/package.json
@@ -47,9 +47,8 @@
     "/jsx-runtime.{d.ts,d.ts.map,js,js.map}"
   ],
   "dependencies": {
-    "@lit-labs/ssr": "^3.1.8-pre.0",
-    "@lit-labs/ssr-client": "^1.1.4-pre.0",
-    "lit": "^3.0.0"
+    "@lit-labs/ssr": "^3.1.8",
+    "@lit-labs/ssr-client": "^1.1.4"
   },
   "peerDependencies": {
     "@types/react": "17 || 18",
@@ -103,6 +102,7 @@
     "@lit/react": "1.0.0",
     "@types/react": "^18.0.27",
     "@types/react-dom": "^18.0.10",
+    "lit": "^3.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "uvu": "^0.5.6"

--- a/packages/labs/ssr/package.json
+++ b/packages/labs/ssr/package.json
@@ -187,7 +187,7 @@
   },
   "devDependencies": {
     "@koa/router": "^12.0.0",
-    "@open-wc/testing": "^3.0.0-next.1",
+    "@open-wc/testing": "^3.2.0",
     "@open-wc/testing-karma": "^4.0.9",
     "@types/command-line-args": "^5.0.0",
     "@types/koa": "^2.0.49",
@@ -206,15 +206,15 @@
     "koa-static": "^5.0.0"
   },
   "dependencies": {
-    "@lit-labs/ssr-client": "^1.1.4-pre.0",
-    "@lit-labs/ssr-dom-shim": "^1.1.2-pre.0",
-    "@lit/reactive-element": "^2.0.0",
+    "@lit-labs/ssr-client": "^1.1.4",
+    "@lit-labs/ssr-dom-shim": "^1.1.2",
+    "@lit/reactive-element": "^1.6.1 || ^2.0.0",
     "@parse5/tools": "^0.3.0",
     "@types/node": "^16.0.0",
     "enhanced-resolve": "^5.10.0",
-    "lit": "^3.0.0",
-    "lit-element": "^4.0.0",
-    "lit-html": "^3.0.0",
+    "lit": "^2.7.0 || ^3.0.0",
+    "lit-element": "^3.3.0 || ^4.0.0",
+    "lit-html": "^2.7.0 || ^3.0.0",
     "node-fetch": "^3.2.8",
     "parse5": "^7.1.1"
   },


### PR DESCRIPTION
Last of the dependency version changes!

Affected packages:

- '@lit-labs/eleventy-plugin-lit': patch
- '@lit-labs/ssr': patch
- '@lit-labs/ssr-client': patch

Minimum versions used:
- [`lit-html`@2.7.0](https://github.com/lit/lit/blob/main/packages/lit-html/CHANGELOG.md#270): Includes https://github.com/lit/lit/pull/3667
- [`lit-element`@3.3.0](https://github.com/lit/lit/blob/main/packages/lit-element/CHANGELOG.md#330): Includes https://github.com/lit/lit/pull/3677, specifically reflected ARIA attribute removal on hydration.
- [`@lit/reactive-element@1.6.1`](https://github.com/lit/lit/blob/main/packages/reactive-element/CHANGELOG.md#161): Includes https://github.com/lit/lit/pull/3561 with auto-shimming Node build
- [`lit@2.7.0`](https://github.com/lit/lit/blob/main/packages/lit/CHANGELOG.md#270): Version that contains all of the above

Also,

- '@lit-labs/ssr-react': patch

Moved `lit` package from dependency to dev dependency because it's not actually used for library code, only for testing.
