### PR TITLE
Lit/React – Wraps `ref` in a stable callback

### DIFF
--- a/.changeset/violet-bugs-return.md
+++ b/.changeset/violet-bugs-return.md
@@ -1,5 +1,5 @@
 ---
-"@lit/react": patch
+'@lit/react': patch
 ---
 
-Use a stable callback for passing the forwarded `ref` to the underlying custom element.
+When passing a `ref` callback to the Component, `createComponent` was previously intercepting it and wrapping it in an unbound function. This change memoizes the consumer `ref` with `useCallback`, to keep the reference stable and ensure it isn't invoked repeatedly on subsequent renders.

--- a/.changeset/violet-bugs-return.md
+++ b/.changeset/violet-bugs-return.md
@@ -2,4 +2,4 @@
 "@lit/react": patch
 ---
 
-Lit/React – Wraps `ref` in a stable callback
+Use a stable callback for passing the forwarded `ref` to the underlying custom element.

--- a/.changeset/violet-bugs-return.md
+++ b/.changeset/violet-bugs-return.md
@@ -1,0 +1,5 @@
+---
+"@lit/react": patch
+---
+
+Lit/React – Wraps `ref` in a stable callback

--- a/packages/react/src/create-component.ts
+++ b/packages/react/src/create-component.ts
@@ -315,14 +315,17 @@ export const createComponent = <
 
     return React.createElement(tagName, {
       ...reactProps,
-      ref: (node: I) => {
-        elementRef.current = node;
-        if (typeof ref === 'function') {
-          ref(node);
-        } else if (ref !== null) {
-          ref.current = node;
-        }
-      },
+      ref: React.useCallback(
+        (node: I) => {
+          elementRef.current = node;
+          if (typeof ref === 'function') {
+            ref(node);
+          } else if (ref !== null) {
+            ref.current = node;
+          }
+        },
+        [ref]
+      ),
     });
   });
 


### PR DESCRIPTION
I noticed in the case of providing a stable `ref` callback to a wrapped React component, it was invoking it on every render. This is because the internal `ref` is set to an unstable function, with a new reference on every render. This was particularly problematic when using a callback to do some kind of setup/cleanup loop based on connecting/disconnecting to the DOM.

To my knowledge, both React and Lit's `ref` callback functionality is to ensure this only happens on connect/disconnect, or if the reference changes.

E.g.

```ts
const MyComponent = () => {
  // Stable ref callback
  const onNode = useCallback((node: HTMLElement | null) => {
    console.log(node);
    if (node) {
      // Element is mounted, do some setup
    } else {
      // Element is unmounted, do some cleanup
    }
  }, []);
  
  return (
    <LitReactComponent ref={onNode} />
  );
}

// onNode invoked twice every render:
// call 1: null
// call 2: node
```

This PR ensures the intercepted `ref` callback within `createComponent` is stable between renders.