### PR TITLE
[raise_max_size] Maximum size of virtualizer is artificially limited

### DIFF
--- a/packages/labs/virtualizer/src/Virtualizer.ts
+++ b/packages/labs/virtualizer/src/Virtualizer.ts
@@ -27,6 +27,7 @@ import {
   UnpinnedEvent,
 } from './events.js';
 import {ScrollerController} from './ScrollerController.js';
+import { getMaxSupportedCssHeight } from './maxHeight.js';
 
 // Virtualizer depends on `ResizeObserver`, which is supported in
 // all modern browsers. For developers whose browser support
@@ -230,6 +231,8 @@ export class Virtualizer {
    */
   private _layoutInitialized: Promise<void> | null = null;
 
+  private _maxHeigth: number = 0;
+
   constructor(config: VirtualizerConfig) {
     if (!config) {
       throw new Error(
@@ -263,6 +266,8 @@ export class Virtualizer {
     // Save the promise returned by `_initLayout` as a state
     // variable we can check before updating layout config
     this._layoutInitialized = this._initLayout(layoutConfig);
+    // let us find the max supported heigth
+    this._maxHeigth = getMaxSupportedCssHeight();
   }
 
   private _initObservers() {
@@ -688,9 +693,8 @@ export class Virtualizer {
     // Some browsers seem to crap out if the host element gets larger than
     // a certain size, so we clamp it here (this value based on ad hoc
     // testing in Chrome / Safari / Firefox Mac)
-    const max = 8200000;
-    const h = size && size.width !== null ? Math.min(max, size.width) : 0;
-    const v = size && size.height !== null ? Math.min(max, size.height) : 0;
+    const h = size && size.width !== null ? Math.min(this._maxHeigth, size.width) : 0;
+    const v = size && size.height !== null ? Math.min(this._maxHeigth, size.height) : 0;
 
     if (this._isScroller) {
       this._getSizer().style.transform = `translate(${h}px, ${v}px)`;

--- a/packages/labs/virtualizer/src/maxHeight.ts
+++ b/packages/labs/virtualizer/src/maxHeight.ts
@@ -1,0 +1,52 @@
+/**
+ * Creates a dummy div with the given height and returns the height of the dummy div.
+ * The returned height may become null if the height is not supported.
+ *
+ * @param height the height to set
+ * @returns in case the heigt is supported, the height of the dummy div, otherwise 0
+ */
+export const setHeight = (height: number) => {
+  const div = document.createElement("div");
+  div.style.display = "hidden";
+  div.style.height = height + "px";
+  document.body.prepend(div);
+  const returnHeight = div.clientHeight;
+  div.remove();
+  return returnHeight;
+}
+
+/**
+ * Trail and error approach to find the maximum supported height of a div.
+ * This depends on the browser and the device.
+ * @returns the maximum supported height of a div
+ */
+export const getMaxSupportedCssHeight = () => {
+  const tooBig = Math.pow(2, 53);
+  let supportedHeight: number = 800000;
+  let lower: number;
+  let upper: number;
+  for (lower = 1, upper = 1; setHeight(upper); upper *= 2) {
+    lower = upper;
+    if (upper >= tooBig) {
+      console.log(upper)
+      supportedHeight = setHeight(upper);
+      console.log(supportedHeight)
+      return supportedHeight;
+    }
+
+  }
+  while (lower <= upper) {
+    var mid = Math.floor((lower + upper) / 2);
+    if (setHeight(mid)) {
+      if (!setHeight(mid + 1)) {
+        supportedHeight = setHeight(mid);
+        break;
+      } else {
+        lower = mid + 1;
+      }
+    } else {
+      upper = mid - 1;
+    }
+  }
+  return supportedHeight;
+}


### PR DESCRIPTION
- [ ] measure the max height and use that number instead of the static limit
- [ ]  see what the item max per browser are
- [ ] find a way to still render everything that is not in the limits (e.g. shrink artificially height so all fits in or something else)

https://github.com/lit/lit/issues/3572