### PR TITLE
Ensure renderRoot exists before first update

### DIFF
--- a/.changeset/pink-maps-exercise.md
+++ b/.changeset/pink-maps-exercise.md
@@ -1,0 +1,7 @@
+---
+'@lit/reactive-element': patch
+'lit': patch
+'lit-element': patch
+---
+
+Ensure `renderRoot` exists before first update (#4268)

--- a/.changeset/slow-singers-compare.md
+++ b/.changeset/slow-singers-compare.md
@@ -1,0 +1,5 @@
+---
+'@lit/reactive-element': patch
+---
+
+ensures `renderRoot` exists before first update (#4268)

--- a/.changeset/slow-singers-compare.md
+++ b/.changeset/slow-singers-compare.md
@@ -1,5 +1,0 @@
----
-'@lit/reactive-element': patch
----
-
-ensures `renderRoot` exists before first update (#4268)

--- a/packages/reactive-element/src/reactive-element.ts
+++ b/packages/reactive-element/src/reactive-element.ts
@@ -1105,7 +1105,7 @@ export abstract class ReactiveElement
    * @category lifecycle
    */
   connectedCallback() {
-    // Create renderRoot before first update.
+    // Create renderRoot before controllers `hostConnected`
     (this as Mutable<typeof this, 'renderRoot'>).renderRoot ??=
       this.createRenderRoot();
     this.enableUpdating(true);
@@ -1379,6 +1379,10 @@ export abstract class ReactiveElement
     }
     debugLogEvent?.({kind: 'update'});
     if (!this.hasUpdated) {
+      // Create renderRoot before first update. This occurs in `connectedCallback`
+      // but is done here to support out of tree calls to `enableUpdating`/`performUpdate`.
+      (this as Mutable<typeof this, 'renderRoot'>).renderRoot ??=
+        this.createRenderRoot();
       if (DEV_MODE) {
         // Produce warning if any reactive properties on the prototype are
         // shadowed by class fields. Instance fields set before upgrade are

--- a/packages/reactive-element/src/test/reactive-element_test.ts
+++ b/packages/reactive-element/src/test/reactive-element_test.ts
@@ -53,6 +53,19 @@ suite('ReactiveElement', () => {
     assert.isTrue(el.hasRenderRoot);
   });
 
+  test(`renderRoot exists before first update (without connecting)`, async () => {
+    class E extends ReactiveElement {
+      hasRenderRoot = false;
+      protected override willUpdate() {
+        this.hasRenderRoot = !!this.renderRoot;
+      }
+    }
+    customElements.define(generateElementName(), E);
+    const el = new E();
+    (el as any).performUpdate();
+    assert.isTrue(el.hasRenderRoot);
+  });
+
   test(`createRenderRoot is called only once`, async () => {
     class E extends ReactiveElement {
       renderRootCalls = 0;

--- a/packages/reactive-element/src/test/reactive-element_test.ts
+++ b/packages/reactive-element/src/test/reactive-element_test.ts
@@ -59,11 +59,15 @@ suite('ReactiveElement', () => {
       protected override willUpdate() {
         this.hasRenderRoot = !!this.renderRoot;
       }
+      flushUpdate() {
+        this.performUpdate();
+      }
     }
     customElements.define(generateElementName(), E);
     const el = new E();
-    (el as any).performUpdate();
+    el.flushUpdate();
     assert.isTrue(el.hasRenderRoot);
+    assert.isFalse(el.isConnected);
   });
 
   test(`createRenderRoot is called only once`, async () => {

--- a/scripts/check-size.js
+++ b/scripts/check-size.js
@@ -9,7 +9,7 @@ import * as fs from 'fs';
 // it's likely that we'll ask you to investigate ways to reduce the size.
 //
 // In either case, update the size here and push a new commit to your PR.
-const expectedLitCoreSize = 15423;
+const expectedLitCoreSize = 15465;
 const expectedLitHtmlSize = 7250;
 
 const litCoreSrc = fs.readFileSync('packages/lit/lit-core.min.js', 'utf8');


### PR DESCRIPTION
Fixes #4268. Ensures `renderRoot` exists before first update. It's created upon first connection by default (so that it exists before controllers' `hostConntected`), but this change supports early calls to `performUpdate`/`enableUpdating` without
depending on connection.