### PR TITLE
Remove unused internal parameters to requestUpdate

### DIFF
--- a/.changeset/odd-buckets-attend.md
+++ b/.changeset/odd-buckets-attend.md
@@ -1,5 +1,7 @@
 ---
 '@lit/reactive-element': patch
+'lit-element': patch
+'lit': patch
 ---
 
 Remove unused internal parameters to `requestUpdate()`

--- a/.changeset/odd-buckets-attend.md
+++ b/.changeset/odd-buckets-attend.md
@@ -1,0 +1,5 @@
+---
+'@lit/reactive-element': patch
+---
+
+Remove unused internal parameters to `requestUpdate()`

--- a/packages/reactive-element/src/reactive-element.ts
+++ b/packages/reactive-element/src/reactive-element.ts
@@ -1237,22 +1237,12 @@ export abstract class ReactiveElement
    * @param oldValue old value of requesting property
    * @param options property options to use instead of the previously
    *     configured options
-   * @param initial whether this call is for the initial value of the property.
-   *     Initial values do not reflect to an attribute.
    * @category updates
    */
   requestUpdate(
     name?: PropertyKey,
     oldValue?: unknown,
     options?: PropertyDeclaration
-  ): void;
-  /* @internal */
-  requestUpdate(
-    name?: PropertyKey,
-    oldValue?: unknown,
-    options?: PropertyDeclaration,
-    initial = false,
-    initialValue?: unknown
   ): void {
     // If we have a property key, perform property update steps.
     if (name !== undefined) {
@@ -1260,7 +1250,7 @@ export abstract class ReactiveElement
         this.constructor as typeof ReactiveElement
       ).getPropertyOptions(name);
       const hasChanged = options.hasChanged ?? notEqual;
-      const newValue = initial ? initialValue : this[name as keyof this];
+      const newValue = this[name as keyof this];
       if (hasChanged(newValue, oldValue)) {
         this._$changeProperty(name, oldValue, options);
       } else {

--- a/scripts/check-size.js
+++ b/scripts/check-size.js
@@ -9,7 +9,7 @@ import * as fs from 'fs';
 // it's likely that we'll ask you to investigate ways to reduce the size.
 //
 // In either case, update the size here and push a new commit to your PR.
-const expectedLitCoreSize = 15447;
+const expectedLitCoreSize = 15436;
 const expectedLitHtmlSize = 7250;
 
 const litCoreSrc = fs.readFileSync('packages/lit/lit-core.min.js', 'utf8');


### PR DESCRIPTION
I noticed this while re-reading some of the code. This was for distinguishing initial values while we were still trying to not reflect initial values for standard decorators.