### PR TITLE
[infra] Add browser export conditions to package.json

### DIFF
--- a/.changeset/funny-files-tease.md
+++ b/.changeset/funny-files-tease.md
@@ -9,5 +9,5 @@
 ---
 
 Add "browser" export condition entrypoints to any package.json files with "node"
-export conditions. This fixes test runners that were incorrectly loading the
+export conditions. This fixes Node test runners emulating browser environments that were incorrectly loading the
 "node" entrypoints instead of the browser code.

--- a/.changeset/funny-files-tease.md
+++ b/.changeset/funny-files-tease.md
@@ -1,0 +1,13 @@
+---
+'@lit/reactive-element': patch
+'@lit-labs/ssr-client': patch
+'@lit-labs/react': patch
+'lit-html': patch
+'@lit/react': patch
+'lit-element': patch
+'lit': patch
+---
+
+Add "browser" export condition entrypoints to any package.json files with "node"
+export conditions. This fixes test runners that were incorrectly loading the
+"node" entrypoints instead of the browser code.

--- a/package-lock.json
+++ b/package-lock.json
@@ -26389,6 +26389,7 @@
         "puppeteer": "^15.4.0"
       },
       "bin": {
+        "add-browser-exports": "bin/add-browser-exports.js",
         "release-image": "bin/release-image.js",
         "treemirror": "bin/treemirror.js"
       },

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "test:not-starter-kits": "wireit",
     "test:lit-starter-js": "wireit",
     "test:lit-starter-ts": "wireit",
+    "test:package-exports": "wireit",
     "test:windows": "wireit",
     "prepare": "husky install",
     "changeset": "changeset",
@@ -151,7 +152,7 @@
         "See ./packages/tests/src/web-test-runner.config.ts"
       ],
       "dependencies": [
-        "./packages/internal-scripts:test",
+        "test:package-exports",
         "./packages/localize:test",
         "./packages/localize-tools:test",
         "./packages/react:test",
@@ -199,6 +200,12 @@
         "./packages/lit-starter-ts/web-test-runner.config.js"
       ],
       "output": []
+    },
+    "test:package-exports": {
+      "command": "add-browser-exports test",
+      "dependencies": [
+        "./packages/internal-scripts:build"
+      ]
     },
     "test:windows": {
       "dependencies": [

--- a/package.json
+++ b/package.json
@@ -151,6 +151,7 @@
         "See ./packages/tests/src/web-test-runner.config.ts"
       ],
       "dependencies": [
+        "./packages/internal-scripts:test",
         "./packages/localize:test",
         "./packages/localize-tools:test",
         "./packages/react:test",

--- a/packages/internal-scripts/bin/add-browser-exports.js
+++ b/packages/internal-scripts/bin/add-browser-exports.js
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+import {run} from '../lib/add-browser-exports.js';
+
+run();

--- a/packages/internal-scripts/package.json
+++ b/packages/internal-scripts/package.json
@@ -18,8 +18,7 @@
   },
   "scripts": {
     "build": "wireit",
-    "build:ts": "wireit",
-    "test": "wireit"
+    "build:ts": "wireit"
   },
   "wireit": {
     "build": {
@@ -36,12 +35,6 @@
       ],
       "output": [
         "lib"
-      ]
-    },
-    "test": {
-      "command": "(cd ../../ && node packages/internal-scripts/bin/add-browser-exports.js test)",
-      "dependencies": [
-        "build"
       ]
     }
   },

--- a/packages/internal-scripts/package.json
+++ b/packages/internal-scripts/package.json
@@ -12,6 +12,7 @@
   "license": "BSD-3-Clause",
   "type": "module",
   "bin": {
+    "add-browser-exports": "bin/add-browser-exports.js",
     "treemirror": "bin/treemirror.js",
     "release-image": "bin/release-image.js"
   },

