### PR TITLE
[localize] Loosen type of `@localized()` decorator

### DIFF
--- a/.changeset/healthy-dingos-pay.md
+++ b/.changeset/healthy-dingos-pay.md
@@ -1,0 +1,5 @@
+---
+'@lit/localize': patch
+---
+
+Loosen type for the `@localized()` decorator to accept cross version `ReactiveElement`s. Also remove dependency on `@lit/reactive-element` as it is already covered by the `lit` dependency.

--- a/.changeset/healthy-dingos-pay.md
+++ b/.changeset/healthy-dingos-pay.md
@@ -2,4 +2,4 @@
 '@lit/localize': patch
 ---
 
-Loosen type for the `@localized()` decorator to accept cross version `ReactiveElement`s. Also remove dependency on `@lit/reactive-element` as it is already covered by the `lit` dependency.
+Loosen type for the `@localized()` decorator to be able to decorate any `ReactiveControllerHost` which also alleviates type errors that could arise with multiple copies of `@lit/reactive-element` present in the project. Also remove dependency on `@lit/reactive-element` as it is already covered by the `lit` dependency.

--- a/package-lock.json
+++ b/package-lock.json
@@ -27747,7 +27747,6 @@
       "version": "0.12.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit/reactive-element": "^1.0.0 || ^2.0.0",
         "lit": "^2.0.0 || ^3.0.0"
       }
     },

--- a/packages/localize/package.json
+++ b/packages/localize/package.json
@@ -89,7 +89,6 @@
     "/init/"
   ],
   "dependencies": {
-    "@lit/reactive-element": "^1.0.0 || ^2.0.0",
     "lit": "^2.0.0 || ^3.0.0"
   }
 }

--- a/packages/localize/src/internal/localized-decorator.ts
+++ b/packages/localize/src/internal/localized-decorator.ts
@@ -6,7 +6,7 @@
 
 import {updateWhenLocaleChanges} from './localized-controller.js';
 
-import type {ReactiveElement} from '@lit/reactive-element';
+import type {ReactiveControllerHost} from 'lit';
 
 /**
  * Generates a public interface type that removes private and protected fields.
@@ -17,9 +17,10 @@ export type Interface<T> = {
   [K in keyof T]: T[K];
 };
 
-type ReactiveElementClass = Interface<typeof ReactiveElement> & {
+type ReactiveElementClass = {
+  addInitializer(initializer: (element: ReactiveControllerHost) => void): void;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  new (...args: any[]): Interface<ReactiveElement>;
+  new (...args: any[]): ReactiveControllerHost;
 };
 
 export type LocalizedDecorator = {


### PR DESCRIPTION
This alleviates type errors when there's a different version of `reactive-element` that `@lit/localize` is using versus what the user's component is using.

Because `localized` is a class decorator, the standard `Interface` with `Omit` or `Pick` was not usable as there were static properties on it that conflict. I tried `Pick<typeof ReactiveElement, 'addInitializer'>` but the initializer type references `ReactiveElement` directly which breaks because of `renderRoot`.

I also removed the dependency on `@lit/reactive-element` and just import everything from `lit`.

I do wonder though.. `@lit/localize` only uses the `lit` package for types/interfaces. It exports utilities strictly meant to be used with `lit` projects and nothing is standalone. This is a prime candidate for marking `lit` as a peer dependency as described in https://github.com/lit/rfcs/issues/31.

I tried it locally by updating the package.json to specify lit as a peer dependency, without the loosened type fix `npm pack` and installed the tarball in a lit 2 test project that was having type errors before. It no longer errors as it did not create a nested duplicate `@lit/reactive-element`. But, to be fair, this was also the case with just expanding the dependency version to include lit 2 even as a non-peer regular dependency as npm was able to dedupe it then too.