### PR TITLE
[labs/ssr] fix server templates dropping top level `td` elements

### DIFF
--- a/.changeset/tough-crews-cover.md
+++ b/.changeset/tough-crews-cover.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/ssr': patch
+---
+
+Fix a bug where a top level 'td' tag would be removed from a server template.

--- a/packages/labs/ssr/src/lib/render-value.ts
+++ b/packages/labs/ssr/src/lib/render-value.ts
@@ -224,6 +224,14 @@ type Op =
   | PossibleNodeMarkerOp;
 
 /**
+ * Any of these top level tags will be removed by parse5's `parseFragment` and
+ * will cause part errors if there are any part bindings. For only these tags,
+ * we use a page-level template `parse`.
+ */
+const REGEXP_TEMPLATE_STARTS_WITH_PAGE_TAG =
+  /^\s*(<(!doctype|html|head|body))/i;
+
+/**
  * For a given TemplateResult, generates and/or returns a cached list of opcodes
  * for the associated Template.  Opcodes are designed to allow emitting
  * contiguous static text from the template as much as possible, with specific
@@ -285,11 +293,9 @@ type Op =
  * - `custom-element-close`
  *   - Pop the CE `instance`+`renderer` off the `customElementInstanceStack`
  */
-const getTemplateOpcodes = (
-  result: TemplateResult,
-  isServerTemplate = false
-) => {
+const getTemplateOpcodes = (result: TemplateResult) => {
   const template = templateCache.get(result.strings);
+  console.log('got undefined template', result.strings);
   if (template !== undefined) {
     return template;
   }
@@ -302,6 +308,9 @@ const getTemplateOpcodes = (
   );
 
   const hydratable = isHydratable(result);
+  const htmlString = String(html);
+  const isPageLevelTemplate =
+    REGEXP_TEMPLATE_STARTS_WITH_PAGE_TAG.test(htmlString);
 
   /**
    * The html string is parsed into a parse5 AST with source code information
@@ -311,7 +320,7 @@ const getTemplateOpcodes = (
    * Server Templates need to use `parse` as they may contain document tags such
    * as `<html>`.
    */
-  const ast = (isServerTemplate ? parse : parseFragment)(String(html), {
+  const ast = (isPageLevelTemplate ? parse : parseFragment)(htmlString, {
     sourceCodeLocationInfo: true,
   });
 
@@ -702,7 +711,7 @@ function* renderTemplateResult(
   // previous span of HTML.
 
   const hydratable = isHydratable(result);
-  const ops = getTemplateOpcodes(result, !hydratable);
+  const ops = getTemplateOpcodes(result);
 
   /* The next value in result.values to render */
   let partIndex = 0;

--- a/packages/labs/ssr/src/test/lib/render-lit_test.ts
+++ b/packages/labs/ssr/src/test/lib/render-lit_test.ts
@@ -666,6 +666,7 @@ for (const global of [emptyVmGlobal, shimmedVmGlobal]) {
   });
 
   test('server-only document templates compose', async () => {
+    console.log('\n\nTEMPLATES COMPOSE TEST START\n\n');
     const {render, serverOnlyDocumentTemplatesCompose} = await setup();
     const result = await render(serverOnlyDocumentTemplatesCompose);
     assert.is(
@@ -683,6 +684,13 @@ for (const global of [emptyVmGlobal, shimmedVmGlobal]) {
 </html>
 `
     );
+  });
+
+  // Regression test for https://github.com/lit/lit/issues/4513
+  test('server-only table templates can contain attribute bindings', async () => {
+    const {render, serverOnlyTdTag} = await setup();
+    const result = await render(serverOnlyTdTag);
+    assert.is(result, `<td colspan="2">Table content</td>`);
   });
 
   test('server-only template throws on property bindings', async () => {

--- a/packages/labs/ssr/src/test/test-files/render-test-module.ts
+++ b/packages/labs/ssr/src/test/test-files/render-test-module.ts
@@ -340,6 +340,8 @@ ${serverhtml`<html lang="${'ko'}">
 </html>`}
 `;
 
+export const serverOnlyTdTag = serverhtml`<td colspan=${2}>${'Table content'}</td>`;
+
 export const serverOnlyArray = serverhtml`<div>${[
   'one',
   'two',


### PR DESCRIPTION
Fixes: https://github.com/lit/lit/issues/4513

### Context

Using `parse` from parse5 everywhere for server templates is not ideal, and unfortunately has consequences for some cases such as the issue template containing a top level `td` element. Parsing this as a page level HTML causes the element to be removed (which matches browser behavior). However, we instead want to treat this case as a fragment.

### Fix

This is a possible fix. I'm not super stoked about it but it does improve the situation.

Basically, there are 3 tags that I could find that `parseFragment` will not handle as a top-level element: `html`, `head`, and `body`.
Thus, detect those cases and only use `parse` if one of these top-level tags is detected. Otherwise use `parseFragment`.

### Test plan

Added a regression test for the template flagged in the issue.

### Risk

There's technically some other edge cases that can fall out of this. For example, the following template will not work correctly due to the HTML comment throwing off the regex:

```js
html`<!-- My nifty comment --><head>...</head>`
```

This might be acceptable as the situation has been improved by this PR.