### PR TITLE
[labs/ssr] fix patched directives memory leak

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -5,6 +5,6 @@
   "linked": [],
   "access": "public",
   "baseBranch": "main",
-  "updateInternalDependencies": "minor",
+  "updateInternalDependencies": "patch",
   "ignore": []
 }

--- a/.changeset/long-points-deliver.md
+++ b/.changeset/long-points-deliver.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/ssr': patch
+---
+
+fix a memory leak when patching directive constructors.

--- a/.changeset/long-points-deliver.md
+++ b/.changeset/long-points-deliver.md
@@ -1,5 +1,6 @@
 ---
 '@lit-labs/ssr': patch
+'lit-html': patch
 ---
 
-fix a memory leak when patching directive constructors.
+Fix a memory leak when patching directive constructors for SSR.

--- a/packages/labs/ssr/src/lib/render-value.ts
+++ b/packages/labs/ssr/src/lib/render-value.ts
@@ -74,6 +74,10 @@ declare module 'parse5/dist/tree-adapters/default.js' {
   }
 }
 
+interface MaybePatchedDirective extends DirectiveClass {
+  patchedDirective: true | undefined;
+}
+
 const patchedDirectiveCache = new WeakMap<DirectiveClass, DirectiveClass>();
 
 /**
@@ -83,7 +87,10 @@ const patchedDirectiveCache = new WeakMap<DirectiveClass, DirectiveClass>();
 const patchIfDirective = (value: unknown) => {
   // This property needs to remain unminified.
   const directiveCtor = getDirectiveClass(value);
-  if (directiveCtor !== undefined) {
+  if (
+    directiveCtor !== undefined &&
+    (directiveCtor as MaybePatchedDirective).patchedDirective === undefined
+  ) {
     let patchedCtor = patchedDirectiveCache.get(directiveCtor);
     if (patchedCtor === undefined) {
       patchedCtor = overrideDirectiveResolve(
@@ -94,6 +101,7 @@ const patchIfDirective = (value: unknown) => {
           return patchIfDirective(directive.render(...values));
         }
       );
+      (patchedCtor as MaybePatchedDirective).patchedDirective = true;
       patchedDirectiveCache.set(directiveCtor, patchedCtor);
     }
     // This property needs to remain unminified.

--- a/packages/labs/ssr/src/lib/render-value.ts
+++ b/packages/labs/ssr/src/lib/render-value.ts
@@ -7,11 +7,7 @@
  */
 
 import type {TemplateResult, ChildPart, CompiledTemplateResult} from 'lit';
-import type {
-  Directive,
-  DirectiveClass,
-  DirectiveResult,
-} from 'lit/directive.js';
+import type {Directive} from 'lit/directive.js';
 
 import {nothing, noChange} from 'lit';
 import {PartType} from 'lit/directive.js';
