### PR TITLE
[labs/compiler] Fix elementParts being compiled as attributeParts

### DIFF
--- a/.changeset/fair-fishes-tell.md
+++ b/.changeset/fair-fishes-tell.md
@@ -1,0 +1,6 @@
+---
+'@lit-labs/compiler': patch
+---
+
+Fix bug where adjacent attribute and element parts would mix-up their values
+during compilation.

--- a/packages/labs/compiler/src/lib/template-transform.ts
+++ b/packages/labs/compiler/src/lib/template-transform.ts
@@ -320,7 +320,7 @@ class CompiledTemplatePass {
                 attributesToRemove.add(attr);
                 if (isAttributePart) {
                   const realName = attrNames[attrNameIndex++];
-                  if (!realName) {
+                  if (realName === undefined) {
                     throw new Error(
                       `Internal Error: realName is not defined. Please file an issue at https://github.com/lit/lit/issues/new/choose`
                     );

--- a/packages/labs/compiler/src/lib/template-transform.ts
+++ b/packages/labs/compiler/src/lib/template-transform.ts
@@ -314,13 +314,17 @@ class CompiledTemplatePass {
           }
           if (node.attrs.length > 0) {
             for (const attr of node.attrs) {
-              if (
-                attr.name.endsWith(boundAttributeSuffix) ||
-                attr.name.startsWith(marker)
-              ) {
+              const isAttributePart = attr.name.endsWith(boundAttributeSuffix);
+              const isElementPart = attr.name.startsWith(marker);
+              if (isAttributePart || isElementPart) {
                 attributesToRemove.add(attr);
-                const realName = attrNames[attrNameIndex++];
-                if (realName !== undefined) {
+                if (isAttributePart) {
+                  const realName = attrNames[attrNameIndex++];
+                  if (!realName) {
+                    throw new Error(
+                      `Internal Error: realName is not defined. Please file an issue at https://github.com/lit/lit/issues/new/choose`
+                    );
+                  }
                   const statics = attr.value.split(marker);
                   // We store the case-sensitive name from `attrNames` (generated
                   // while parsing the template strings); note that this assumes

--- a/packages/labs/compiler/test_files/part_element.golden.js
+++ b/packages/labs/compiler/test_files/part_element.golden.js
@@ -1,5 +1,8 @@
 import { html } from 'lit-html';
 import { ref } from 'lit-html/directives/ref.js';
+import * as litHtmlPrivate_1 from "lit-html/private-ssr-support.js";
+const { AttributePart: A_1 } = litHtmlPrivate_1._$LH;
 const b_1 = i => i;
-const lit_template_1 = { h: b_1 `<input>`, parts: [{ type: 6, index: 0 }] };
-const one = { ["_$litType$"]: lit_template_1, values: [ref(console.log)] };
+const lit_template_1 = { h: b_1 `<input>`, parts: [{ type: 1, index: 0, name: "a", strings: ["", ""], ctor: A_1 }, { type: 6, index: 0 }, { type: 1, index: 0, name: "b", strings: ["", ""], ctor: A_1 }] };
+// Ensure that part order is respected in compiled output.
+const one = { ["_$litType$"]: lit_template_1, values: ['a', ref(console.log), 'b'] };

--- a/packages/labs/compiler/test_files/part_element.ts
+++ b/packages/labs/compiler/test_files/part_element.ts
@@ -1,4 +1,5 @@
 import {html} from 'lit-html';
 import {ref} from 'lit-html/directives/ref.js';
 
-const one = html`<input ${ref(console.log)}>`;
+// Ensure that part order is respected in compiled output.
+const one = html`<input a=${'a'} ${ref(console.log)} b=${'b'}>`;

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -78,6 +78,7 @@
         "../labs/task:build",
         "../lit-element:build",
         "../lit-html:build",
+        "../lit-html:build:compiled:ts:tests",
         "../lit:build",
         "../context:build",
         "../task:build",

--- a/packages/tests/src/web-test-runner.config.ts
+++ b/packages/tests/src/web-test-runner.config.ts
@@ -172,6 +172,7 @@ const config: TestRunnerConfig = {
     '../context/development/**/*_test.(js|html)',
     '../task/development/**/*_test.(js|html)',
     '../lit-element/development/**/*_test.(js|html)',
+    '../lit-html/compiled/**/*_test.(js|html)',
     '../lit-html/development/**/*_test.(js|html)',
     '../reactive-element/development/**/*_test.(js|html)',
   ],


### PR DESCRIPTION
### Context

This PR fixes two issues.

1. The compiled lit_html tests were not running on CI. I only discovered the error via local testing.
2. Element parts were not being handled accurately.

#### Element part issue

Element parts were being ordered by `realName`, which would prioritize ordering attribute parts first, followed by element parts.
This is also not aligned with how lit-html detects the parts.

Fix is to look at attribute names to detect element vs attribute parts!


### Test plan

Test with golden test and lit_html tests locally.
Then also added the compiled lit_html tests to test config so now it should run in CI.
