### PR TITLE
Controllers can be added/removed during lifecycle.

### DIFF
--- a/.changeset/healthy-elephants-itch.md
+++ b/.changeset/healthy-elephants-itch.md
@@ -1,0 +1,5 @@
+---
+'@lit/reactive-element': patch
+---
+
+Controllers can be added/removed during lifecycle (#4266).

--- a/.changeset/healthy-elephants-itch.md
+++ b/.changeset/healthy-elephants-itch.md
@@ -1,5 +1,0 @@
----
-'@lit/reactive-element': patch
----
-
-Controllers can be added/removed during lifecycle (#4266).

--- a/.changeset/strong-ants-think.md
+++ b/.changeset/strong-ants-think.md
@@ -4,4 +4,4 @@
 'lit-element': patch
 ---
 
-Controllers can be added/removed during lifecycle (#4266).
+Fixes bug where adding or removing controllers during a reactive controller lifecycle would affect the execution of other controllers (#4266). Controllers can now be added/removed during lifecycle without affecting others.

--- a/.changeset/strong-ants-think.md
+++ b/.changeset/strong-ants-think.md
@@ -1,0 +1,7 @@
+---
+'@lit/reactive-element': patch
+'lit': patch
+'lit-element': patch
+---
+
+Controllers can be added/removed during lifecycle (#4266).

--- a/packages/reactive-element/src/reactive-element.ts
+++ b/packages/reactive-element/src/reactive-element.ts
@@ -993,7 +993,7 @@ export abstract class ReactiveElement
   /**
    * Set of controllers.
    */
-  private __controllers?: ReactiveController[];
+  private __controllers?: Set<ReactiveController>;
 
   constructor() {
     super();
@@ -1030,7 +1030,7 @@ export abstract class ReactiveElement
    * @category controllers
    */
   addController(controller: ReactiveController) {
-    (this.__controllers ??= []).push(controller);
+    (this.__controllers ??= new Set()).add(controller);
     // If a controller is added after the element has been connected,
     // call hostConnected. Note, re-using existence of `renderRoot` here
     // (which is set in connectedCallback) to avoid the need to track a
@@ -1045,9 +1045,7 @@ export abstract class ReactiveElement
    * @category controllers
    */
   removeController(controller: ReactiveController) {
-    // Note, if the indexOf is -1, the >>> will flip the sign which makes the
-    // splice do nothing.
-    this.__controllers?.splice(this.__controllers.indexOf(controller) >>> 0, 1);
+    this.__controllers?.delete(controller);
   }
 
   /**

--- a/scripts/check-size.js
+++ b/scripts/check-size.js
@@ -9,7 +9,7 @@ import * as fs from 'fs';
 // it's likely that we'll ask you to investigate ways to reduce the size.
 //
 // In either case, update the size here and push a new commit to your PR.
-const expectedLitCoreSize = 15423;
+const expectedLitCoreSize = 15405;
 const expectedLitHtmlSize = 7250;
 
 const litCoreSrc = fs.readFileSync('packages/lit/lit-core.min.js', 'utf8');


### PR DESCRIPTION
Fixes https://github.com/lit/lit/issues/4266. Controllers are maintained via a Set instead of an Arry, allowing them to be iterated stably while being modified.