### PR TITLE
[labs/ssr] allow binding attributes to html tag when using server templates

### DIFF
--- a/.changeset/lazy-beans-tap.md
+++ b/.changeset/lazy-beans-tap.md
@@ -1,0 +1,6 @@
+---
+'@lit-labs/ssr': patch
+---
+
+Fix server template throwing when encountering an attribute binding on the
+`html` tag. This is now handled correctly.

--- a/packages/labs/ssr/src/lib/render-value.ts
+++ b/packages/labs/ssr/src/lib/render-value.ts
@@ -51,7 +51,7 @@ import {
 
 import {escapeHtml} from './util/escape-html.js';
 
-import {parseFragment} from 'parse5';
+import {parseFragment, parse} from 'parse5';
 import {
   isElementNode,
   isCommentNode,
@@ -285,7 +285,10 @@ type Op =
  * - `custom-element-close`
  *   - Pop the CE `instance`+`renderer` off the `customElementInstanceStack`
  */
-const getTemplateOpcodes = (result: TemplateResult) => {
+const getTemplateOpcodes = (
+  result: TemplateResult,
+  isServerTemplate = false
+) => {
   const template = templateCache.get(result.strings);
   if (template !== undefined) {
     return template;
@@ -305,8 +308,11 @@ const getTemplateOpcodes = (result: TemplateResult) => {
    * The html string is parsed into a parse5 AST with source code information
    * on; this lets us skip over certain ast nodes by string character position
    * while walking the AST.
+   *
+   * Server Templates need to use `parse` as they may contain document tags such
+   * as `<html>`.
    */
-  const ast = parseFragment(String(html), {
+  const ast = (isServerTemplate ? parse : parseFragment)(String(html), {
     sourceCodeLocationInfo: true,
   });
 
@@ -697,7 +703,7 @@ function* renderTemplateResult(
   // previous span of HTML.
 
   const hydratable = isHydratable(result);
-  const ops = getTemplateOpcodes(result);
+  const ops = getTemplateOpcodes(result, !hydratable);
 
   /* The next value in result.values to render */
   let partIndex = 0;

--- a/packages/labs/ssr/src/test/lib/render-lit_test.ts
+++ b/packages/labs/ssr/src/test/lib/render-lit_test.ts
@@ -639,6 +639,19 @@ for (const global of [emptyVmGlobal, shimmedVmGlobal]) {
     );
   });
 
+  // Regression test for https://github.com/lit/lit/issues/4417
+  test('server-only template can bind attributes to html tag', async () => {
+    const {render, serverOnlyBindAttributeOnHtml} = await setup();
+    const result = await render(serverOnlyBindAttributeOnHtml);
+    assert.is(
+      result,
+      `
+<!DOCTYPE html>
+<html lang="ko"></html>
+`
+    );
+  });
+
   test('server-only template throws on property bindings', async () => {
     const {render, serverOnlyRenderPropertyBinding} = await setup();
     assert.throws(

--- a/packages/labs/ssr/src/test/lib/render-lit_test.ts
+++ b/packages/labs/ssr/src/test/lib/render-lit_test.ts
@@ -652,6 +652,25 @@ for (const global of [emptyVmGlobal, shimmedVmGlobal]) {
     );
   });
 
+  test('server-only document templates compose', async () => {
+    const {render, serverOnlyDocumentTemplatesCompose} = await setup();
+    const result = await render(serverOnlyDocumentTemplatesCompose);
+    assert.is(
+      result,
+      `
+<!DOCTYPE html>
+<html lang="ko">
+  <head>
+    <title>Server only title</title>
+  </head>
+  <body>
+    <p>Content</p>
+  </body>
+</html>
+`
+    );
+  });
+
   test('server-only template throws on property bindings', async () => {
     const {render, serverOnlyRenderPropertyBinding} = await setup();
     assert.throws(

--- a/packages/labs/ssr/src/test/test-files/render-test-module.ts
+++ b/packages/labs/ssr/src/test/test-files/render-test-module.ts
@@ -321,6 +321,18 @@ export const serverOnlyBindAttributeOnHtml = serverhtml`
 <html lang="${'ko'}"></html>
 `;
 
+export const serverOnlyDocumentTemplatesCompose = serverhtml`
+${serverhtml`<!DOCTYPE html>`}
+${serverhtml`<html lang="${'ko'}">
+  ${serverhtml`<head>
+    ${serverhtml`<title>${'Server only title'}</title>`}
+  </head>`}
+  ${serverhtml`<body>
+    ${serverhtml`<p>${'Content'}</p>`}
+  </body>`}
+</html>`}
+`;
+
 export const serverOnlyArray = serverhtml`<div>${[
   'one',
   'two',

--- a/packages/labs/ssr/src/test/test-files/render-test-module.ts
+++ b/packages/labs/ssr/src/test/test-files/render-test-module.ts
@@ -316,6 +316,11 @@ export const serverOnlyDocumentTemplate = serverhtml`
     </html>
   `;
 
+export const serverOnlyBindAttributeOnHtml = serverhtml`
+<!DOCTYPE html>
+<html lang="${'ko'}"></html>
+`;
+
 export const serverOnlyArray = serverhtml`<div>${[
   'one',
   'two',


### PR DESCRIPTION
Fixes: https://github.com/lit/lit/issues/4417

### Why

Server templates reuse a lot of the code paths of non server templates. In the server we convert templates to an HTML ast with parse5's `parseFragment` function.

However, this results in the following:

```html
<script type="module">
import {parseFragment, serialize} from 'https://cdn.jsdelivr.net/npm/parse5@7.1.2/+esm';

console.log(serialize(parseFragment("<html lang='ko'><p>Content</p></html>")));
// → <p>Content</p>
</script>
```

The attribute part thus cannot be added, and a part mismatch error is thrown.

### Fix

For server templates, use parse5's `parse` function. This handles document tags such as `html`. In fact it puts everything in a document.

```html
<script type="module">
import {parse, serialize} from 'https://cdn.jsdelivr.net/npm/parse5@7.1.2/+esm';

console.log(serialize(parse("<html lang='ko'><p>Content</p></html>")));
// → <html lang="ko"><head></head><body><p>Content</p></body></html>
</script>
```

### Test plan

Added a regression test, and a composition test that shows an extreme level of server template composition. This ensures that using parse5's `parse` doesn't cause issues when composing server templates.

### Questions

What about those extra nodes that parse5 creates? Such as `<body>` in the example above?
  - If we were generating comment nodes (which we are not with server templates), the node index would be wrong. This isn't a problem with server templates as they result in a string of html without comment node metadata.

Do those extra document nodes get sent down the wire?
  - They do not–and the unit tests confirm this.