### PR TITLE
[localize-tools] Preserve existing placeholder id/index on extract

### DIFF
--- a/.changeset/mean-cars-appear.md
+++ b/.changeset/mean-cars-appear.md
@@ -1,0 +1,5 @@
+---
+'@lit/localize-tools': patch
+---
+
+Fix an issue where running `extract` on an existing translation target would rewrite the "id" for placeholders signifying the expression index, which breaks translation targets where the expressions need to be reordered.

--- a/packages/localize-tools/src/formatters/xlb.ts
+++ b/packages/localize-tools/src/formatters/xlb.ts
@@ -130,14 +130,13 @@ class XlbFormatter implements Formatter {
       }
       indent(messagesNode, 2);
       messagesNode.appendChild(messageNode);
-      let phIdx = 0;
       for (const content of contents) {
         if (typeof content === 'string') {
           messageNode.appendChild(doc.createTextNode(content));
         } else {
-          const {untranslatable} = content;
+          const {untranslatable, index} = content;
           const ph = doc.createElement('ph');
-          ph.setAttribute('name', String(phIdx++));
+          ph.setAttribute('name', String(index));
           ph.appendChild(doc.createTextNode(untranslatable));
           messageNode.appendChild(ph);
         }

--- a/packages/localize-tools/src/formatters/xliff.ts
+++ b/packages/localize-tools/src/formatters/xliff.ts
@@ -278,14 +278,11 @@ export class XliffFormatter implements Formatter {
    */
   private encodeContents(doc: Document, contents: Message['contents']): Node[] {
     const nodes = [];
-    // We need a unique ID within each source for each placeholder. The index
-    // will do.
-    let phIdx = 0;
     for (const content of contents) {
       if (typeof content === 'string') {
         nodes.push(doc.createTextNode(content));
       } else {
-        nodes.push(this.createPlaceholder(doc, String(phIdx++), content));
+        nodes.push(this.createPlaceholder(doc, content));
       }
     }
     return nodes;
@@ -293,10 +290,12 @@ export class XliffFormatter implements Formatter {
 
   private createPlaceholder(
     doc: Document,
-    id: string,
-    {untranslatable}: Placeholder
+    {untranslatable, index}: Placeholder
   ): HTMLElement {
     const style = this.xliffConfig.placeholderStyle ?? 'x';
+    // We need a unique ID within each source for each placeholder. The index
+    // will do.
+    const id = String(index);
     if (style === 'x') {
       // https://docs.oasis-open.org/xliff/v1.2/os/xliff-core.html#x
       const el = doc.createElement('x');

--- a/packages/localize-tools/testdata/extract-xliff-merge/goldens/foo.ts
+++ b/packages/localize-tools/testdata/extract-xliff-merge/goldens/foo.ts
@@ -7,7 +7,9 @@
 import {msg, str} from '@lit/localize';
 
 const who = 'World';
+const kind = 'Small';
 msg(str`I am translated. Hello ${who}.`, {desc: 'Description of translated'});
+msg(str`I am translated with swapped order. Hello ${kind} ish ${who}.`);
 msg('I am not translated', {desc: 'Description of not translated'});
 msg('I am translated with a note', {desc: 'Happy note'});
 msg('My note needs to be migrated', {desc: 'Existing note'});

--- a/packages/localize-tools/testdata/extract-xliff-merge/goldens/xliff/es-419.xlf
+++ b/packages/localize-tools/testdata/extract-xliff-merge/goldens/xliff/es-419.xlf
@@ -8,6 +8,10 @@
       <target state="translated">Estoy traducido. Hola <ph id="0">${who}</ph>.</target>
   <note from="lit-localize">Description of translated</note>
     </trans-unit>
+    <trans-unit id="s648aae3daabd8fcc">
+      <source>I am translated with swapped order. Hello <ph id="0">${kind}</ph> ish <ph id="1">${who}</ph>.</source>
+      <target state="translated">Estoy traducido con orden intercambiada. Hola <ph id="1">${who}</ph> más o menos <ph id="0">${kind}</ph>.</target>
+    </trans-unit>
     <trans-unit id="s18fa8e4d6470399d">
       <source foo:attribute="bar">I am translated with a note</source>
       <target state="translated">Estoy traducido con una nota</target>

--- a/packages/localize-tools/testdata/extract-xliff-merge/input/foo.ts
+++ b/packages/localize-tools/testdata/extract-xliff-merge/input/foo.ts
@@ -7,7 +7,9 @@
 import {msg, str} from '@lit/localize';
 
 const who = 'World';
+const kind = 'Small';
 msg(str`I am translated. Hello ${who}.`, {desc: 'Description of translated'});
+msg(str`I am translated with swapped order. Hello ${kind} ish ${who}.`);
 msg('I am not translated', {desc: 'Description of not translated'});
 msg('I am translated with a note', {desc: 'Happy note'});
 msg('My note needs to be migrated', {desc: 'Existing note'});

--- a/packages/localize-tools/testdata/extract-xliff-merge/input/xliff/es-419.xlf
+++ b/packages/localize-tools/testdata/extract-xliff-merge/input/xliff/es-419.xlf
@@ -7,6 +7,10 @@
       <source>I was translated. Hello <ph id="0">${who}</ph>.</source>
       <target state="translated">Estoy traducido. Hola <ph id="0">${who}</ph>.</target>
     </trans-unit>
+    <trans-unit id="s648aae3daabd8fcc">
+      <source>I am translated with swapped order. Hello <ph id="0">${kind}</ph> ish <ph id="1">${who}</ph>.</source>
+      <target state="translated">Estoy traducido con orden intercambiada. Hola <ph id="1">${who}</ph> más o menos <ph id="0">${kind}</ph>.</target>
+    </trans-unit>
     <trans-unit id="s18fa8e4d6470399d">
       <source foo:attribute="bar">I am translated with a note</source>
       <target state="translated">Estoy traducido con una nota</target>


### PR DESCRIPTION
Fixes https://github.com/lit/lit/issues/4490

Instead of creating a new placeholder index on write which will always be in the order seen, we should use the existing index for untranslatables which could be out of order if they're read from an already translated target.