### PR TITLE
Set up token permissions for GitHub Workflows

### DIFF
--- a/.github/workflows/benchmarks-report.yaml
+++ b/.github/workflows/benchmarks-report.yaml
@@ -8,11 +8,17 @@ on:
       - completed
       - requested
 
+permissions:
+  contents: read
+
 jobs:
   # Optional job to update existing comments with a "benchmarks are running" text
   report_running:
     name: Report benchmarks are in-progress
     runs-on: ubuntu-latest
+    permissions:
+      issues: write # needed to write comments on PRs 
+      pull-requests: write # needed to write comments on PRs 
     # Only add the "benchmarks are running" text when the workflow_run starts
     if: ${{ github.event.action == 'requested' }}
     steps:
@@ -26,6 +32,9 @@ jobs:
   report_results:
     name: Report benchmark results
     runs-on: ubuntu-latest
+    permissions:
+      issues: write # needed to write comments on PRs 
+      pull-requests: write # needed to write comments on PRs 
     # Only run this job if the event action was "completed" and the triggering
     # workflow_run was successful
     if: ${{ github.event.action == 'completed' && github.event.workflow_run.conclusion == 'success' }}

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -2,6 +2,9 @@ name: Benchmarks
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   benchmarks:
     name: benchmarks

--- a/.github/workflows/changeset-status.yaml
+++ b/.github/workflows/changeset-status.yaml
@@ -2,6 +2,9 @@ name: Changeset Status
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   # Enforce that all PRs that change packages need changesets. Changes
   # without changesets result in this job failing.

--- a/.github/workflows/release-image.yaml
+++ b/.github/workflows/release-image.yaml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   release-image:
-    # if: github.repository == 'lit/lit'
+    if: github.repository == 'lit/lit'
 
     name: Generate Release Image
     runs-on: ubuntu-latest

--- a/.github/workflows/release-image.yaml
+++ b/.github/workflows/release-image.yaml
@@ -8,9 +8,12 @@ on:
     paths:
       - '**/CHANGELOG.md'
 
+permissions:
+  contents: read
+
 jobs:
   release-image:
-    if: github.repository == 'lit/lit'
+    # if: github.repository == 'lit/lit'
 
     name: Generate Release Image
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,9 +5,14 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   release:
     # Don't run on forks. We can and should only release from the main repo.
+    permissions:
+      contents: write  # for Git to git push
     if: github.repository == 'lit/lit'
 
     name: Release

--- a/.github/workflows/sauce.yaml
+++ b/.github/workflows/sauce.yaml
@@ -8,6 +8,9 @@ on:
     # This is the default list, but I don't know how to YAML an empty pull_request:
     types: [opened, reopened, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   tests-sauce:
     # Sauce tests need access to secrets.

--- a/.github/workflows/sizecheck-report.yaml
+++ b/.github/workflows/sizecheck-report.yaml
@@ -6,8 +6,14 @@ on:
     branches: ['**']
     types: [completed]
 
+permissions:
+  contents: read
+
 jobs:
   report:
+    permissions:
+      actions: read  # for dawidd6/action-download-artifact to query and download artifacts
+      pull-requests: read  # for dawidd6/action-download-artifact to query commit hash
     name: Report sizecheck result
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/sizecheck-report.yaml
+++ b/.github/workflows/sizecheck-report.yaml
@@ -13,7 +13,7 @@ jobs:
   report:
     permissions:
       actions: read  # for dawidd6/action-download-artifact to query and download artifacts
-      pull-requests: read  # for dawidd6/action-download-artifact to query commit hash
+      pull-requests: write  # for thollander/actions-comment-pull-request to write comment
     name: Report sizecheck result
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/sizecheck.yaml
+++ b/.github/workflows/sizecheck.yaml
@@ -2,6 +2,9 @@ name: Sizecheck
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   checksize:
     name: sizecheck

--- a/.github/workflows/starter-kits.yaml
+++ b/.github/workflows/starter-kits.yaml
@@ -5,9 +5,14 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   starter-kits:
     # Don't run on forks. We can and should only release from the main repo.
+    permissions:
+      contents: write  # for Git to git push
     if: github.repository == 'lit/lit'
 
     name: Sync Starter Kits

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,9 @@ on:
     # This is the default list, but I don't know how to YAML an empty pull_request:
     types: [opened, reopened, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #4438

Workflow runs with the given permissions:

- benchmarks.yaml https://github.com/joycebrum/lit/actions/runs/7120241683
- changeset-status.yaml https://github.com/joycebrum/lit/actions/runs/7120241687
- release-image.yaml https://github.com/joycebrum/lit/actions/runs/7120191834
- benchmarks-report.yaml https://github.com/joycebrum/lit/actions/runs/7120322262
- sizecheck-report.yaml https://github.com/joycebrum/lit/actions/runs/7120268829
- sizecheck.yaml https://github.com/joycebrum/lit/actions/runs/7120241690
- tests.yaml https://github.com/joycebrum/lit/actions/runs/7120235759

The remaining workflows I did not run since it is not supposed to work on forks. Let me know if I missed anything.