### PR TITLE
[lit-labs/ssr-dom-shim] shim Element.prototype.toggleAttribute method

### DIFF
--- a/.changeset/fresh-fishes-do.md
+++ b/.changeset/fresh-fishes-do.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/ssr-dom-shim': minor
+---
+
+Add `toggleAttribute` to the Element shim.

--- a/.eslintignore
+++ b/.eslintignore
@@ -348,6 +348,7 @@ packages/labs/ssr-client/lit-element-hydrate-support.*
 
 packages/labs/ssr-dom-shim/index.*
 packages/labs/ssr-dom-shim/lib/
+packages/labs/ssr-dom-shim/test/
 
 packages/labs/ssr-react/node/
 packages/labs/ssr-react/lib/

--- a/.prettierignore
+++ b/.prettierignore
@@ -336,6 +336,7 @@ packages/labs/ssr-client/lit-element-hydrate-support.*
 
 packages/labs/ssr-dom-shim/index.*
 packages/labs/ssr-dom-shim/lib/
+packages/labs/ssr-dom-shim/test/
 
 packages/labs/ssr-react/node/
 packages/labs/ssr-react/lib/

--- a/package.json
+++ b/package.json
@@ -174,6 +174,7 @@
         "./packages/labs/react:test",
         "./packages/labs/rollup-plugin-minify-html-literals:test",
         "./packages/labs/ssr:test",
+        "./packages/labs/ssr-dom-shim:test",
         "./packages/labs/ssr-react:test",
         "./packages/labs/testing:test",
         "./packages/labs/virtualizer:test",

--- a/packages/labs/ssr-dom-shim/.gitignore
+++ b/packages/labs/ssr-dom-shim/.gitignore
@@ -1,2 +1,3 @@
 /index.*
 /lib/
+/test/

--- a/packages/labs/ssr-dom-shim/package.json
+++ b/packages/labs/ssr-dom-shim/package.json
@@ -28,7 +28,8 @@
   ],
   "scripts": {
     "build": "wireit",
-    "build:ts": "wireit"
+    "build:ts": "wireit",
+    "test": "wireit"
   },
   "wireit": {
     "build": {
@@ -48,6 +49,16 @@
         "index.{d.ts,d.ts.map,js,js.map}",
         "tsconfig.tsbuildinfo"
       ]
+    },
+    "test": {
+      "command": "uvu test \"_test\\.js$\"",
+      "dependencies": [
+        "build"
+      ],
+      "env": {
+        "NODE_OPTIONS": "--enable-source-maps"
+      },
+      "output": []
     }
   }
 }

--- a/packages/labs/ssr-dom-shim/src/index.ts
+++ b/packages/labs/ssr-dom-shim/src/index.ts
@@ -61,6 +61,17 @@ const ElementShim = class Element {
   removeAttribute(name: string) {
     attributesForElement(this).delete(name);
   }
+  toggleAttribute(name: string, force?: boolean): boolean {
+    if (force === undefined) {
+      force = !this.hasAttribute(name);
+    }
+    if (force) {
+      this.setAttribute(name, '');
+    } else {
+      this.removeAttribute(name);
+    }
+    return force;
+  }
   hasAttribute(name: string) {
     return attributesForElement(this).has(name);
   }

--- a/packages/labs/ssr-dom-shim/src/test/element-shim_test.ts
+++ b/packages/labs/ssr-dom-shim/src/test/element-shim_test.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {suite} from 'uvu';
+// eslint-disable-next-line import/extensions
+import * as assert from 'uvu/assert';
+import {HTMLElement} from '@lit-labs/ssr-dom-shim';
+
+const test = suite('Element Shim');
+
+test('toggleAttribute adds and removes attributes', () => {
+  const shimmedEl = new HTMLElement();
+  assert.ok(shimmedEl.toggleAttribute('potato'));
+  assert.ok(shimmedEl.hasAttribute('potato'));
+  assert.not.ok(shimmedEl.toggleAttribute('potato'));
+  assert.not.ok(shimmedEl.hasAttribute('potato'));
+});
+
+test('toggleAttribute accepts an optional force parameter', () => {
+  const shimmedEl = new HTMLElement();
+  assert.not.ok(shimmedEl.toggleAttribute('potato', false));
+  assert.not.ok(shimmedEl.hasAttribute('potato'));
+  assert.ok(shimmedEl.toggleAttribute('potato', true));
+  assert.ok(shimmedEl.hasAttribute('potato'));
+  // A no-op, ensuring attribute remains
+  assert.ok(shimmedEl.toggleAttribute('potato', true));
+  assert.ok(shimmedEl.hasAttribute('potato'));
+});
+
+test('setAttribute silently casts values to a string', () => {
+  const shimmedEl = new HTMLElement();
+  // It is possible to pass any value to `setAttribute`, and we
+  // silently convert it to a string.
+  shimmedEl.setAttribute('tomato', {} as unknown as string);
+  assert.equal(shimmedEl.getAttribute('tomato'), '[object Object]');
+});
+
+test.run();


### PR DESCRIPTION
Fixes: https://github.com/lit/lit/issues/4468

This adds [`Element.prototype.toggleAttribute(name, force?)`](https://developer.mozilla.org/en-US/docs/Web/API/Element/toggleAttribute) to the SSR ElementShim.

### Test plan

Unit tested in the node environment using `uvu`. Note, the package originally didn't have unit tests, so I've also set up a new `test` rule.

### Assumptions about casing

Documenting this as I was going to implement lower-casing of attribute names until I spoke with Augustine.

Ignoring casing is by design in the shim because these shimmed APIs can be used on SVG elements where casing is preserved. I believe the justification is we preserve casing during SSR, and then the browser will lowercase the attributes if in the HTML namespace. E.g. if we SSR `<div cLaSs="example">`, it'll be parsed into `<div class="example">`. But `<svg viewBox=...>` will be preserved as `<svg viewBox=...>`.
