### PR TITLE
[labs/virtualizer] correctly specify lit dependency as a peer

### DIFF
--- a/packages/labs/virtualizer/package.json
+++ b/packages/labs/virtualizer/package.json
@@ -159,7 +159,9 @@
     "tachometer": "^0.7.0"
   },
   "dependencies": {
-    "lit": "^2 || ^3",
     "tslib": "^2.0.3"
+  },
+  "peerDependencies": {
+    "lit": "^2 || ^3"
   }
 }


### PR DESCRIPTION
currently lit is specified as a "prod" dependency rather than a peer dependency. This will lead more developers to ending up with the "Muliple versions of lit loaded" error message