### PR TITLE
[labs/ssr] fix: RenderResultReadable skipping async work

### DIFF
--- a/.changeset/tasty-sloths-pump.md
+++ b/.changeset/tasty-sloths-pump.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/ssr': patch
+---
+
+fix a race condition in `RenderResultReadable` which could skip async work.

--- a/.changeset/tasty-sloths-pump.md
+++ b/.changeset/tasty-sloths-pump.md
@@ -2,4 +2,4 @@
 '@lit-labs/ssr': patch
 ---
 
-fix a race condition in `RenderResultReadable` which could skip async work.
+Fix a race condition in `RenderResultReadable` which could skip async work.

--- a/packages/labs/ssr/src/lib/render-result-readable.ts
+++ b/packages/labs/ssr/src/lib/render-result-readable.ts
@@ -59,10 +59,6 @@ export class RenderResultReadable extends Readable {
     // - _read() should call `this.push()` as many times as it can until
     //   `this.push()` returns false, which means the underlying Readable
     //   does not want any more values.
-    // - `this._read()` should not be called by the underlying Readable until
-    //   after this.push() has returned false, so we can wait on a Promise
-    //   and call _read() when it resolves to continue without a race condition.
-    //   (We try to verify this with the this._waiting field)
     // - `this.push(null)` ends the stream
     //
     // This means that we cannot use for/of loops to iterate on the render


### PR DESCRIPTION
### Context

Fix a race condition bug with RenderResultReadable.

### What is the bug?

The `RenderResultReadable` class lets us efficiently stream synchronous or async iterables. It's architecture is [designed to be as optimal as possible](https://github.com/lit/lit/pull/3467#issuecomment-1319448671), so synchronous streams go fast and have minimal overhead from the async handling.

Our `RenderResultReadable.prototype._read` implementation is async, allowing us to `await` values in the stream.
From [Node.js documentation](https://nodejs.org/api/stream.html#readable_readsize): "`_read()` will be called again after each call to [`this.push(dataChunk)`](https://nodejs.org/api/stream.html#readablepushchunk-encoding) once the stream is ready to accept more data."

This is also the behavior back to [Node.js v10](https://nodejs.org/docs/latest-v10.x/api/stream.html#stream_readable_read_size_1).

What happens for the test case below (without the fix) when we are reading from the stream:

```ts
new RenderResultReadable([
    'a',
    new Promise((res) => setTimeout(res, 50)).then((_) => ['b']),
    'c',
]);
```

 1. Node.js calls `_read()`. We synchronously `push('a')`.
 2. Our `_read` encounters the promise and awaits the promise.
 3. Node.js calls `_read()`, and we synchronously `push('c')`, then we loop and synchronously call `push(null)` terminating the stream.

Thus the promise is skipped.

### Fix

Once `_read()` is called, it will not be called again until `readable.push()` has been called. This makes it safe for us to noop a `_read()` call while a Promise is waiting. Then once that promise resolves, it will result in `push()` being called with the resolved data and we're back in a consistent state.

### Test plan

I added two tests that reproduce without the `_waiting` flag.