### PR TITLE
[infra] Use Node 18 for windows-tools test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,7 +87,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 18
           cache: 'npm'
           cache-dependency-path: package-lock.json
 


### PR DESCRIPTION
I've been seeing a lot of windows-tools workflow failures like https://github.com/lit/lit/actions/runs/6660895512/job/18102830296

Possibly related issues:
https://github.com/npm/cli/issues/6763
https://github.com/orgs/nodejs/discussions/49784

There's a potential fix https://github.com/nodejs/node/pull/50136 that hasn't made it to latest node 20 that github actions is getting.

So I'm just trying to downgrade to 18 see if it'll help.