### PR TITLE
[infra] Re-enable wireit github cache and make tests-local parallel 2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       WIREIT_LOGGER: quiet-ci
-      WIREIT_PARALLEL: 1
+      WIREIT_PARALLEL: 2
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,7 +60,7 @@ jobs:
           cache: 'npm'
           cache-dependency-path: package-lock.json
 
-      # - uses: google/wireit@setup-github-actions-caching/v1
+      - uses: google/wireit@setup-github-actions-caching/v1
 
       - name: Install playwright deps
         run: npx playwright install-deps
@@ -91,7 +91,7 @@ jobs:
           cache: 'npm'
           cache-dependency-path: package-lock.json
 
-      # - uses: google/wireit@setup-github-actions-caching/v1
+      - uses: google/wireit@setup-github-actions-caching/v1
 
       - name: NPM install
         run: npm ci


### PR DESCRIPTION
Full run of tests-local is taking ~28 minutes.

Wireit github caching was skipped to see if there was erroneous caching of artifacts but we're still seeing test build failures with not finding type defs and such so these have not been helping against that.