--- a/packages/internal-scripts/package.json
+++ b/packages/internal-scripts/package.json
@@ -18,7 +18,8 @@
   },
   "scripts": {
     "build": "wireit",
-    "build:ts": "wireit"
+    "build:ts": "wireit",
+    "test": "wireit"
   },
   "wireit": {
     "build": {
@@ -35,6 +36,12 @@
       ],
       "output": [
         "lib"
+      ]
+    },
+    "test": {
+      "command": "(cd ../../ && node packages/internal-scripts/bin/add-browser-exports.js test)",
+      "dependencies": [
+        "build"
       ]
     }
   },

--- a/packages/internal-scripts/src/add-browser-exports.ts
+++ b/packages/internal-scripts/src/add-browser-exports.ts
@@ -160,7 +160,7 @@ function optionallyAddBrowserExportCondition(exports: Exports): {
           assert.notStrictEqual(
             exportPath,
             undefined,
-            `Any key/value exports defined in a node conditional export needs a browser export. Got undefind for "exports.node.${nodeKey}".`
+            `Any key/value exports defined in a node conditional export needs a browser export. Got undefined for "exports.node.${nodeKey}".`
           );
           browserExports[nodeKey] = exportPath;
         }

--- a/packages/internal-scripts/src/add-browser-exports.ts
+++ b/packages/internal-scripts/src/add-browser-exports.ts
@@ -1,0 +1,213 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// This script exists to perform a one time operation of adding the "browser"
+// exports field to relevant package.json files. Motivated by:
+// https://github.com/lit/lit/issues/4446
+//
+// The script is idempotent.
+//
+// # Instructions
+// After building the script run:
+// `node packages/internal-scripts/bin/add-browser-exports.js`
+
+import assert from 'assert';
+import {execSync} from 'child_process';
+import {readFile, writeFile} from 'fs/promises';
+import {resolve} from 'path';
+
+testScriptIntegrity();
+
+/**
+ * A loose structure for what we might find in the "exports" value within a
+ * `package.json` file.
+ */
+interface Exports {
+  [path: string]: {
+    types?: string;
+    browser?: {
+      development?: string;
+      default?: string;
+    };
+    node?: {
+      development?: string;
+      default?: string;
+    };
+    development?: string;
+    default?: string;
+  };
+}
+
+const result = execSync(`find . -name package.json`);
+
+const packageJsonFiles = result
+  .toString()
+  .trim()
+  .split('\n')
+  .filter((filePath) => !filePath.includes('/node_modules/'))
+  .filter((filePath) => !filePath.includes('/test-files/'))
+  .filter((filePath) => !filePath.includes('/test-goldens/'))
+  .filter((filePath) => !filePath.includes('/goldens/'));
+
+const absolutePackageJsonFilePaths = packageJsonFiles.map((relativePath) =>
+  resolve(process.cwd(), relativePath)
+);
+
+export const run = async () => {
+  const work: Promise<void>[] = [];
+  for (const packageJsonPath of absolutePackageJsonFilePaths) {
+    work.push(
+      (async (): Promise<void> => {
+        const parsedPackageJson = JSON.parse(
+          await readFile(packageJsonPath, {encoding: 'utf8'})
+        );
+        const exports: Exports | string | undefined =
+          parsedPackageJson['exports'];
+        if (exports === undefined) {
+          return;
+        }
+        // `"exports": "./index.js"` can be skipped.
+        if (typeof exports === 'string') {
+          return;
+        }
+        const fixedExports = optionallyAddBrowserExportCondition(exports);
+        parsedPackageJson['exports'] = fixedExports;
+        await writeFile(
+          packageJsonPath,
+          JSON.stringify(parsedPackageJson, null, 2) + '\n'
+        );
+      })()
+    );
+  }
+
+  await Promise.allSettled(work);
+};
+
+function optionallyAddBrowserExportCondition(exports: Exports): Exports {
+  const newExports: Exports = {};
+  for (const [path, exportValue] of Object.entries(exports)) {
+    if (exportValue.node === undefined || exportValue.browser !== undefined) {
+      newExports[path] = exportValue;
+      continue;
+    }
+    // If there is a node export condition defined without a browser export
+    // condition above it, then add the browser export condition.
+    const keyOrder = Object.keys(exportValue) as Array<
+      keyof typeof exportValue
+    >;
+    // The order of key/value pairs in the export condition matters. Here we
+    // ensure "browser" ends up directly above "node".
+    const newExportObject: Exports[typeof path] = {};
+    for (const key of keyOrder) {
+      // Add the browser export condition above the node export condition.
+      if (key === 'node') {
+        const browserExports: Partial<Exports['']['browser']> = {};
+        for (const nodeKey of Object.keys(exportValue.node) as Array<
+          keyof typeof exportValue.node
+        >) {
+          const exportPath = exportValue[nodeKey];
+          assert.notStrictEqual(
+            exportPath,
+            undefined,
+            `Any key/value exports defined in a node conditional export needs a browser export. Got undefind for "exports.node.${nodeKey}".`
+          );
+          browserExports[nodeKey] = exportPath;
+        }
+        newExportObject['browser'] = browserExports;
+      }
+      Object.assign(newExportObject, {[key]: exportValue[key]});
+    }
+    newExports[path] = newExportObject;
+  }
+  return newExports;
+}
+
+/**
+ * This function contains lightweight test assertions to ensure this script
+ * behaves as expected. This function will throw and prevent script execution in
+ * the case where a test fails.
+ */
+function testScriptIntegrity() {
+  /**
+   * Test: Empty object remains empty.
+   */
+  assert.deepStrictEqual(
+    optionallyAddBrowserExportCondition({}),
+    {},
+    'Expect empty exports to return empty exports'
+  );
+  /**
+   * Test: node export condition generates a browser export.
+   */
+  assert.deepStrictEqual(
+    optionallyAddBrowserExportCondition({
+      '.': {
+        types: './dev/path.d.ts',
+        node: {
+          development: './node/dev/path.js',
+          default: './node/path.js',
+        },
+        development: './dev/path.js',
+        default: './path.js',
+      },
+    }),
+    {
+      '.': {
+        types: './dev/path.d.ts',
+        browser: {
+          development: './dev/path.js',
+          default: './path.js',
+        },
+        node: {
+          development: './node/dev/path.js',
+          default: './node/path.js',
+        },
+        development: './dev/path.js',
+        default: './path.js',
+      },
+    },
+    `Expected browser exports to be added above the node export.`
+  );
+
+  /**
+   * Test: Export with am explicit browser condition is not modified
+   */
+  const exportsWithBrowser = {
+    '.': {
+      types: './dev/path.d.ts',
+      browser: {
+        development: './dev/path.js',
+        default: './apath.js',
+      },
+      node: {
+        development: './node/dev/path.js',
+        default: './node/path.js',
+      },
+      development: './dev/path.js',
+      default: './path.js',
+    },
+  };
+  assert.deepStrictEqual(
+    optionallyAddBrowserExportCondition(exportsWithBrowser),
+    exportsWithBrowser,
+    `Expected browser exports to be added above the node export.`
+  );
+
+  /**
+   * Test: There must be top level exports for any nested node exports.
+   */
+  assert.throws(() =>
+    optionallyAddBrowserExportCondition({
+      '.': {
+        node: {
+          development: './node/dev/path.js',
+          default: './node/path.js',
+        },
+        // Throws because there is no non-node exports to use for the
+        // browser export condition.
+      },
+    })
+  );
+}

