### PR TITLE
[lit-html] Add DEV_MODE error if duplicate attribute bindings are encountered

### DIFF
--- a/.changeset/forty-schools-flash.md
+++ b/.changeset/forty-schools-flash.md
@@ -1,5 +1,6 @@
 ---
 'lit-html': patch
+'lit': patch
 ---
 
 Add a DEV_MODE error to catch duplicate attribute bindings that otherwise create silent errors.

--- a/.changeset/forty-schools-flash.md
+++ b/.changeset/forty-schools-flash.md
@@ -1,0 +1,5 @@
+---
+'lit-html': patch
+---
+
+Add a DEV_MODE error to catch duplicate attribute bindings that otherwise create silent errors.

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -1041,7 +1041,9 @@ class Template {
       // If there was a duplicate attribute on a tag, then when the tag is
       // parsed into an element the attribute gets de-duplicated. We can detect
       // this mismatch if we haven't precisely consumed every attribute name
-      // when preparing the template. This works because `attrNames` is built from the template string and `attrNameIndex` comes from processing the resulting DOM.
+      // when preparing the template. This works because `attrNames` is built
+      // from the template string and `attrNameIndex` comes from processing the
+      // resulting DOM.
       if (attrNames.length !== attrNameIndex) {
         throw new Error(
           `Detected duplicate attribute bindings. This occurs if your template ` +

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -1045,7 +1045,7 @@ class Template {
       if (attrNames.length !== attrNameIndex) {
         throw new Error(
           `Detected duplicate attribute bindings. This occurs if your template ` +
-            `has the dupliate attributes on an element tag. For example ` +
+            `has duplicate attributes on an element tag. For example ` +
             `"<input ?disabled=\${true} ?disabled=\${false}>" contains a ` +
             `duplicate "disabled" attribute. The error was detected in ` +
             `the following template: \n` +

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -1041,7 +1041,7 @@ class Template {
       // If there was a duplicate attribute on a tag, then when the tag is
       // parsed into an element the attribute gets de-duplicated. We can detect
       // this mismatch if we haven't precisely consumed every attribute name
-      // when preparing the template.
+      // when preparing the template. This works because `attrNames` is built from the template string and `attrNameIndex` comes from processing the resulting DOM.
       if (attrNames.length !== attrNameIndex) {
         throw new Error(
           `Detected duplicate attribute bindings. This occurs if your template ` +

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -925,6 +925,29 @@ class Template {
 
     // Create template element
     const [html, attrNames] = getTemplateHtml(strings, type);
+    if (DEV_MODE) {
+      let attrSet;
+      if ((attrSet = new Set(attrNames)).size !== attrNames.length) {
+        // Report all duplicated attributes. This is linear time, but is only
+        // done in DEV_MODE when an error is expected.
+        const duplicatedAttributes = new Set<string>();
+        for (const attrName of attrNames) {
+          if (!attrSet.has(attrName)) {
+            continue;
+          }
+          duplicatedAttributes.add(attrName);
+        }
+        throw new Error(
+          `Detected duplicate attribute ` +
+            `bindings of attribute${
+              duplicatedAttributes.size > 1 ? 's' : ''
+            }: '${[...duplicatedAttributes].join(', ')}', in the template: ` +
+            '`' +
+            strings.join('${...}') +
+            '`'
+        );
+      }
+    }
     this.el = Template.createElement(html, options);
     walker.currentNode = this.el.content;
 

--- a/packages/lit-html/src/test/lit-html_test.ts
+++ b/packages/lit-html/src/test/lit-html_test.ts
@@ -2193,6 +2193,12 @@ suite('lit-html', () => {
         );
       });
 
+      test('Duplicate attributes throw', () => {
+        assert.throws(() => {
+          render(html`<input ?disabled=${true} ?disabled=${false}>`, container);
+        }, `Detected duplicate attribute bindings of attribute: '?disabled', in the template: \`<input ?disabled=\${...} ?disabled=\${...}>\``);
+      });
+
       test('Expressions inside nested templates throw in dev mode', () => {
         // top level
         assert.throws(() => {

--- a/packages/lit-html/src/test/lit-html_test.ts
+++ b/packages/lit-html/src/test/lit-html_test.ts
@@ -2195,8 +2195,20 @@ suite('lit-html', () => {
 
       test('Duplicate attributes throw', () => {
         assert.throws(() => {
-          render(html`<input ?disabled=${true} ?disabled=${false}>`, container);
-        }, `Detected duplicate attribute bindings of attribute: '?disabled', in the template: \`<input ?disabled=\${...} ?disabled=\${...}>\``);
+          render(
+            html`<input ?disabled=${true} ?disabled=${false} fooAttribute=${'potato'}>`,
+            container
+          );
+        }, `Detected duplicate attribute bindings. This occurs if your template has the dupliate attributes on an element tag. For example "<input ?disabled=\${true} ?disabled=\${false}>" contains a duplicate "disabled" attribute. The error was detected in the following template: \n\`<input ?disabled=\${...} ?disabled=\${...} fooAttribute=\${...}>\``);
+      });
+
+      test('Matching attribute bindings across elements should not throw', () => {
+        assert.doesNotThrow(() => {
+          render(
+            html`<input ?disabled=${true}><input ?disabled=${false}>`,
+            container
+          );
+        });
       });
 
       test('Expressions inside nested templates throw in dev mode', () => {

--- a/packages/lit-html/src/test/lit-html_test.ts
+++ b/packages/lit-html/src/test/lit-html_test.ts
@@ -2193,7 +2193,7 @@ suite('lit-html', () => {
         );
       });
 
-      test('Duplicate attributes throw', () => {
+      skipTestIfCompiled('Duplicate attributes throw', () => {
         assert.throws(() => {
           render(
             html`<input ?disabled=${true} ?disabled=${false} fooAttribute=${'potato'}>`,

--- a/packages/lit-html/src/test/lit-html_test.ts
+++ b/packages/lit-html/src/test/lit-html_test.ts
@@ -2199,7 +2199,7 @@ suite('lit-html', () => {
             html`<input ?disabled=${true} ?disabled=${false} fooAttribute=${'potato'}>`,
             container
           );
-        }, `Detected duplicate attribute bindings. This occurs if your template has the dupliate attributes on an element tag. For example "<input ?disabled=\${true} ?disabled=\${false}>" contains a duplicate "disabled" attribute. The error was detected in the following template: \n\`<input ?disabled=\${...} ?disabled=\${...} fooAttribute=\${...}>\``);
+        }, `Detected duplicate attribute bindings. This occurs if your template has duplicate attributes on an element tag. For example "<input ?disabled=\${true} ?disabled=\${false}>" contains a duplicate "disabled" attribute. The error was detected in the following template: \n\`<input ?disabled=\${...} ?disabled=\${...} fooAttribute=\${...}>\``);
       });
 
       test('Matching attribute bindings across elements should not throw', () => {


### PR DESCRIPTION
Fixes: https://github.com/lit/lit/issues/4194

### Context

A lot of the context is in the issue, but in short, if an attribute binding is duplicated, such as in the following example:

```html
<textarea 
      ?disabled=${this.disabled} 
      ?disabled=${this.disabled} 
      placeholder=${this.placeholder}
></textarea>
```

The result is that Lit parts get out of sync with the values (because attributes are de-duped by the browser).

### Fix

I've implemented this as a DEV_MODE error, but I'm open to making it a DEV_MODE warning.

The following template: `<input ?disabled=${true} ?disabled=${false}>`, will throw:

```
Detected duplicate attribute bindings of attribute: '?disabled', in the template: `<input ?disabled=${...} ?disabled=${...}>`
```