### PR TITLE
[labs/ssr] fix ModuleLoader failing with multiple concurrent entrypoints

### DIFF
--- a/.changeset/eighty-jars-help.md
+++ b/.changeset/eighty-jars-help.md
@@ -1,0 +1,6 @@
+---
+'@lit-labs/eleventy-plugin-lit': patch
+'@lit-labs/ssr': patch
+---
+
+Fix ModuleLoader so it can load modules concurrently.

--- a/packages/labs/eleventy-plugin-lit/src/index.ts
+++ b/packages/labs/eleventy-plugin-lit/src/index.ts
@@ -157,11 +157,11 @@ ${reset}`
     )) as typeof import('@lit-labs/ssr/lib/module-loader.js');
     const window = getWindow({includeJSBuiltIns: true});
     const loader = new ModuleLoader({global: window});
-    // TODO(aomarks) Replace with concurrent Promise.all version once
-    // https://github.com/lit/lit/issues/2549 has been addressed.
-    for (const module of resolvedComponentModules) {
-      await loader.importModule(module, renderModulePath);
-    }
+    await Promise.all(
+      resolvedComponentModules.map((module) =>
+        loader.importModule(module, renderModulePath)
+      )
+    );
     contextifiedRender = (
       await loader.importModule(
         '@lit-labs/ssr/lib/render-lit-html.js',

--- a/packages/labs/ssr/src/test/lib/module-loader_test.ts
+++ b/packages/labs/ssr/src/test/lib/module-loader_test.ts
@@ -96,4 +96,18 @@ test('prefers "module" condition over "import"', async () => {
   assert.ok(loader.cache.has(packagePath));
 });
 
+test('concurrently load modules with a shared dependency without crashing', async () => {
+  const loader = new ModuleLoader();
+  // Both of these dependencies import LitElement from `lit`.
+  const [rootResult, result] = await Promise.all([
+    loader.importModule('./lit-import-from-root.js', testIndex),
+    loader.importModule('./lit-import.js', testIndex),
+  ]);
+  const {module: rootModule} = rootResult;
+  const {module} = result;
+
+  assert.ok(rootModule.namespace.litElement);
+  assert.is(rootModule.namespace.litElement, module.namespace.litElement);
+});
+
 test.run();

--- a/packages/labs/ssr/src/test/test-files/module-loader/lit-import-from-root.js
+++ b/packages/labs/ssr/src/test/test-files/module-loader/lit-import-from-root.js
@@ -1,2 +1,3 @@
-import {isServer} from 'lit';
+import {isServer, LitElement} from 'lit';
 export const litIsServer = isServer;
+export const litElement = LitElement;

--- a/packages/labs/ssr/src/test/test-files/module-loader/lit-import.js
+++ b/packages/labs/ssr/src/test/test-files/module-loader/lit-import.js
@@ -1,2 +1,4 @@
 import {isServer} from 'lit-html/is-server.js';
+import {LitElement} from 'lit-element';
 export const litIsServer = isServer;
+export const litElement = LitElement;


### PR DESCRIPTION
Fixes: https://github.com/lit/lit/issues/2549

### Context

When the eleventy ssr plugin loads modules concurrently, it would previously fail with an error. Something like:

```
Error: request for '@lit/reactive-element' is not yet fulfilled
        at SourceTextModule.link (node:internal/vm/module:198:17)
        at ModuleLoader.importModule (/home/aomarks/work/wireit-lit/packages/labs/ssr/src/lib/module-loader.ts:107:7)
        at async Promise.all (index 1)
```

Investigating this issue I found:
 - Specification of the module methods: https://tc39.es/ecma262/#table-abstract-methods-of-module-records
 - Located the error message in the node codebase: https://github.com/nodejs/node/blob/eed33c9deaa336e76c5385a077490107c6110f08/src/module_wrap.cc#L532-L535

Solution is to closer match the spec. `LoadRequestedModules` should prepare module for linking by loading **all** dependencies.
Then when `Link` is called, `LoadRequestedModules` must have completed.

### Theory

Before linking our code does:

```
async importModule(...){
    ...
    const result = await this._loadModule(specifier, referrerPath); // <--- `LoadRequestedModules`
    const module = result.module as vm.Module;
    if (module.status === 'unlinked') {
      await module.link(this._linker); // <--- `Link`
    }
   ...
}
```

However previously our `_loadModule` method did not load all dependencies, relying on `module.link` to load the dependencies. This seems to work when not loading multiple modules concurrently.

But, to allow multiple modules to load concurrently I've added some additional module loading logic to `_loadModule` so dependencies get loaded.

The result is that by the time `module.link` is reached, all modules should have been loaded.

### Test plan

I added a unit test which throws `Error: request for 'XXXX' is not yet fulfilled` without the fix.

### Risk

There is a risk that this adds a regression to the eleventy SSR plugin if something isn't quite right.