@@ -29,8 +25,7 @@ const {
   marker,
   markerMatch,
   boundAttributeSuffix,
-  overrideDirectiveResolve,
-  setDirectiveClass,
+  patchDirectiveResolve,
   getAttributePartCommittedValue,
   resolveDirective,
   AttributePart,
@@ -67,6 +62,7 @@ import {reflectedAttributeName} from './reflected-attributes.js';
 
 import type {RenderResult} from './render-result.js';
 import {isHydratable} from './server-template.js';
+import type {Part} from 'lit-html';
 
 declare module 'parse5/dist/tree-adapters/default.js' {
   interface Element {
@@ -74,38 +70,20 @@ declare module 'parse5/dist/tree-adapters/default.js' {
   }
 }
 
-interface MaybePatchedDirective extends DirectiveClass {
-  patchedDirective: true | undefined;
+function ssrResolve(this: Directive, _part: Part, values: unknown[]) {
+  // Since the return value may also be a directive result in the case of nested
+  // directives, we may need to patch that as well.
+  return patchIfDirective(this.render(...values));
 }
 
-const patchedDirectiveCache = new WeakMap<DirectiveClass, DirectiveClass>();
-
 /**
- * Looks for values of type `DirectiveResult` and replaces its Directive class
- * with a subclass that calls `render` rather than `update`
+ * Looks for values of type `DirectiveResult` and patches its Directive class
+ * such that it calls `render` rather than `update`.
  */
 const patchIfDirective = (value: unknown) => {
-  // This property needs to remain unminified.
   const directiveCtor = getDirectiveClass(value);
-  if (
-    directiveCtor !== undefined &&
-    (directiveCtor as MaybePatchedDirective).patchedDirective === undefined
-  ) {
-    let patchedCtor = patchedDirectiveCache.get(directiveCtor);
-    if (patchedCtor === undefined) {
-      patchedCtor = overrideDirectiveResolve(
-        directiveCtor,
-        (directive: Directive, values: unknown[]) => {
-          // Since the return value may also be a directive result in the case of
-          // nested directives, we may need to patch that as well
-          return patchIfDirective(directive.render(...values));
-        }
-      );
-      (patchedCtor as MaybePatchedDirective).patchedDirective = true;
-      patchedDirectiveCache.set(directiveCtor, patchedCtor);
-    }
-    // This property needs to remain unminified.
-    setDirectiveClass(value as DirectiveResult, patchedCtor);
+  if (directiveCtor !== undefined) {
+    patchDirectiveResolve(directiveCtor, ssrResolve);
   }
   return value;
 };

--- a/packages/lit-html/src/private-ssr-support.ts
+++ b/packages/lit-html/src/private-ssr-support.ts
@@ -59,7 +59,11 @@ export const _$LH = {
     },
   patchDirectiveResolve: (
     directiveClass: new (part: PartInfo) => Directive,
-    resolveOverrideFn: Directive['_$resolve']
+    resolveOverrideFn: (
+      this: Directive,
+      _part: Part,
+      values: unknown[]
+    ) => unknown
   ) => {
     if (directiveClass.prototype._$resolve !== resolveOverrideFn) {
       directiveClass.prototype._$resolve = resolveOverrideFn;

--- a/packages/lit-html/src/private-ssr-support.ts
+++ b/packages/lit-html/src/private-ssr-support.ts
@@ -88,9 +88,9 @@ export const _$LH = {
       // client contains multiple duplicate Lit modules with minified and
       // unminified exports, we currently cannot handle both.
       throw new Error(
-        `Internal error: It is possible  that both dev mode and production mode` +
-          ` Lit was mixed together during SSR. Please file a bug at: ` +
-          `https://github.com/lit/lit/issues/new/choose`
+        `Internal error: It is possible that both dev mode and production mode` +
+          ` Lit was mixed together during SSR. Please comment on the issue: ` +
+          `https://github.com/lit/lit/issues/4527`
       );
     }
   },

--- a/packages/lit-html/src/private-ssr-support.ts
+++ b/packages/lit-html/src/private-ssr-support.ts
@@ -59,11 +59,7 @@ export const _$LH = {
     },
   patchDirectiveResolve: (
     directiveClass: new (part: PartInfo) => Directive,
-    resolveOverrideFn: (
-      this: Directive,
-      _part: Part,
-      values: unknown[]
-    ) => unknown
+    resolveOverrideFn: Directive['_$resolve']
   ) => {
     if (directiveClass.prototype._$resolve !== resolveOverrideFn) {
       directiveClass.prototype._$resolve = resolveOverrideFn;

--- a/packages/lit-html/src/private-ssr-support.ts
+++ b/packages/lit-html/src/private-ssr-support.ts
@@ -28,7 +28,7 @@ import type {
 } from './lit-html.js';
 
 // Contains either the minified or unminified `_$resolve` Directive method name.
-let resolveName = null;
+let resolveMethodName: Extract<keyof Directive, '_$resolve'> | null = null;
 
 /**
  * END USERS SHOULD NOT RELY ON THIS OBJECT.
@@ -69,13 +69,15 @@ export const _$LH = {
     ) => unknown
   ) => {
     if (directiveClass.prototype._$resolve !== resolveOverrideFn) {
-      resolveName ??= directiveClass.prototype._$resolve.name;
-      let proto = directiveClass.prototype;
-      for (; proto !== Object.prototype; proto = Object.getPrototypeOf(proto)) {
-        if (proto.hasOwnProperty(resolveName)) {
-          (proto as unknown as {[key: string]: typeof resolveOverrideFn})[
-            resolveName
-          ] = resolveOverrideFn;
+      resolveMethodName ??= directiveClass.prototype._$resolve
+        .name as NonNullable<typeof resolveMethodName>;
+      for (
+        let proto = directiveClass.prototype;
+        proto !== Object.prototype;
+        proto = Object.getPrototypeOf(proto)
+      ) {
+        if (proto.hasOwnProperty(resolveMethodName)) {
+          proto[resolveMethodName] = resolveOverrideFn;
           return;
         }
       }

--- a/packages/lit-html/src/private-ssr-support.ts
+++ b/packages/lit-html/src/private-ssr-support.ts
@@ -58,13 +58,17 @@ export const _$LH = {
       }
     },
   patchDirectiveResolve: (
-    directiveClass: new (part: PartInfo) => Directive,
+    directiveClass: typeof Directive,
     resolveOverrideFn: (
       this: Directive,
       _part: Part,
       values: unknown[]
     ) => unknown
   ) => {
+    // TODO: This could be optimized such that `_$resolve` is only patched on
+    // the Directive base class once. This should reduce class shape changes and
+    // be slightly more optimal. The hazard is that we need to handle both the
+    // unminified and minified property keys.
     if (directiveClass.prototype._$resolve !== resolveOverrideFn) {
       directiveClass.prototype._$resolve = resolveOverrideFn;
     }

--- a/packages/lit-html/src/private-ssr-support.ts
+++ b/packages/lit-html/src/private-ssr-support.ts
@@ -57,6 +57,18 @@ export const _$LH = {
         return resolveOverrideFn(this, values);
       }
     },
+  patchDirectiveResolve: (
+    directiveClass: new (part: PartInfo) => Directive,
+    resolveOverrideFn: (
+      this: Directive,
+      _part: Part,
+      values: unknown[]
+    ) => unknown
+  ) => {
+    if (directiveClass.prototype._$resolve !== resolveOverrideFn) {
+      directiveClass.prototype._$resolve = resolveOverrideFn;
+    }
+  },
   setDirectiveClass(value: DirectiveResult, directiveClass: DirectiveClass) {
     // This property needs to remain unminified.
     value['_$litDirective$'] = directiveClass;


### PR DESCRIPTION
# Context

A memory leak was reported in Lit SSR.

Found by testing with https://github.com/lit/lit/pull/4514, and going test by test.
 - The `repeat` directive test contained this leak. After this PR the directive test no longer leaks.

So far no other test shows memory leak characteristics.

### Why?

Because we have a cache of `WeakMap<non patched directive, patched directive>`. This is an issue because we can pull a patched directive off the `value`, and then it won't be found in the WeakMap. Because it's in the value of the WeakMap and not the `key`. Thus the patched directive gets patched again and stored in the WeakMap. This repeats for the number of patch calls resulting in a nested doll of patched directive constructors.

### Fix

~~I implemented a super simple naive fix. Just flag the patched directive ctor with a sentinel property. Now when pulling the directive constructor off the `value`, we can immediately check if it's patched by looking at the sentinel.~~

Fix was updated per Justin's feedback. It now patches the `_$resolve` field. This simplifies a lot of the book keeping code. Which has a much nicer memory footprint.

However, this fix does need to be backwards compatible hence the new API, `patchDirectiveResolve`. This allows for the following:

- User has lit-html and ssr, and bumps lit-html only. The older ssr package can still use `overrideDirectiveResolve`.
- User has lit-html and ssr, and bumps ssr. This will need to depend on the version of lit-html that introduces `patchDirectiveResolve`, v3.1.2 (unreleased).



### Test plan

No memory test for this change because memory tests are expensive and slow. Instead this is covered by existing behavior tests. I can add tests if required.
The memory characteristics of this change were verified by pulling this change into https://github.com/lit/lit/pull/4514

Plan is to commit a memory test as a separate PR.