### PR TITLE
[labs/ssr-client] Avoid nullish logical assignment in hydrate-lit-html

### DIFF
--- a/.changeset/olive-otters-vanish.md
+++ b/.changeset/olive-otters-vanish.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/ssr-client': patch
+---
+
+Avoid nullish logical assignment in hydrate-lit-html which some minification process would not handle correctly. Fixes hydration errors in Next.js production bundles.

--- a/packages/labs/ssr-client/src/lib/hydrate-lit-html.ts
+++ b/packages/labs/ssr-client/src/lib/hydrate-lit-html.ts
@@ -163,7 +163,7 @@ export const hydrate = (
       }
       // Create a new ChildPart and push it onto the stack
       currentChildPart = openChildPart(rootValue, marker, stack, options);
-      // Using nullish logical assignment below can cause some minifier to move
+      // Using nullish logical assignment below can cause next.js's swc to move
       // the `openChildPart()` call above behind the nullish check.
       // See https://github.com/lit/lit/issues/4289
       if (rootPart === undefined) {

--- a/packages/labs/ssr-client/src/lib/hydrate-lit-html.ts
+++ b/packages/labs/ssr-client/src/lib/hydrate-lit-html.ts
@@ -163,7 +163,12 @@ export const hydrate = (
       }
       // Create a new ChildPart and push it onto the stack
       currentChildPart = openChildPart(rootValue, marker, stack, options);
-      rootPart ??= currentChildPart;
+      // Using nullish logical assignment below can cause some minifier to move
+      // the `openChildPart()` call above behind the nullish check.
+      // See https://github.com/lit/lit/issues/4289
+      if (rootPart === undefined) {
+        rootPart = currentChildPart;
+      }
       rootPartMarker ??= marker;
     } else if (markerText.startsWith('lit-node')) {
       // Create and hydrate attribute parts into the current ChildPart on the


### PR DESCRIPTION
Fixes https://github.com/lit/lit/issues/4289

While swc did fix this upstream it's not released yet and I don't know how long it takes for that to make it into Next.js's version of swc.

It seems like a tiny lift for us to add this to make it work now.