### PR TITLE
Add a warning when binding this.requestUpdate to an event listener

### DIFF
--- a/.changeset/ninety-bananas-sneeze.md
+++ b/.changeset/ninety-bananas-sneeze.md
@@ -1,5 +1,7 @@
 ---
 '@lit/reactive-element': patch
+'lit-element': patch
+'lit': patch
 ---
 
 Add a warning in dev mode when binding this.requestUpdate directly as an event listener.

--- a/.changeset/ninety-bananas-sneeze.md
+++ b/.changeset/ninety-bananas-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@lit/reactive-element': patch
+---
+
+Add a warning in dev mode when binding this.requestUpdate directly as an event listener.

--- a/packages/reactive-element/src/reactive-element.ts
+++ b/packages/reactive-element/src/reactive-element.ts
@@ -1246,6 +1246,12 @@ export abstract class ReactiveElement
   ): void {
     // If we have a property key, perform property update steps.
     if (name !== undefined) {
+      if (DEV_MODE && (name as unknown) instanceof Event) {
+        issueWarning(
+          `request-update-event`,
+          `The requestUpdate() method was called with an Event as the property name. This is probably a mistake caused by binding this.requestUpdate as an event listener. Instead bind a function that will call it with no arguments: () => this.requestUpdate()`
+        );
+      }
       options ??= (
         this.constructor as typeof ReactiveElement
       ).getPropertyOptions(name);

--- a/packages/reactive-element/src/reactive-element.ts
+++ b/packages/reactive-element/src/reactive-element.ts
@@ -1248,7 +1248,7 @@ export abstract class ReactiveElement
     if (name !== undefined) {
       if (DEV_MODE && (name as unknown) instanceof Event) {
         issueWarning(
-          `request-update-event`,
+          ``,
           `The requestUpdate() method was called with an Event as the property name. This is probably a mistake caused by binding this.requestUpdate as an event listener. Instead bind a function that will call it with no arguments: () => this.requestUpdate()`
         );
       }


### PR DESCRIPTION
This is an uncommon use case to do in real code, but a reasonable thing to try when experimenting and debugging, so we want to help someone out with a warning here.