### PR TITLE
[context, react] Update dependency on graduated package to `^1.0.0`

### DIFF
--- a/.changeset/late-books-draw.md
+++ b/.changeset/late-books-draw.md
@@ -1,0 +1,6 @@
+---
+'@lit-labs/context': patch
+'@lit-labs/react': patch
+---
+
+Update dependency version range on graduated package to `^1.0.0` so this package can receive updates.

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -9,14 +9,14 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@lit-labs/nextjs": "0.1.2",
-    "@lit/react": "1.0.0",
+    "@lit-labs/nextjs": "^0.1.2",
+    "@lit/react": "^1.0.0",
     "@types/node": "^18.11.11",
     "@types/react": "^18.0.26",
     "@types/react-dom": "^18.0.9",
     "eslint": "^8.29.0",
     "eslint-config-next": "^13.0.6",
-    "lit": "3.0.0",
+    "lit": "^3.0.0",
     "next": "^13.0.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/examples/preact/package.json
+++ b/examples/preact/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "preact": "^10.15.1",
-    "@lit-internal/test-elements-react": "1.0.1"
+    "@lit-internal/test-elements-react": "^1.0.1"
   },
   "devDependencies": {
     "@preact/preset-vite": "^2.5.0",

--- a/packages/labs/context/package.json
+++ b/packages/labs/context/package.json
@@ -162,7 +162,7 @@
   },
   "author": "Google LLC",
   "dependencies": {
-    "@lit/context": "1.0.0"
+    "@lit/context": "^1.0.0"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4-fix.0",

--- a/packages/labs/react/package.json
+++ b/packages/labs/react/package.json
@@ -175,7 +175,7 @@
   },
   "author": "Google LLC",
   "dependencies": {
-    "@lit/react": "1.0.0"
+    "@lit/react": "^1.0.0"
   },
   "devDependencies": {
     "@lit-internal/scripts": "^1.0.1",


### PR DESCRIPTION
Our original intention was to have the labs packages automatically track the first major version of the graduated package so it'll automatically receive updates. This got erroneously pinned to the exact version for initial release as we were moving/exiting pre-release mode.

I also took this opportunity to add `^` dependencies in examples/ projects so they don't get a version bump every release.