### PR TITLE
[labs/virtualizer] Fix #4346

### DIFF
--- a/.changeset/young-elephants-care.md
+++ b/.changeset/young-elephants-care.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/virtualizer': patch
+---
+
+Fix issue where virtualizer didn't render children when slotted into a position:fixed ancestor (#4346)

--- a/packages/labs/virtualizer/src/Virtualizer.ts
+++ b/packages/labs/virtualizer/src/Virtualizer.ts
@@ -556,12 +556,7 @@ export class Virtualizer {
     // Only update the layout and trigger a re-render if we have:
     //   a) A layout
     //   b) A scrollerController, which means we're connected
-    //   c) An offsetParent, which means we're not hidden
-    if (
-      this._layout &&
-      this._scrollerController &&
-      this._hostElement?.offsetParent
-    ) {
+    if (this._layout && this._scrollerController) {
       this._layout.items = this._items;
       this._updateView();
       if (this._childMeasurements !== null) {
@@ -675,8 +670,8 @@ export class Virtualizer {
       const scrollTop = top - hostElementBounds.top + hostElement.scrollTop;
       const scrollLeft = left - hostElementBounds.left + hostElement.scrollLeft;
 
-      const height = Math.max(1, bottom - top);
-      const width = Math.max(1, right - left);
+      const height = bottom - top;
+      const width = right - left;
 
       layout.viewportSize = {width, height};
       layout.viewportScroll = {top: scrollTop, left: scrollLeft};

--- a/packages/labs/virtualizer/src/test/scenarios/fixed-position-ancestor.test.ts
+++ b/packages/labs/virtualizer/src/test/scenarios/fixed-position-ancestor.test.ts
@@ -4,11 +4,13 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+import {LitElement, html} from 'lit';
+import {customElement} from 'lit/decorators.js';
 import {array, ignoreBenignErrors} from '../helpers.js';
 import {LitVirtualizer} from '../../lit-virtualizer.js';
 import {grid} from '../../layouts/grid.js';
 import {styleMap} from 'lit/directives/style-map.js';
-import {expect, html, fixture} from '@open-wc/testing';
+import {expect, html as testingHtml, fixture} from '@open-wc/testing';
 
 interface NamedItem {
   name: string;
@@ -42,7 +44,7 @@ describe('Virtualizer behaves properly when it has a position: fixed ancestor', 
     // We use the grid layout here because it conveniently will not
     // render any items if it calculates that it doesn't have sufficient
     // space, making our testing job easier.
-    const container = await fixture(html`
+    const container = await fixture(testingHtml`
       <div id="container" style=${styleMap(containerStyles)}>
         <div id="scroller" style=${styleMap(scrollerStyles)}>
           <lit-virtualizer
@@ -87,7 +89,7 @@ describe('Virtualizer behaves properly when it has a position: fixed ancestor', 
       overflow: 'auto',
     };
 
-    const container = await fixture(html`
+    const container = await fixture(testingHtml`
       <div id="container" style=${styleMap(containerStyles)}>
         <div id="scroller" style=${styleMap(scrollerStyles)}>
           <lit-virtualizer
@@ -115,5 +117,59 @@ describe('Virtualizer behaves properly when it has a position: fixed ancestor', 
     scroller.scrollTo(0, scroller.scrollHeight);
     await virtualizer.layoutComplete;
     expect(virtualizer.textContent).to.contain('Item 99');
+  });
+});
+
+@customElement('simple-dialog')
+export class SimpleDialog extends LitElement {
+  render() {
+    return html`<div style="position: fixed; width: 200px;">
+      <slot></slot>
+    </div> `;
+  }
+}
+
+describe('Virtualizer renders properly when it is slotted into a position: fixed ancestor', () => {
+  ignoreBenignErrors(beforeEach, afterEach);
+
+  // Regression test for https://github.com/lit/lit/issues/4346
+  it('should render children', async () => {
+    const container = await fixture(testingHtml`
+      <simple-dialog>
+        <lit-virtualizer
+          .items=${_100Items}
+          .renderItem=${({name}: NamedItem) => html`<p>${name}</p>`}
+        ></lit-virtualizer>
+      </simple-dialog>
+    `);
+
+    const virtualizer = container.querySelector('lit-virtualizer')!;
+    expect(virtualizer).to.be.instanceOf(LitVirtualizer);
+
+    // In practice, we'll time out if we fail here because the `layoutComplete`
+    // promise will never be fulfilled.
+    await virtualizer.layoutComplete;
+    expect(virtualizer.textContent).to.contain('Item 0');
+  });
+});
+
+describe('Virtualizer renders properly when it is position: fixed', () => {
+  ignoreBenignErrors(beforeEach, afterEach);
+
+  it('should render children', async () => {
+    const virtualizer = (await fixture(testingHtml`
+      <lit-virtualizer
+        style="position: fixed; width: 200px;"
+        .items=${_100Items}
+        .renderItem=${({name}: NamedItem) => html`<p>${name}</p>`}
+      ></lit-virtualizer>
+    `)) as LitVirtualizer;
+
+    expect(virtualizer).to.be.instanceOf(LitVirtualizer);
+
+    // In practice, we'll time out if we fail here because the `layoutComplete`
+    // promise will never be fulfilled.
+    await virtualizer.layoutComplete;
+    expect(virtualizer.textContent).to.contain('Item 0');
   });
 });

--- a/packages/labs/virtualizer/src/test/scenarios/hidden.test.ts
+++ b/packages/labs/virtualizer/src/test/scenarios/hidden.test.ts
@@ -1,0 +1,71 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {ignoreBenignErrors} from '../helpers.js';
+import {html, LitElement} from 'lit';
+import {customElement, property} from 'lit/decorators.js';
+import '../../lit-virtualizer.js';
+import {expect, html as testingHtml, fixture} from '@open-wc/testing';
+
+/*
+  This file contains regression tests for https://github.com/lit/lit/issues/3815
+*/
+
+type Item = {label: number};
+
+@customElement('virtualizer-hider')
+export class VirtualizerHider extends LitElement {
+  _list: Item[] = Array(100)
+    .fill('')
+    .map((_, index) => ({
+      label: index,
+    }));
+
+  @property({type: Boolean})
+  hidden = false;
+
+  render() {
+    return html`
+      <button @click=${() => (this.hidden = !this.hidden)}>Toggle</button>
+      <div style="display:${this.hidden ? 'none' : 'block'}">
+        <lit-virtualizer
+          .items=${this._list}
+          .renderItem=${({label}: Item) => html`<div>${label}</div>`}
+        ></lit-virtualizer>
+      </div>
+    `;
+  }
+}
+
+describe("Don't render any children if the virtualizer is hidden", () => {
+  ignoreBenignErrors(beforeEach, afterEach);
+
+  it('should not render any children when initially hidden', async () => {
+    const el = await fixture<VirtualizerHider>(
+      testingHtml`
+        <virtualizer-hider hidden></virtualizer-hider>
+      `
+    );
+    const virtualizer = el.shadowRoot!.querySelector('lit-virtualizer')!;
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    expect(virtualizer.children.length).to.equal(0);
+  });
+
+  it('should not render any children when subsequently hidden', async () => {
+    const el = await fixture<VirtualizerHider>(
+      testingHtml`
+        <virtualizer-hider></virtualizer-hider>
+      `
+    );
+    const virtualizer = el.shadowRoot!.querySelector('lit-virtualizer')!;
+    await virtualizer.layoutComplete;
+    expect(virtualizer.children.length).to.be.greaterThan(0);
+
+    el.hidden = true;
+    await virtualizer.layoutComplete;
+    expect(virtualizer.children.length).to.equal(0);
+  });
+});


### PR DESCRIPTION
Fix #4346 by not relying on `offsetParent` to detect the case where a virtualizer is hidden because itself or one of its ancestors is `display: none`.

It turns out that, due to some Shadow-DOM-specific behavior (see [comment](https://github.com/lit/lit/issues/4346#issuecomment-1785809477) for background reading), `offsetParent` returned `null` in cases where a (visible) virtualizer was slotted into a shadow tree beneath a `position: fixed` ancestor, making this an unreliable check.

Instead of using the `offsetParent` check, we will rely on existing Virtualizer functionality to avoid rendering children when a virtualizer is hidden. In determining which children to render, a virtualizer calculates the size of the on-screen region it needs to fill, taking into account its position in the document and the current scroll position. This calculation already returns `width` and `height` of `0` when the virtualizer is hidden, which should be a signal not to render any children. However, for reasons not documented and long forgotten, we have been forcing the `width` and `height` passed to the layout to be at least `1px` each. I am quite confident that this was a hacky workaround for some no-longer-existent issue; I know that it predates much significant work on Virtualizer's rendering pipeline and that removing it doesn't cause any tests to fail.

Added and updated some relevant tests.

