### PR TITLE
Draft: Trying out DOMParser for lit-html

### DIFF
--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -856,7 +856,7 @@ const getTemplateHtml = (
 export type {Template};
 class Template {
   /** @internal */
-  static parser = new DOMParser();
+  static parser: DOMParser;
 
   /** @internal */
   el!: DocumentFragment;
@@ -1001,6 +1001,9 @@ class Template {
     _options?: RenderOptions | undefined,
     type?: ResultType
   ) {
+    if (this.parser === undefined) {
+      this.parser = new DOMParser();
+    }
     const doc = this.parser.parseFromString(
       '<body>' + (html as unknown as string) + '</body>',
       'text/html'

--- a/scripts/check-size.js
+++ b/scripts/check-size.js
@@ -9,8 +9,8 @@ import * as fs from 'fs';
 // it's likely that we'll ask you to investigate ways to reduce the size.
 //
 // In either case, update the size here and push a new commit to your PR.
-const expectedLitCoreSize = 15423;
-const expectedLitHtmlSize = 7250;
+const expectedLitCoreSize = 15506;
+const expectedLitHtmlSize = 7331;
 
 const litCoreSrc = fs.readFileSync('packages/lit/lit-core.min.js', 'utf8');
 const litCoreSize = fs.readFileSync('packages/lit/lit-core.min.js').byteLength;


### PR DESCRIPTION
DOMParser actually returns a document, and can weirdly move comments around if we don't specifically wrap the text in a `<body>` tag, so I'm re-parenting the nodes from the document body to a new document fragment.

The template instance now stores the document fragment instead of the template element in `.el`.

The parser always need to run with text/html, even for svg tags, as we want created elements in the document to actually be SVGElements so we still have to do the `<svg>` element wrapping.

For polyfill-support, since `ShadyDOM.prepareTemplateStyles` expects a template element, I'm then reparenting the fragment back into a template element, letting ShadyDOM prepare, then reparent again.

These re-parentings probably will make things slower.