### PR TITLE
fix: support for className with whitespace and so on

### DIFF
--- a/packages/lit-html/package.json
+++ b/packages/lit-html/package.json
@@ -490,7 +490,8 @@
     }
   },
   "dependencies": {
-    "@types/trusted-types": "^2.0.2"
+    "@types/trusted-types": "^2.0.2",
+    "classnames": "^2.3.2"
   },
   "devDependencies": {
     "@lit-internal/scripts": "^1.0.1",

--- a/packages/lit-html/src/directives/class-map.ts
+++ b/packages/lit-html/src/directives/class-map.ts
@@ -12,7 +12,7 @@ import {
   PartInfo,
   PartType,
 } from '../directive.js';
-
+import classNames from 'classnames';
 /**
  * A key-value set of class names to truthy values.
  */
@@ -43,14 +43,7 @@ class ClassMapDirective extends Directive {
   }
 
   render(classInfo: ClassInfo) {
-    // Add spaces to ensure separation from static classes
-    return (
-      ' ' +
-      Object.keys(classInfo)
-        .filter((key) => classInfo[key])
-        .join(' ') +
-      ' '
-    );
+    return classNames(classInfo);
   }
 
   override update(part: AttributePart, [classInfo]: DirectiveParameters<this>) {

--- a/packages/lit-html/src/test/lit-html_test.ts
+++ b/packages/lit-html/src/test/lit-html_test.ts
@@ -26,6 +26,8 @@ import {
   PartInfo,
   DirectiveParameters,
 } from 'lit-html/directive.js';
+import {classMap} from 'lit-html/directives/class-map.js';
+
 import {isCompiledTemplateResult} from 'lit-html/directive-helpers.js';
 import {assert} from '@esm-bundle/chai';
 import {
@@ -906,6 +908,17 @@ suite('lit-html', () => {
     test('renders a binding in a class attribute', () => {
       render(html`<div class="${'red'}"></div>`, container);
       assertContent('<div class="red"></div>');
+    });
+
+    test('renders a binding object in a class attribute', () => {
+      const className = 'red';
+      const obj = {
+        [className]: true,
+        bold: false,
+        'italic blue': true,
+      };
+      render(html`<div class=${classMap(obj)}></div>`, container);
+      assertContent('<div class="red italic blue"></div>');
     });
 
     test('renders a binding in an input value attribute', () => {


### PR DESCRIPTION
fix  https://github.com/lit/lit/issues/3095 

use classname. a lib be used in vue and react.