### PR TITLE
[infra] Split changeset status workflow out of lint

### DIFF
--- a/.github/workflows/changeset-status.yaml
+++ b/.github/workflows/changeset-status.yaml
@@ -1,0 +1,31 @@
+name: Changeset Status
+
+on: [pull_request]
+
+jobs:
+  # Enforce that all PRs that change packages need changesets. Changes
+  # without changesets result in this job failing.
+  changeset:
+    runs-on: ubuntu-latest
+    # Skip if author is lit-robot which means it's a release PR that doesn't
+    # need this check.
+    if: ${{ github.event.pull_request.user.login != 'lit-robot' }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Checkout and NPM install
+        run: |
+          git checkout main
+          git checkout ${{ github.sha }}
+          npm ci
+
+      - name: Changeset status
+        run: npm run changeset status -- --since=main

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-      # Temporary for pre-release.
-      - '3.0'
 
 jobs:
   release:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,16 +11,8 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    # When lit-robot creates a release PR, skip this check as it will always
-    # fail.
-    if: ${{ github.actor != 'lit-robot' }}
-    env:
-      WIREIT_LOGGER: quiet-ci
-
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
 
       - uses: actions/setup-node@v3
         with:
@@ -29,21 +21,13 @@ jobs:
           cache-dependency-path: package-lock.json
 
       - name: NPM install
-        run: |
-          git checkout main
-          git checkout ${{ github.sha }}
-          npm ci
+        run: npm ci
 
       - name: Lint
         run: npm run lint
 
       - name: Check formatting
         run: npm run format:check
-
-      - name: Changeset
-        # Enforce that all PRs that change packages need changesets. Changes
-        # without changesets result in this job failing.
-        run: npm run changeset status -- --since=main
 
   tests-local:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I didn't like that lint and changeset were combined.
While we do somewhat enforce the changeset check and add empty changesets when needed, I would like to see if lint and format checks fail separately from the changeset check.

I don't think doing an extra checkout and npm install is that costly.

Splitting out made it so the changeset will only run on pull requests, not on pushes to main. I also updated the condition so that it should continue to skip when the PR author is lit-robot, not just the initiator of the workflow. The previous condition would not skip the check and fail when one of us pushed up fixes to the release PR branch.

I also discovered changesets authors do not recommend this failing CI step (https://github.com/changesets/changesets/blob/main/docs/checking-for-changesets.md) since there's a bot that will check and comment on the packages being bumped. I think it does serve value for us as we may have now been conditioned to rely on the failure to remind us, and rarely check the comment.

Also took the opportunity to remove the 3.0 branch from the release workflow target.