### PR TITLE
[labs/ssr-react] Fix hydration ordering for nested custom elements

### DIFF
--- a/.changeset/brave-moles-check.md
+++ b/.changeset/brave-moles-check.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/ssr-react': patch
+---
+
+Fix rendering of nested custom elements so that child custom elements will properly have the `defer-hydration` attribute from SSR, ensuring correct hydration order from parent to child.

--- a/examples/nextjs/src/count-display.ts
+++ b/examples/nextjs/src/count-display.ts
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {LitElement, html} from 'lit';
+import {customElement, property} from 'lit/decorators.js';
+
+@customElement('count-display')
+export class CountDisplay extends LitElement {
+  @property({type: Number})
+  count = 0;
+  render() {
+    return html`<p>Count: ${this.count}</p>`;
+  }
+}

--- a/examples/nextjs/src/simple-greeter.ts
+++ b/examples/nextjs/src/simple-greeter.ts
@@ -7,6 +7,7 @@
 import {LitElement, html, css} from 'lit';
 import {customElement, property} from 'lit/decorators.js';
 import type React from 'react';
+import './count-display';
 
 @customElement('simple-greeter')
 export class SimpleGreeter extends LitElement {
@@ -44,7 +45,7 @@ export class SimpleGreeter extends LitElement {
     return html`
       <div>
         <h1>Hello, <span>${this.name}</span>!</h1>
-        <p>Count: ${this.count}</p>
+        <count-display .count=${this.count}></count-display>
         <button @click=${() => this.count++}>++</button>
       </div>
     `;

--- a/packages/labs/ssr-react/src/lib/node/render-custom-element.ts
+++ b/packages/labs/ssr-react/src/lib/node/render-custom-element.ts
@@ -69,6 +69,7 @@ export const renderCustomElement = (tagName: string, props: {} | null) => {
   renderer.connectedCallback();
 
   renderInfo.customElementInstanceStack.push(renderer);
+  renderInfo.customElementHostStack.push(renderer);
 
   const shadowContents = renderer.renderShadow(renderInfo);
 

--- a/packages/labs/ssr-react/src/test/child-element.ts
+++ b/packages/labs/ssr-react/src/test/child-element.ts
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {html, LitElement} from 'lit';
+import {customElement} from 'lit/decorators.js';
+
+@customElement('child-element')
+export class ChildElement extends LitElement {
+  override render() {
+    return html`<p>Child</p>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'child-element': ChildElement;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace JSX {
+    interface IntrinsicElements {
+      'child-element':
+        | React.DetailedHTMLProps<
+            React.HTMLAttributes<ChildElement>,
+            ChildElement
+          >
+        | Partial<ChildElement>;
+    }
+  }
+}

--- a/packages/labs/ssr-react/src/test/integration/enable-lit-ssr_test.tsx
+++ b/packages/labs/ssr-react/src/test/integration/enable-lit-ssr_test.tsx
@@ -14,6 +14,7 @@ import {TestElement} from '../test-element.js';
 import '../test-element.js';
 import {ObjectTestElement} from '../object-test-element.js';
 import '../object-test-element.js';
+import '../parent-element.js';
 
 import {suite} from 'uvu';
 // eslint-disable-next-line import/extensions
@@ -193,7 +194,7 @@ bareCEtest('single element with dynamic children via props', () => {
   );
 });
 
-bareCEtest('nested element', () => {
+bareCEtest('child custom element', () => {
   assert.equal(
     ReactDOMServer.renderToString(
       <test-element>
@@ -211,6 +212,16 @@ bareCEtest('nested element', () => {
     }
   </style><!--lit-part aHUgh01By8I=--><p>Hello, <!--lit-part-->Somebody<!--/lit-part-->!</p>
       <slot></slot><!--/lit-part--></template></test-element></test-element>`
+  );
+});
+
+bareCEtest('nested custom element', () => {
+  // Note: <child-element> should have defer-hydration attribute to ensure
+  // proper hydration order from parent to child
+  assert.equal(
+    ReactDOMServer.renderToString(<parent-element />),
+    `<parent-element><template shadowroot="open" shadowrootmode="open"><!--lit-part VWvXc8PRUIg=--><p>Parent</p>
+      <!--lit-node 1--><child-element defer-hydration><template shadowroot="open" shadowrootmode="open"><!--lit-part z0Ym6Oo3MXM=--><p>Child</p><!--/lit-part--></template></child-element><!--/lit-part--></template></parent-element>`
   );
 });
 

--- a/packages/labs/ssr-react/src/test/integration/runtime-jsx_test.tsx
+++ b/packages/labs/ssr-react/src/test/integration/runtime-jsx_test.tsx
@@ -187,7 +187,7 @@ test('single element with dynamic children via props', () => {
   );
 });
 
-test('nested element', () => {
+test('custom element child', () => {
   assert.equal(
     ReactDOMServer.renderToString(
       <test-element>
@@ -205,6 +205,16 @@ test('nested element', () => {
     }
   </style><!--lit-part aHUgh01By8I=--><p>Hello, <!--lit-part-->Somebody<!--/lit-part-->!</p>
       <slot></slot><!--/lit-part--></template></test-element></test-element>`
+  );
+});
+
+test('nested custom element', () => {
+  // Note: <child-element> should have defer-hydration attribute to ensure
+  // proper hydration order from parent to child
+  assert.equal(
+    ReactDOMServer.renderToString(<parent-element />),
+    `<parent-element><template shadowroot="open" shadowrootmode="open"><!--lit-part VWvXc8PRUIg=--><p>Parent</p>
+      <!--lit-node 1--><child-element defer-hydration><template shadowroot="open" shadowrootmode="open"><!--lit-part z0Ym6Oo3MXM=--><p>Child</p><!--/lit-part--></template></child-element><!--/lit-part--></template></parent-element>`
   );
 });
 

--- a/packages/labs/ssr-react/src/test/parent-element.ts
+++ b/packages/labs/ssr-react/src/test/parent-element.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {html, LitElement} from 'lit';
+import {customElement} from 'lit/decorators.js';
+import './child-element.js';
+
+@customElement('parent-element')
+export class ParentElement extends LitElement {
+  override render() {
+    return html`<p>Parent</p>
+      <child-element></child-element>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'parent-element': ParentElement;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace JSX {
+    interface IntrinsicElements {
+      'parent-element':
+        | React.DetailedHTMLProps<
+            React.HTMLAttributes<ParentElement>,
+            ParentElement
+          >
+        | Partial<ParentElement>;
+    }
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/lit/lit/issues/4363

I also kept the changes I made to the `nextjs` example to reproduce the error.. It might not be really necessary but also doesn't hurt to keep it around.

Testing for this looks specifically for `defer-hydration` attribute on SSRed string on a child custom element that is rendered by a parent custom element.

The test we had formerly called "nested element" actually tests that a custom element that is  React child in the provided JSX renders properly so I've renamed to "custom element child" instead.