### PR TITLE
[labs/ssr] fix patching of patched directives memory leak

### DIFF
--- a/.changeset/shy-wasps-begin.md
+++ b/.changeset/shy-wasps-begin.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/ssr': patch
+---
+
+Fix a memory leak when patching directive constructors for SSR.

--- a/packages/labs/ssr/src/lib/render-value.ts
+++ b/packages/labs/ssr/src/lib/render-value.ts
@@ -95,6 +95,10 @@ const patchIfDirective = (value: unknown) => {
         }
       );
       patchedDirectiveCache.set(directiveCtor, patchedCtor);
+      // If `patchIfDirective` is called with a previously patched directive,
+      // the patched directive will become patched again unless it's also a key
+      // in the WeakMap. This line prevents a memory leak.
+      patchedDirectiveCache.set(patchedCtor, patchedCtor);
     }
     // This property needs to remain unminified.
     setDirectiveClass(value as DirectiveResult, patchedCtor);


### PR DESCRIPTION
### Context

This has been split out of https://github.com/lit/lit/pull/4515 which explored a performant and more optimal fix. However, this revealed some possible other issues, e.g. https://github.com/lit/lit/issues/4527.

This change is a super tiny incremental fix which resolves the leak, and leaves the door open for future improvements.

### How does this resolve the leak?

The leak occurs due to directive constructors being re-used. However on re-use, the constructor is patched and isn't in the key of the `WeakMap`. The leak is then caused by patching the directive by applying another patch mixin. This occurs over and over. Because each patched directive extends the prior patched directive, they can never be cleaned up and on each SSR render you end up with directives being extended an additional time.

By adding the patched directive into the key, when the patched directive is encountered, we no longer patch it again. Thus fixing the leak.

### Test plan

This was manually tested with https://github.com/lit/lit/pull/4514

### Risk

The risk of this is tiny since the change is laser focused, and results in a patch bump to only SSR (Whilst the solution explored in https://github.com/lit/lit/pull/4515 requires `lit-html` to be bumped).

Credit to @augustjk for this much simpler fix that my initial branding of the patched directive.