### PR TITLE
[labs/motion] chore: improve adjustments of ancestor condition check

### DIFF
--- a/.changeset/serious-books-flow.md
+++ b/.changeset/serious-books-flow.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/motion': patch
+---
+
+Fix a harmless but incorrect check on array during ancestor adjustment. This fix is purely an optimization with no change in behavior.

--- a/packages/labs/motion/src/animate.ts
+++ b/packages/labs/motion/src/animate.ts
@@ -514,7 +514,7 @@ export class Animate extends AsyncDirective {
       .filter((a) => a !== undefined) as CSSValues[];
     let dScaleX = 1;
     let dScaleY = 1;
-    if (ancestorProps !== undefined) {
+    if (ancestorProps.length) {
       // gather scaling data for ancestors
       ancestorProps.forEach((a) => {
         if (a['width']) {

--- a/packages/labs/motion/src/animate.ts
+++ b/packages/labs/motion/src/animate.ts
@@ -514,7 +514,7 @@ export class Animate extends AsyncDirective {
       .filter((a) => a !== undefined) as CSSValues[];
     let dScaleX = 1;
     let dScaleY = 1;
-    if (ancestorProps.length) {
+    if (ancestorProps.length > 0) {
       // gather scaling data for ancestors
       ancestorProps.forEach((a) => {
         if (a['width']) {


### PR DESCRIPTION
`ancestorProps` is an array there, so it's always not equal `undefiend`. There should validate its `length`