--- a/packages/internal-scripts/src/add-browser-exports.ts
+++ b/packages/internal-scripts/src/add-browser-exports.ts
@@ -10,7 +10,7 @@
 // The script is idempotent.
 //
 // # Instructions
-// After building the script run:
+// After building the script run from monorepo root:
 // `node packages/internal-scripts/bin/add-browser-exports.js`
 
 import assert from 'assert';
@@ -40,7 +40,7 @@ interface Exports {
   };
 }
 
-const result = execSync(`find . -name package.json`);
+const result = execSync(`find ./packages -name package.json`);
 
 const packageJsonFiles = result
   .toString()

--- a/packages/labs/react/package.json
+++ b/packages/labs/react/package.json
@@ -19,6 +19,10 @@
   "exports": {
     ".": {
       "types": "./development/index.d.ts",
+      "browser": {
+        "development": "./development/index.js",
+        "default": "./index.js"
+      },
       "node": {
         "development": "./node/development/index.js",
         "default": "./node/index.js"
@@ -28,6 +32,10 @@
     },
     "./use-controller.js": {
       "types": "./development/use-controller.d.ts",
+      "browser": {
+        "development": "./development/use-controller.js",
+        "default": "./use-controller.js"
+      },
       "node": {
         "development": "./node/development/use-controller.js",
         "default": "./node/use-controller.js"

--- a/packages/labs/ssr-client/package.json
+++ b/packages/labs/ssr-client/package.json
@@ -19,6 +19,10 @@
   "exports": {
     ".": {
       "types": "./development/index.d.ts",
+      "browser": {
+        "development": "./development/index.js",
+        "default": "./index.js"
+      },
       "node": {
         "development": "./node/development/index.js",
         "default": "./node/index.js"
@@ -28,6 +32,10 @@
     },
     "./lit-element-hydrate-support.js": {
       "types": "./development/lit-element-hydrate-support.d.ts",
+      "browser": {
+        "development": "./development/lit-element-hydrate-support.js",
+        "default": "./lit-element-hydrate-support.js"
+      },
       "node": {
         "development": "./node/development/lit-element-hydrate-support.js",
         "default": "./node/lit-element-hydrate-support.js"

--- a/packages/lit-html/package.json
+++ b/packages/lit-html/package.json
@@ -15,6 +15,10 @@
   "exports": {
     ".": {
       "types": "./development/lit-html.d.ts",
+      "browser": {
+        "development": "./development/lit-html.js",
+        "default": "./lit-html.js"
+      },
       "node": {
         "development": "./node/development/lit-html.js",
         "default": "./node/lit-html.js"
@@ -24,6 +28,10 @@
     },
     "./async-directive.js": {
       "types": "./development/async-directive.d.ts",
+      "browser": {
+        "development": "./development/async-directive.js",
+        "default": "./async-directive.js"
+      },
       "node": {
         "development": "./node/development/async-directive.js",
         "default": "./node/async-directive.js"
@@ -33,6 +41,10 @@
     },
     "./directive-helpers.js": {
       "types": "./development/directive-helpers.d.ts",
+      "browser": {
+        "development": "./development/directive-helpers.js",
+        "default": "./directive-helpers.js"
+      },
       "node": {
         "development": "./node/development/directive-helpers.js",
         "default": "./node/directive-helpers.js"
@@ -42,6 +54,10 @@
     },
     "./directive.js": {
       "types": "./development/directive.d.ts",
+      "browser": {
+        "development": "./development/directive.js",
+        "default": "./directive.js"
+      },
       "node": {
         "development": "./node/development/directive.js",
         "default": "./node/directive.js"
@@ -51,6 +67,10 @@
     },
     "./directives/async-append.js": {
       "types": "./development/directives/async-append.d.ts",
+      "browser": {
+        "development": "./development/directives/async-append.js",
+        "default": "./directives/async-append.js"
+      },
       "node": {
         "development": "./node/development/directives/async-append.js",
         "default": "./node/directives/async-append.js"
@@ -60,6 +80,10 @@
     },
     "./directives/async-replace.js": {
       "types": "./development/directives/async-replace.d.ts",
+      "browser": {
+        "development": "./development/directives/async-replace.js",
+        "default": "./directives/async-replace.js"
+      },
       "node": {
         "development": "./node/development/directives/async-replace.js",
         "default": "./node/directives/async-replace.js"
@@ -69,6 +93,10 @@
     },
     "./directives/cache.js": {
       "types": "./development/directives/cache.d.ts",
+      "browser": {
+        "development": "./development/directives/cache.js",
+        "default": "./directives/cache.js"
+      },
       "node": {
         "development": "./node/development/directives/cache.js",
         "default": "./node/directives/cache.js"
@@ -78,6 +106,10 @@
     },
     "./directives/choose.js": {
       "types": "./development/directives/choose.d.ts",
+      "browser": {
+        "development": "./development/directives/choose.js",
+        "default": "./directives/choose.js"
+      },
       "node": {
         "development": "./node/development/directives/choose.js",
         "default": "./node/directives/choose.js"
@@ -87,6 +119,10 @@
     },
     "./directives/class-map.js": {
       "types": "./development/directives/class-map.d.ts",
+      "browser": {
+        "development": "./development/directives/class-map.js",
+        "default": "./directives/class-map.js"
+      },
       "node": {
         "development": "./node/development/directives/class-map.js",
         "default": "./node/directives/class-map.js"
@@ -96,6 +132,10 @@
     },
     "./directives/guard.js": {
       "types": "./development/directives/guard.d.ts",
+      "browser": {
+        "development": "./development/directives/guard.js",
+        "default": "./directives/guard.js"
+      },
       "node": {
         "development": "./node/development/directives/guard.js",
         "default": "./node/directives/guard.js"
@@ -105,6 +145,10 @@
     },
     "./directives/if-defined.js": {
       "types": "./development/directives/if-defined.d.ts",
+      "browser": {
+        "development": "./development/directives/if-defined.js",
+        "default": "./directives/if-defined.js"
+      },
       "node": {
         "development": "./node/development/directives/if-defined.js",
         "default": "./node/directives/if-defined.js"
@@ -114,6 +158,10 @@
     },
     "./directives/join.js": {
       "types": "./development/directives/join.d.ts",
+      "browser": {
+        "development": "./development/directives/join.js",
+        "default": "./directives/join.js"
+      },
       "node": {
         "development": "./node/development/directives/join.js",
         "default": "./node/directives/join.js"
@@ -123,6 +171,10 @@
     },
     "./directives/keyed.js": {
       "types": "./development/directives/keyed.d.ts",
+      "browser": {
+        "development": "./development/directives/keyed.js",
+        "default": "./directives/keyed.js"
+      },
       "node": {
         "development": "./node/development/directives/keyed.js",
         "default": "./node/directives/keyed.js"
@@ -132,6 +184,10 @@
     },
     "./directives/live.js": {
       "types": "./development/directives/live.d.ts",
+      "browser": {
+        "development": "./development/directives/live.js",
+        "default": "./directives/live.js"
+      },
       "node": {
         "development": "./node/development/directives/live.js",
         "default": "./node/directives/live.js"
@@ -141,6 +197,10 @@
     },
     "./directives/map.js": {
       "types": "./development/directives/map.d.ts",
+      "browser": {
+        "development": "./development/directives/map.js",
+        "default": "./directives/map.js"
+      },
       "node": {
         "development": "./node/development/directives/map.js",
         "default": "./node/directives/map.js"
@@ -150,6 +210,10 @@
     },
     "./directives/range.js": {
       "types": "./development/directives/range.d.ts",
+      "browser": {
+        "development": "./development/directives/range.js",
+        "default": "./directives/range.js"
+      },
       "node": {
         "development": "./node/development/directives/range.js",
         "default": "./node/directives/range.js"
@@ -159,6 +223,10 @@
     },
     "./directives/ref.js": {
       "types": "./development/directives/ref.d.ts",
+      "browser": {
+        "development": "./development/directives/ref.js",
+        "default": "./directives/ref.js"
+      },
       "node": {
         "development": "./node/development/directives/ref.js",
         "default": "./node/directives/ref.js"
@@ -168,6 +236,10 @@
     },
     "./directives/repeat.js": {
       "types": "./development/directives/repeat.d.ts",
+      "browser": {
+        "development": "./development/directives/repeat.js",
+        "default": "./directives/repeat.js"
+      },
       "node": {
         "development": "./node/development/directives/repeat.js",
         "default": "./node/directives/repeat.js"
@@ -177,6 +249,10 @@
     },
     "./directives/style-map.js": {
       "types": "./development/directives/style-map.d.ts",
+      "browser": {
+        "development": "./development/directives/style-map.js",
+        "default": "./directives/style-map.js"
+      },
       "node": {
         "development": "./node/development/directives/style-map.js",
         "default": "./node/directives/style-map.js"
@@ -186,6 +262,10 @@
     },
     "./directives/template-content.js": {
       "types": "./development/directives/template-content.d.ts",
+      "browser": {
+        "development": "./development/directives/template-content.js",
+        "default": "./directives/template-content.js"
+      },
       "node": {
         "development": "./node/development/directives/template-content.js",
         "default": "./node/directives/template-content.js"
@@ -195,6 +275,10 @@
     },
     "./directives/unsafe-html.js": {
       "types": "./development/directives/unsafe-html.d.ts",
+      "browser": {
+        "development": "./development/directives/unsafe-html.js",
+        "default": "./directives/unsafe-html.js"
+      },
       "node": {
         "development": "./node/development/directives/unsafe-html.js",
         "default": "./node/directives/unsafe-html.js"
@@ -204,6 +288,10 @@
     },
     "./directives/unsafe-svg.js": {
       "types": "./development/directives/unsafe-svg.d.ts",
+      "browser": {
+        "development": "./development/directives/unsafe-svg.js",
+        "default": "./directives/unsafe-svg.js"
+      },
       "node": {
         "development": "./node/development/directives/unsafe-svg.js",
         "default": "./node/directives/unsafe-svg.js"
@@ -213,6 +301,10 @@
     },
     "./directives/until.js": {
       "types": "./development/directives/until.d.ts",
+      "browser": {
+        "development": "./development/directives/until.js",
+        "default": "./directives/until.js"
+      },
       "node": {
         "development": "./node/development/directives/until.js",
         "default": "./node/directives/until.js"
@@ -222,6 +314,10 @@
     },
     "./directives/when.js": {
       "types": "./development/directives/when.d.ts",
+      "browser": {
+        "development": "./development/directives/when.js",
+        "default": "./directives/when.js"
+      },
       "node": {
         "development": "./node/development/directives/when.js",
         "default": "./node/directives/when.js"
@@ -231,6 +327,10 @@
     },
     "./polyfill-support.js": {
       "types": "./development/polyfill-support.d.ts",
+      "browser": {
+        "development": "./development/polyfill-support.js",
+        "default": "./polyfill-support.js"
+      },
       "node": {
         "development": "./node/development/polyfill-support.js",
         "default": "./node/polyfill-support.js"
@@ -240,6 +340,10 @@
     },
     "./private-ssr-support.js": {
       "types": "./development/private-ssr-support.d.ts",
+      "browser": {
+        "development": "./development/private-ssr-support.js",
+        "default": "./private-ssr-support.js"
+      },
       "node": {
         "development": "./node/development/private-ssr-support.js",
         "default": "./node/private-ssr-support.js"
@@ -249,6 +353,10 @@
     },
     "./static.js": {
       "types": "./development/static.d.ts",
+      "browser": {
+        "development": "./development/static.js",
+        "default": "./static.js"
+      },
       "node": {
         "development": "./node/development/static.js",
         "default": "./node/static.js"
@@ -258,6 +366,10 @@
     },
     "./is-server.js": {
       "types": "./development/is-server.d.ts",
+      "browser": {
+        "development": "./development/is-server.js",
+        "default": "./is-server.js"
+      },
       "node": {
         "development": "./node/development/is-server.js",
         "default": "./node/is-server.js"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -19,6 +19,10 @@
   "exports": {
     ".": {
       "types": "./development/index.d.ts",
+      "browser": {
+        "development": "./development/index.js",
+        "default": "./index.js"
+      },
       "node": {
         "development": "./node/development/index.js",
         "default": "./node/index.js"
@@ -28,6 +32,10 @@
     },
     "./use-controller.js": {
       "types": "./development/use-controller.d.ts",
+      "browser": {
+        "development": "./development/use-controller.js",
+        "default": "./use-controller.js"
+      },
       "node": {
         "development": "./node/development/use-controller.js",
         "default": "./node/use-controller.js"

--- a/packages/reactive-element/package.json
+++ b/packages/reactive-element/package.json
@@ -19,6 +19,10 @@
   "exports": {
     ".": {
       "types": "./development/reactive-element.d.ts",
+      "browser": {
+        "development": "./development/reactive-element.js",
+        "default": "./reactive-element.js"
+      },
       "node": {
         "development": "./node/development/reactive-element.js",
         "default": "./node/reactive-element.js"
@@ -28,6 +32,10 @@
     },
     "./css-tag.js": {
       "types": "./development/css-tag.d.ts",
+      "browser": {
+        "development": "./development/css-tag.js",
+        "default": "./css-tag.js"
+      },
       "node": {
         "development": "./node/development/css-tag.js",
         "default": "./node/css-tag.js"
@@ -37,6 +45,10 @@
     },
     "./decorators.js": {
       "types": "./development/decorators.d.ts",
+      "browser": {
+        "development": "./development/decorators.js",
+        "default": "./decorators.js"
+      },
       "node": {
         "development": "./node/development/decorators.js",
         "default": "./node/decorators.js"
@@ -46,6 +58,10 @@
     },
     "./decorators/base.js": {
       "types": "./development/decorators/base.d.ts",
+      "browser": {
+        "development": "./development/decorators/base.js",
+        "default": "./decorators/base.js"
+      },
       "node": {
         "development": "./node/development/decorators/base.js",
         "default": "./node/decorators/base.js"
@@ -55,6 +71,10 @@
     },
     "./decorators/custom-element.js": {
       "types": "./development/decorators/custom-element.d.ts",
+      "browser": {
+        "development": "./development/decorators/custom-element.js",
+        "default": "./decorators/custom-element.js"
+      },
       "node": {
         "development": "./node/development/decorators/custom-element.js",
         "default": "./node/decorators/custom-element.js"
@@ -64,6 +84,10 @@
     },
     "./decorators/event-options.js": {
       "types": "./development/decorators/event-options.d.ts",
+      "browser": {
+        "development": "./development/decorators/event-options.js",
+        "default": "./decorators/event-options.js"
+      },
       "node": {
         "development": "./node/development/decorators/event-options.js",
         "default": "./node/decorators/event-options.js"
@@ -73,6 +97,10 @@
     },
     "./decorators/property.js": {
       "types": "./development/decorators/property.d.ts",
+      "browser": {
+        "development": "./development/decorators/property.js",
+        "default": "./decorators/property.js"
+      },
       "node": {
         "development": "./node/development/decorators/property.js",
         "default": "./node/decorators/property.js"
@@ -82,6 +110,10 @@
     },
     "./decorators/query-all.js": {
       "types": "./development/decorators/query-all.d.ts",
+      "browser": {
+        "development": "./development/decorators/query-all.js",
+        "default": "./decorators/query-all.js"
+      },
       "node": {
         "development": "./node/development/decorators/query-all.js",
         "default": "./node/decorators/query-all.js"
@@ -91,6 +123,10 @@
     },
     "./decorators/query-assigned-elements.js": {
       "types": "./development/decorators/query-assigned-elements.d.ts",
+      "browser": {
+        "development": "./development/decorators/query-assigned-elements.js",
+        "default": "./decorators/query-assigned-elements.js"
+      },
       "node": {
         "development": "./node/development/decorators/query-assigned-elements.js",
         "default": "./node/decorators/query-assigned-elements.js"
@@ -100,6 +136,10 @@
     },
     "./decorators/query-assigned-nodes.js": {
       "types": "./development/decorators/query-assigned-nodes.d.ts",
+      "browser": {
+        "development": "./development/decorators/query-assigned-nodes.js",
+        "default": "./decorators/query-assigned-nodes.js"
+      },
       "node": {
         "development": "./node/development/decorators/query-assigned-nodes.js",
         "default": "./node/decorators/query-assigned-nodes.js"
@@ -109,6 +149,10 @@
     },
     "./decorators/query-async.js": {
       "types": "./development/decorators/query-async.d.ts",
+      "browser": {
+        "development": "./development/decorators/query-async.js",
+        "default": "./decorators/query-async.js"
+      },
       "node": {
         "development": "./node/development/decorators/query-async.js",
         "default": "./node/decorators/query-async.js"
@@ -118,6 +162,10 @@
     },
     "./decorators/query.js": {
       "types": "./development/decorators/query.d.ts",
+      "browser": {
+        "development": "./development/decorators/query.js",
+        "default": "./decorators/query.js"
+      },
       "node": {
         "development": "./node/development/decorators/query.js",
         "default": "./node/decorators/query.js"
@@ -127,6 +175,10 @@
     },
     "./decorators/state.js": {
       "types": "./development/decorators/state.d.ts",
+      "browser": {
+        "development": "./development/decorators/state.js",
+        "default": "./decorators/state.js"
+      },
       "node": {
         "development": "./node/development/decorators/state.js",
         "default": "./node/decorators/state.js"
@@ -136,6 +188,10 @@
     },
     "./polyfill-support.js": {
       "types": "./development/polyfill-support.d.ts",
+      "browser": {
+        "development": "./development/polyfill-support.js",
+        "default": "./polyfill-support.js"
+      },
       "node": {
         "development": "./node/development/polyfill-support.js",
         "default": "./node/polyfill-support.js"
@@ -145,6 +201,10 @@
     },
     "./reactive-controller.js": {
       "types": "./development/reactive-controller.d.ts",
+      "browser": {
+        "development": "./development/reactive-controller.js",
+        "default": "./reactive-controller.js"
+      },
       "node": {
         "development": "./node/development/reactive-controller.js",
         "default": "./node/reactive-controller.js"


### PR DESCRIPTION
Fixes: https://github.com/lit/lit/issues/4446

### Context

This is a compromise so that testing in Vitest works. As part of this work I explored simplifying the package.json exports using subpath patterns. Unfortunately the [ecosystem doesn't support those very well, so it's been punted](https://github.com/lit/lit/pull/4483).

- First commit contains the script.
- Second commit contains the result of running the script.

Marked this a patch change, as it's a minor "bug fix" workaround for testing in Jest and Vitest.

This script has two modes:

 - `test`: won't write any files, but instead checks that no files need to be fixed. Is run as part of our CI.
 - `fix`: writes to package.json files.

### Test plan

The prior browser/node entrypoints are tested via our CI.

The script itself is lightly tested via node assertions. The script won't run if an assertion fails.

### Risk

This changes the entrypoints in some of our package.json configurations, so it is a slightly risky change. We've manually verified that adding the browser export above node works correctly. Similarly if our test suite passes, then this should not be a regression as we use the exports in our tests.