### PR TITLE
async-replace correctly re-renders when value is unchanged

### DIFF
--- a/.changeset/brave-frogs-tan.md
+++ b/.changeset/brave-frogs-tan.md
@@ -1,0 +1,6 @@
+---
+'lit-html': patch
+'lit': patch
+---
+
+asyncReplace correctly re-renders when value is unchanged (#4408)

--- a/packages/lit-html/src/directives/async-replace.ts
+++ b/packages/lit-html/src/directives/async-replace.ts
@@ -37,7 +37,7 @@ export class AsyncReplaceDirective extends AsyncDirective {
     // If we've already set up this particular iterable, we don't need
     // to do anything.
     if (value === this.__value) {
-      return;
+      return noChange;
     }
     this.__value = value;
     let i = 0;

--- a/packages/lit-html/src/test/directives/async-replace_test.ts
+++ b/packages/lit-html/src/test/directives/async-replace_test.ts
@@ -184,9 +184,7 @@ suite('asyncReplace', () => {
     render(t(iterable), container);
     assert.equal(stripExpressionMarkers(container.innerHTML), '<div></div>');
 
-    const wait = iterable.push('hello');
-    render(t(iterable), container);
-    await wait;
+    await iterable.push('hello');
     assert.equal(
       stripExpressionMarkers(container.innerHTML),
       '<div>hello</div>'

--- a/packages/lit-html/src/test/directives/async-replace_test.ts
+++ b/packages/lit-html/src/test/directives/async-replace_test.ts
@@ -179,7 +179,7 @@ suite('asyncReplace', () => {
     assert.equal(stripExpressionMarkers(container.innerHTML), '<div>bar</div>');
   });
 
-  test('renders the same itetable value when re-rendered with no new value emitted', async () => {
+  test('renders the same iterable value when re-rendered with no new value emitted', async () => {
     const t = (iterable: any) => html`<div>${asyncReplace(iterable)}</div>`;
     render(t(iterable), container);
     assert.equal(stripExpressionMarkers(container.innerHTML), '<div></div>');

--- a/packages/lit-html/src/test/directives/async-replace_test.ts
+++ b/packages/lit-html/src/test/directives/async-replace_test.ts
@@ -179,6 +179,32 @@ suite('asyncReplace', () => {
     assert.equal(stripExpressionMarkers(container.innerHTML), '<div>bar</div>');
   });
 
+  test('renders the same itetable value when re-rendered with no new value emitted', async () => {
+    const t = (iterable: any) => html`<div>${asyncReplace(iterable)}</div>`;
+    render(t(iterable), container);
+    assert.equal(stripExpressionMarkers(container.innerHTML), '<div></div>');
+
+    const wait = iterable.push('hello');
+    render(t(iterable), container);
+    await wait;
+    assert.equal(
+      stripExpressionMarkers(container.innerHTML),
+      '<div>hello</div>'
+    );
+
+    render(t(iterable), container);
+    assert.equal(
+      stripExpressionMarkers(container.innerHTML),
+      '<div>hello</div>'
+    );
+
+    render(t(iterable), container);
+    assert.equal(
+      stripExpressionMarkers(container.innerHTML),
+      '<div>hello</div>'
+    );
+  });
+
   test('renders new value over a pending iterable', async () => {
     const t = (v: any) => html`<div>${v}</div>`;
     // This is a little bit of an odd usage of directives as values, but it


### PR DESCRIPTION
Fixes #4408.