### PR TITLE
[context] Only depend on `@lit/reactive-element`

### DIFF
--- a/.changeset/chilly-geckos-occur.md
+++ b/.changeset/chilly-geckos-occur.md
@@ -1,0 +1,5 @@
+---
+'@lit/context': patch
+---
+
+Remove dependency on `lit` package. All implementation code only uses `@lit/reactive-element`. `lit` is moved to dev dependencies as it is still used for tests.

--- a/package-lock.json
+++ b/package-lock.json
@@ -26266,14 +26266,14 @@
       "version": "1.0.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit/reactive-element": "^1.6.2 || ^2.0.0",
-        "lit": "^2.7.5 || ^3.0.0"
+        "@lit/reactive-element": "^1.6.2 || ^2.0.0"
       },
       "devDependencies": {
         "@esm-bundle/chai": "^4.3.4-fix.0",
         "@lit-internal/scripts": "^1.0.1",
         "@lit-labs/testing": "^0.2.2",
-        "@types/trusted-types": "^2.0.2"
+        "@types/trusted-types": "^2.0.2",
+        "lit": "^3.0.0"
       }
     },
     "packages/internal-scripts": {

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -210,14 +210,14 @@
   },
   "author": "Google LLC",
   "dependencies": {
-    "@lit/reactive-element": "^1.6.2 || ^2.0.0",
-    "lit": "^2.7.5 || ^3.0.0"
+    "@lit/reactive-element": "^1.6.2 || ^2.0.0"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4-fix.0",
     "@lit-internal/scripts": "^1.0.1",
     "@lit-labs/testing": "^0.2.2",
-    "@types/trusted-types": "^2.0.2"
+    "@types/trusted-types": "^2.0.2",
+    "lit": "^3.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/context/src/lib/controllers/context-consumer.ts
+++ b/packages/context/src/lib/controllers/context-consumer.ts
@@ -8,8 +8,11 @@ import {
   ContextCallback,
   ContextRequestEvent,
 } from '../context-request-event.js';
-import {Context, ContextType} from '../create-context.js';
-import {ReactiveController, ReactiveControllerHost} from 'lit';
+import type {Context, ContextType} from '../create-context.js';
+import type {
+  ReactiveController,
+  ReactiveControllerHost,
+} from '@lit/reactive-element';
 
 export interface Options<C extends Context<unknown, unknown>> {
   context: C;

--- a/packages/context/src/lib/controllers/context-provider.ts
+++ b/packages/context/src/lib/controllers/context-provider.ts
@@ -7,7 +7,10 @@
 import {ContextRequestEvent} from '../context-request-event.js';
 import {ValueNotifier} from '../value-notifier.js';
 import type {Context, ContextType} from '../create-context.js';
-import type {ReactiveController, ReactiveControllerHost} from 'lit';
+import type {
+  ReactiveController,
+  ReactiveControllerHost,
+} from '@lit/reactive-element';
 
 declare global {
   interface HTMLElementEventMap {


### PR DESCRIPTION
We had both `lit` and `@lit/reactive-element` listed as dependency but really all we need for the implementation is `@lit/reactive-element` for the types. This would be a good candidate to consider making it a peer dependency as well.

`lit` is moved to dev dependency as it is used for testing.