### PR TITLE
[infra] Split out size check workflow from benchmarks

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -21,23 +21,6 @@ jobs:
       - name: NPM install
         run: npm ci
 
-      - name: Generate size report
-        run: npm run benchmark:size
-
-      - name: Comment on size report empty
-        if: ${{ !failure() }}
-        uses: thollander/actions-comment-pull-request@v2
-        with:
-          message: 'The size of lit-html.js and lit-core.min.js are as expected.'
-          comment_tag: check-size # ensures we delete the comment if present
-
-      - name: Comment about failing size report
-        if: ${{ failure() }}
-        uses: thollander/actions-comment-pull-request@v2
-        with:
-          filePath: scripts/check-size-out.md
-          comment_tag: check-size # ensures we create or update one size comment
-
       - name: Build
         run: |
           cd packages/benchmarks

--- a/.github/workflows/sizecheck-report.yaml
+++ b/.github/workflows/sizecheck-report.yaml
@@ -1,0 +1,40 @@
+name: Report Sizecheck Results
+
+on:
+  workflow_run:
+    workflows: [Sizecheck]
+    branches: ['**']
+    types: [completed]
+
+jobs:
+  on-success:
+    name: Report sizecheck success
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Comment on size report empty
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          message: 'The size of lit-html.js and lit-core.min.js are as expected.'
+          comment_tag: check-size # ensures we overwrite old failure comment if present
+
+  on-failure:
+    name: Report sizecheck failure
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    steps:
+      # Download the artifact from the triggering workflow that contains the
+      # size check results to report
+      - name: Download artifact
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: ${{ github.event.workflow.id }}
+          run_id: ${{ github.event.workflow_run.id }}
+          name: sizecheck
+          path: scripts
+
+      - name: Comment about failing size report
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          filePath: scripts/check-size-out.md
+          comment_tag: check-size # ensures we create or update one size comment

--- a/.github/workflows/sizecheck.yaml
+++ b/.github/workflows/sizecheck.yaml
@@ -1,0 +1,32 @@
+name: Sizecheck
+
+on: [pull_request]
+
+jobs:
+  checksize:
+    name: sizecheck
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - uses: google/wireit@setup-github-actions-caching/v1
+
+      - name: NPM install
+        run: npm ci
+
+      - name: Generate size report
+        run: npm run benchmark:size
+
+      - name: Upload failure artifact
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: sizecheck
+          path: scripts/check-size-out.md


### PR DESCRIPTION
Fixes https://github.com/lit/lit/issues/4288

I followed a similar pattern as the benchmarks report workflow added here https://github.com/lit/lit/pull/4041

Workflows running on forks can't use actions that write comments on the PR. This moves the size check to its own workflow, and a separate workflow that triggers on the completion of that size check is responsible for writing the comment.

The original size check wrote a markdown file on failure for the comment message so that is added as an artifact, similar to how benchmark results are done.

We won't see this work on this PR as workflows that are triggered by other workflows only run off of a protected main branch for security as these workflows have elevated access. It'll show up for PRs after this is merged to main.