### PR TITLE
[infra] Fix sizecheck actions to save PR number for report

### DIFF
--- a/.github/workflows/sizecheck-report.yaml
+++ b/.github/workflows/sizecheck-report.yaml
@@ -7,34 +7,39 @@ on:
     types: [completed]
 
 jobs:
-  on-success:
-    name: Report sizecheck success
+  report:
+    name: Report sizecheck result
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    steps:
-      - name: Comment on size report empty
-        uses: thollander/actions-comment-pull-request@v2
-        with:
-          message: 'The size of lit-html.js and lit-core.min.js are as expected.'
-          comment_tag: check-size # ensures we overwrite old failure comment if present
-
-  on-failure:
-    name: Report sizecheck failure
-    runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
     steps:
       # Download the artifact from the triggering workflow that contains the
-      # size check results to report
+      # size check results and PR number to report to
       - name: Download artifact
         uses: dawidd6/action-download-artifact@v2
         with:
           workflow: ${{ github.event.workflow.id }}
           run_id: ${{ github.event.workflow_run.id }}
           name: sizecheck
-          path: scripts
+          path: artifacts
 
-      - name: Comment about failing size report
+      # `workflow_run` triggered workflow don't always have access to PR number
+      # from event so it is pass via an artifact from the triggering workflow
+      - name: Get pull request number from artifact
+        id: pr_num
+        run: echo "PR_NUMBER=$(cat artifacts/pr_number.txt)" >> $GITHUB_OUTPUT
+        shell: bash
+
+      - name: Comment on size report empty
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
         uses: thollander/actions-comment-pull-request@v2
         with:
-          filePath: scripts/check-size-out.md
+          message: 'The size of lit-html.js and lit-core.min.js are as expected.'
+          comment_tag: check-size # ensures we overwrite old failure comment if present
+          pr_number: ${{ steps.pr_num.outputs.PR_NUMBER }}
+
+      - name: Comment about failing size report
+        if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          filePath: artifacts/check-size-out.md
           comment_tag: check-size # ensures we create or update one size comment
+          pr_number: ${{ steps.pr_num.outputs.PR_NUMBER }}

--- a/.github/workflows/sizecheck.yaml
+++ b/.github/workflows/sizecheck.yaml
@@ -21,12 +21,21 @@ jobs:
       - name: NPM install
         run: npm ci
 
+      # This is needed to be able to read it from sizecheck-report.yaml to
+      # comment on the correct PR
+      - name: Save PR number
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: echo $PR_NUMBER > ./scripts/pr_number.txt
+
       - name: Generate size report
         run: npm run benchmark:size
 
-      - name: Upload failure artifact
-        if: ${{ failure() }}
+      - name: Upload artifacts
+        if: ${{ success() || failure() }}
         uses: actions/upload-artifact@v3
         with:
           name: sizecheck
-          path: scripts/check-size-out.md
+          path: |
+            scripts/check-size-out.md
+            sdripts/pr_number.txt

--- a/.github/workflows/sizecheck.yaml
+++ b/.github/workflows/sizecheck.yaml
@@ -38,4 +38,4 @@ jobs:
           name: sizecheck
           path: |
             scripts/check-size-out.md
-            sdripts/pr_number.txt
+            scripts/pr_number.txt


### PR DESCRIPTION
I made an incorrect assumption in https://github.com/lit/lit/pull/4323

The action used for create comments https://github.com/thollander/actions-comment-pull-request does not work from a `workflow_run` triggered action as it can't pull the PR to comment on from the context of the workflow.

This is apparently not straight forward to do purely within GitHub actions.
https://github.com/orgs/community/discussions/45415
https://stackoverflow.com/questions/59077079/how-to-get-pull-request-number-within-github-actions-workflow

Even GHA's own doc shows using an artifact to pass the PR number to another workflow: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#using-data-from-the-triggering-workflow

I cobbled together a solution from digging through above example and answers to save the PR number from the triggering workflow into an artifact and using it in the reporting workflow. Previously we would only have uploaded an artifact on size check failure which generates a markdown message, but now we just do it for both success and failure.

Side note: My original assumption that it should work was based on benchmarks report workflow working fine in a `workflow_run` triggered action but turns out they have bespoke logic to find the PR to comment on in that case https://github.com/andrewiggins/tachometer-reporter-action/blob/fef5976dd7c57c673de2391f1c2cfbfab7a9c415/src/utils/github.js#L8-L53

An alternative solution, instead of using an artifact, would be to do a logic similar to one done in the `tachometer-reporter-action` to write a GHA script within this workflow to use the commit head and query for a matching PR, but since we were already using an artifact, figured this was the easier solution.