### PR TITLE
[localize] Make placeholder validation pass with different expressions

### DIFF
--- a/.changeset/mighty-cars-confess.md
+++ b/.changeset/mighty-cars-confess.md
@@ -1,0 +1,5 @@
+---
+'@lit/localize-tools': patch
+---
+
+Translated message validation that runs before the `build` step now disregards template literal expressions. This allow source code to have variables in expressions renamed while still keeping the same translations, or avoid errors that could happen from module import order changing which expression gets picked up first when multiple `msg()` calls with the same id have different expressions. This behavior is more consistent with how a translation unit is identified according to [how the message id is generated](https://lit.dev/docs/localization/overview/#id-generation).

--- a/packages/localize-tools/src/tests/e2e/placeholder-errors.test.ts
+++ b/packages/localize-tools/src/tests/e2e/placeholder-errors.test.ts
@@ -12,8 +12,8 @@ e2eGoldensTest(
   1,
   `One or more localized templates contain a set of placeholders (HTML or template literal expressions) that do not exactly match the source code, aborting. Details:
 
-Placeholder error in es-419 localization of extra-expression: unexpected "\${expr}"
-Placeholder error in es-419 localization of missing-expression: missing "\${expr}"
+Placeholder error in es-419 localization of extra-expression: unexpected "\${alert("evil")}"
+Placeholder error in es-419 localization of missing-expression: missing "\${name}"
 Placeholder error in es-419 localization of missing-html: missing "<b>"
 Placeholder error in es-419 localization of missing-html: missing "</b>"
 Placeholder error in es-419 localization of changed-html: unexpected "<blink>"

--- a/packages/localize-tools/src/tests/e2e/placeholder-errors.test.ts
+++ b/packages/localize-tools/src/tests/e2e/placeholder-errors.test.ts
@@ -12,10 +12,8 @@ e2eGoldensTest(
   1,
   `One or more localized templates contain a set of placeholders (HTML or template literal expressions) that do not exactly match the source code, aborting. Details:
 
-Placeholder error in es-419 localization of extra-expression: unexpected "\${alert("evil")}"
-Placeholder error in es-419 localization of missing-expression: missing "\${name}"
-Placeholder error in es-419 localization of changed-expression: unexpected "\${alert("evil") || name}"
-Placeholder error in es-419 localization of changed-expression: missing "\${name}"
+Placeholder error in es-419 localization of extra-expression: unexpected "\${expr}"
+Placeholder error in es-419 localization of missing-expression: missing "\${expr}"
 Placeholder error in es-419 localization of missing-html: missing "<b>"
 Placeholder error in es-419 localization of missing-html: missing "</b>"
 Placeholder error in es-419 localization of changed-html: unexpected "<blink>"

--- a/packages/localize-tools/testdata/build-runtime-xliff-ph/goldens/foo.ts
+++ b/packages/localize-tools/testdata/build-runtime-xliff-ph/goldens/foo.ts
@@ -58,3 +58,7 @@ msg(html`<b>Hello</b>! Click <a href="${urlBase}/${urlPath}">here</a>!`);
 
 // Escaped markup characters should remain escaped
 msg(html`&lt;Hello<b>&lt;World &amp; Friends&gt;</b>!&gt;`);
+
+// Placeholder in translation has different expression
+msg(str`Different ${user}`);
+msg(html`Different <b>${user}</b>`);

--- a/packages/localize-tools/testdata/build-runtime-xliff-ph/goldens/tsout/es-419.ts
+++ b/packages/localize-tools/testdata/build-runtime-xliff-ph/goldens/tsout/es-419.ts
@@ -11,6 +11,7 @@ export const templates = {
   h02c268d9b1fcb031: html`&lt;Hola<b>&lt;Mundo &amp; Amigos&gt;</b>!&gt;`,
   h349c3c4777670217: html`[SALT] Hola <b>${0}</b>!`,
   h3c44aff2d5f5ef6b: html`Hola <b>Mundo</b>!`,
+  h5e2d21ff71e6c8b5: html`<b>${0}</b> diferente`,
   h82ccc38d4d46eaa9: html`Hola <b>${0}</b>!`,
   h8d70dfec810d1eae: html`<b>Hola</b>! Clic <a href="${0}/${1}">aquí</a>!`,
   h99e74f744fda7e25: html`Clic <a href="${0}">aquí</a>!`,
@@ -21,5 +22,6 @@ export const templates = {
   s00ad08ebae1e0f74: str`Hola ${0}!`,
   s03c68d79ad36e8d4: `described 0`,
   s0f19e6c4e521dd53: `Mundo`,
+  s372f95c2b25986c8: str`${0} diferente`,
   s8c0ec8d1fb9e6e32: `Hola Mundo!`,
 };

--- a/packages/localize-tools/testdata/build-runtime-xliff-ph/goldens/tsout/zh_CN.ts
+++ b/packages/localize-tools/testdata/build-runtime-xliff-ph/goldens/tsout/zh_CN.ts
@@ -22,4 +22,6 @@ export const templates = {
   s03c68d79ad36e8d4: `described 0`,
   h8d70dfec810d1eae: html`<b>Hello</b>! Click <a href="${0}/${1}">here</a>!`,
   h02c268d9b1fcb031: html`&lt;Hello<b>&lt;World &amp; Friends&gt;</b>!&gt;`,
+  s372f95c2b25986c8: str`Different ${0}`,
+  h5e2d21ff71e6c8b5: html`Different <b>${0}</b>`,
 };

--- a/packages/localize-tools/testdata/build-runtime-xliff-ph/goldens/xliff/es-419.xlf
+++ b/packages/localize-tools/testdata/build-runtime-xliff-ph/goldens/xliff/es-419.xlf
@@ -59,6 +59,14 @@
   <source>&lt;Hello<ph id="0">&lt;b></ph>&lt;World &amp; Friends><ph id="1">&lt;/b></ph>!></source>
   <target>&lt;Hola<ph id="0">&lt;b></ph>&lt;Mundo &amp; Amigos><ph id="1">&lt;/b></ph>!></target>
 </trans-unit>
+<trans-unit id="s372f95c2b25986c8">
+  <source>Different <ph id="0">${user}</ph></source>
+  <target><ph id="0">${differentUser}</ph> diferente</target>
+</trans-unit>
+<trans-unit id="h5e2d21ff71e6c8b5">
+  <source>Different <ph id="0">&lt;b&gt;${user}&lt;/b&gt;</ph></source>
+  <target><ph id="0">&lt;b&gt;${differentUser}&lt;/b&gt;</ph> diferente</target>
+</trans-unit>
 </body>
 </file>
 </xliff>

--- a/packages/localize-tools/testdata/build-runtime-xliff-ph/input/foo.ts
+++ b/packages/localize-tools/testdata/build-runtime-xliff-ph/input/foo.ts
@@ -58,3 +58,7 @@ msg(html`<b>Hello</b>! Click <a href="${urlBase}/${urlPath}">here</a>!`);
 
 // Escaped markup characters should remain escaped
 msg(html`&lt;Hello<b>&lt;World &amp; Friends&gt;</b>!&gt;`);
+
+// Placeholder in translation has different expression
+msg(str`Different ${user}`);
+msg(html`Different <b>${user}</b>`);

--- a/packages/localize-tools/testdata/build-runtime-xliff-ph/input/xliff/es-419.xlf
+++ b/packages/localize-tools/testdata/build-runtime-xliff-ph/input/xliff/es-419.xlf
@@ -59,6 +59,14 @@
   <source>&lt;Hello<ph id="0">&lt;b></ph>&lt;World &amp; Friends><ph id="1">&lt;/b></ph>!></source>
   <target>&lt;Hola<ph id="0">&lt;b></ph>&lt;Mundo &amp; Amigos><ph id="1">&lt;/b></ph>!></target>
 </trans-unit>
+<trans-unit id="s372f95c2b25986c8">
+  <source>Different <ph id="0">${user}</ph></source>
+  <target><ph id="0">${differentUser}</ph> diferente</target>
+</trans-unit>
+<trans-unit id="h5e2d21ff71e6c8b5">
+  <source>Different <ph id="0">&lt;b&gt;${user}&lt;/b&gt;</ph></source>
+  <target><ph id="0">&lt;b&gt;${differentUser}&lt;/b&gt;</ph> diferente</target>
+</trans-unit>
 </body>
 </file>
 </xliff>

--- a/packages/localize-tools/testdata/build-runtime-xliff/goldens/foo.ts
+++ b/packages/localize-tools/testdata/build-runtime-xliff/goldens/foo.ts
@@ -58,3 +58,7 @@ msg(html`<b>Hello</b>! Click <a href="${urlBase}/${urlPath}">here</a>!`);
 
 // Escaped markup characters should remain escaped
 msg(html`&lt;Hello<b>&lt;World &amp; Friends&gt;</b>!&gt;`);
+
+// Placeholder in translation has different expression
+msg(str`Different ${user}`);
+msg(html`Different <b>${user}</b>`);

--- a/packages/localize-tools/testdata/build-runtime-xliff/goldens/tsout/es-419.ts
+++ b/packages/localize-tools/testdata/build-runtime-xliff/goldens/tsout/es-419.ts
@@ -11,6 +11,7 @@ export const templates = {
   h02c268d9b1fcb031: html`&lt;Hola<b>&lt;Mundo &amp; Amigos&gt;</b>!&gt;`,
   h349c3c4777670217: html`[SALT] Hola <b>${0}</b>!`,
   h3c44aff2d5f5ef6b: html`Hola <b>Mundo</b>!`,
+  h5e2d21ff71e6c8b5: html`<b>${0}</b> diferente`,
   h82ccc38d4d46eaa9: html`Hola <b>${0}</b>!`,
   h8d70dfec810d1eae: html`<b>Hola</b>! Clic <a href="${0}/${1}">aquí</a>!`,
   h99e74f744fda7e25: html`Clic <a href="${0}">aquí</a>!`,
@@ -21,5 +22,6 @@ export const templates = {
   s00ad08ebae1e0f74: str`Hola ${0}!`,
   s03c68d79ad36e8d4: `described 0`,
   s0f19e6c4e521dd53: `Mundo`,
+  s372f95c2b25986c8: str`${0} diferente`,
   s8c0ec8d1fb9e6e32: `Hola Mundo!`,
 };

--- a/packages/localize-tools/testdata/build-runtime-xliff/goldens/tsout/zh_CN.ts
+++ b/packages/localize-tools/testdata/build-runtime-xliff/goldens/tsout/zh_CN.ts
@@ -22,4 +22,6 @@ export const templates = {
   s03c68d79ad36e8d4: `described 0`,
   h8d70dfec810d1eae: html`<b>Hello</b>! Click <a href="${0}/${1}">here</a>!`,
   h02c268d9b1fcb031: html`&lt;Hello<b>&lt;World &amp; Friends&gt;</b>!&gt;`,
+  s372f95c2b25986c8: str`Different ${0}`,
+  h5e2d21ff71e6c8b5: html`Different <b>${0}</b>`,
 };

--- a/packages/localize-tools/testdata/build-runtime-xliff/goldens/xliff/es-419.xlf
+++ b/packages/localize-tools/testdata/build-runtime-xliff/goldens/xliff/es-419.xlf
@@ -59,6 +59,14 @@
   <source>described 0</source>
   <target>described 0</target>
 </trans-unit>
+<trans-unit id="s372f95c2b25986c8">
+  <source>Different <x id="0" equiv-text="${user}"/></source>
+  <target><x id="0" equiv-text="${differentUser}"/> diferente</target>
+</trans-unit>
+<trans-unit id="h5e2d21ff71e6c8b5">
+  <source>Different <x id="0" equiv-text="&lt;b&gt;${user}&lt;/b&gt;"/></source>
+  <target><x id="0" equiv-text="&lt;b&gt;${differentUser}&lt;/b&gt;"/> diferente</target>
+</trans-unit>
 </body>
 </file>
 </xliff>

--- a/packages/localize-tools/testdata/build-runtime-xliff/goldens/xliff/zh_CN.xlf
+++ b/packages/localize-tools/testdata/build-runtime-xliff/goldens/xliff/zh_CN.xlf
@@ -47,6 +47,12 @@
   <note>Description of 0</note>
   <source>described 0</source>
 </trans-unit>
+<trans-unit id="s372f95c2b25986c8">
+  <source>Different <x id="0" equiv-text="${user}"/></source>
+</trans-unit>
+<trans-unit id="h5e2d21ff71e6c8b5">
+  <source>Different <x id="0" equiv-text="&lt;b&gt;${user}&lt;/b&gt;"/></source>
+</trans-unit>
 </body>
 </file>
 </xliff>

--- a/packages/localize-tools/testdata/build-runtime-xliff/input/foo.ts
+++ b/packages/localize-tools/testdata/build-runtime-xliff/input/foo.ts
@@ -58,3 +58,7 @@ msg(html`<b>Hello</b>! Click <a href="${urlBase}/${urlPath}">here</a>!`);
 
 // Escaped markup characters should remain escaped
 msg(html`&lt;Hello<b>&lt;World &amp; Friends&gt;</b>!&gt;`);
+
+// Placeholder in translation has different expression
+msg(str`Different ${user}`);
+msg(html`Different <b>${user}</b>`);

--- a/packages/localize-tools/testdata/build-runtime-xliff/input/xliff/es-419.xlf
+++ b/packages/localize-tools/testdata/build-runtime-xliff/input/xliff/es-419.xlf
@@ -59,6 +59,14 @@
   <source>described 0</source>
   <target>described 0</target>
 </trans-unit>
+<trans-unit id="s372f95c2b25986c8">
+  <source>Different <x id="0" equiv-text="${user}"/></source>
+  <target><x id="0" equiv-text="${differentUser}"/> diferente</target>
+</trans-unit>
+<trans-unit id="h5e2d21ff71e6c8b5">
+  <source>Different <x id="0" equiv-text="&lt;b&gt;${user}&lt;/b&gt;"/></source>
+  <target><x id="0" equiv-text="&lt;b&gt;${differentUser}&lt;/b&gt;"/> diferente</target>
+</trans-unit>
 </body>
 </file>
 </xliff>

--- a/packages/localize-tools/testdata/build-runtime-xliff/input/xliff/zh_CN.xlf
+++ b/packages/localize-tools/testdata/build-runtime-xliff/input/xliff/zh_CN.xlf
@@ -47,6 +47,12 @@
   <note>Description of 0</note>
   <source>described 0</source>
 </trans-unit>
+<trans-unit id="s372f95c2b25986c8">
+  <source>Different <x id="0" equiv-text="${user}"/></source>
+</trans-unit>
+<trans-unit id="h5e2d21ff71e6c8b5">
+  <source>Different <x id="0" equiv-text="&lt;b&gt;${user}&lt;/b&gt;"/></source>
+</trans-unit>
 </body>
 </file>
 </xliff>

--- a/packages/localize-tools/testdata/build-transform-xliff/goldens/foo.ts
+++ b/packages/localize-tools/testdata/build-transform-xliff/goldens/foo.ts
@@ -86,3 +86,7 @@ html`Hello <b foo=${msg('World')}>World</b>`;
 html`<b foo=${msg('Hello')}>Hello</b><b bar=${msg('World')}>World</b>`;
 html`Hello <b .foo=${'World'}>World</b>`;
 html`Hello <b .foo=${msg('World')}>World</b>`;
+
+// Placeholder in translation has different expression
+msg(str`Different ${user}`);
+msg(html`Different <b>${user}</b>`);

--- a/packages/localize-tools/testdata/build-transform-xliff/goldens/tsout/en/foo.js
+++ b/packages/localize-tools/testdata/build-transform-xliff/goldens/tsout/en/foo.js
@@ -60,3 +60,6 @@ html`Hello <b foo=${'World'}>World</b>`;
 html`<b foo=${'Hello'}>Hello</b><b bar=${'World'}>World</b>`;
 html`Hello <b .foo=${'World'}>World</b>`;
 html`Hello <b .foo=${'World'}>World</b>`;
+// Placeholder in translation has different expression
+`Different ${user}`;
+html`Different <b>${user}</b>`;

--- a/packages/localize-tools/testdata/build-transform-xliff/goldens/tsout/es-419/foo.js
+++ b/packages/localize-tools/testdata/build-transform-xliff/goldens/tsout/es-419/foo.js
@@ -57,6 +57,9 @@ html`&lt;Hola<b>&lt;Mundo &amp; Amigos&gt;</b>!&gt;`;
 // Expressions as attribute values should stay as expressions
 html`Hello <b foo=${'World'}>World</b>`;
 html`Hello <b foo=${`Mundo`}>World</b>`;
-html`<b foo=${'Hello'}>Hello</b><b bar=${`Mundo`}>World</b>`;
+html`<b foo=${`Hola`}>Hello</b><b bar=${`Mundo`}>World</b>`;
 html`Hello <b .foo=${'World'}>World</b>`;
 html`Hello <b .foo=${`Mundo`}>World</b>`;
+// Placeholder in translation has different expression
+`${user} diferente`;
+html`<b>${user}</b> diferente`;

--- a/packages/localize-tools/testdata/build-transform-xliff/goldens/tsout/zh_CN/foo.js
+++ b/packages/localize-tools/testdata/build-transform-xliff/goldens/tsout/zh_CN/foo.js
@@ -60,3 +60,6 @@ html`Hello <b foo=${'World'}>World</b>`;
 html`<b foo=${'Hello'}>Hello</b><b bar=${'World'}>World</b>`;
 html`Hello <b .foo=${'World'}>World</b>`;
 html`Hello <b .foo=${'World'}>World</b>`;
+// Placeholder in translation has different expression
+`Different ${user}`;
+html`Different <b>${user}</b>`;

--- a/packages/localize-tools/testdata/build-transform-xliff/goldens/xliff/es-419.xlf
+++ b/packages/localize-tools/testdata/build-transform-xliff/goldens/xliff/es-419.xlf
@@ -46,6 +46,18 @@
   <source>&lt;Hello<ph id="0">&lt;b></ph>&lt;World &amp; Friends><ph id="1">&lt;/b></ph>!></source>
   <target>&lt;Hola<ph id="0">&lt;b></ph>&lt;Mundo &amp; Amigos><ph id="1">&lt;/b></ph>!></target>
 </trans-unit>
+<trans-unit id="s63f0bfacf2c00f6b">
+  <source>Hello</source>
+  <target>Hola</target>
+</trans-unit>
+<trans-unit id="s372f95c2b25986c8">
+  <source>Different <ph id="0">${user}</ph></source>
+  <target><ph id="0">${differentUser}</ph> diferente</target>
+</trans-unit>
+<trans-unit id="h5e2d21ff71e6c8b5">
+  <source>Different <ph id="0">&lt;b&gt;${user}&lt;/b&gt;</ph></source>
+  <target><ph id="0">&lt;b&gt;${differentUser}&lt;/b&gt;</ph> diferente</target>
+</trans-unit>
 </body>
 </file>
 </xliff>

--- a/packages/localize-tools/testdata/build-transform-xliff/input/foo.ts
+++ b/packages/localize-tools/testdata/build-transform-xliff/input/foo.ts
@@ -86,3 +86,7 @@ html`Hello <b foo=${msg("World")}>World</b>`;
 html`<b foo=${msg("Hello")}>Hello</b><b bar=${msg("World")}>World</b>`;
 html`Hello <b .foo=${"World"}>World</b>`;
 html`Hello <b .foo=${msg("World")}>World</b>`;
+
+// Placeholder in translation has different expression
+msg(str`Different ${user}`);
+msg(html`Different <b>${user}</b>`);

--- a/packages/localize-tools/testdata/build-transform-xliff/input/xliff/es-419.xlf
+++ b/packages/localize-tools/testdata/build-transform-xliff/input/xliff/es-419.xlf
@@ -46,6 +46,18 @@
   <source>&lt;Hello<ph id="0">&lt;b></ph>&lt;World &amp; Friends><ph id="1">&lt;/b></ph>!></source>
   <target>&lt;Hola<ph id="0">&lt;b></ph>&lt;Mundo &amp; Amigos><ph id="1">&lt;/b></ph>!></target>
 </trans-unit>
+<trans-unit id="s63f0bfacf2c00f6b">
+  <source>Hello</source>
+  <target>Hola</target>
+</trans-unit>
+<trans-unit id="s372f95c2b25986c8">
+  <source>Different <ph id="0">${user}</ph></source>
+  <target><ph id="0">${differentUser}</ph> diferente</target>
+</trans-unit>
+<trans-unit id="h5e2d21ff71e6c8b5">
+  <source>Different <ph id="0">&lt;b&gt;${user}&lt;/b&gt;</ph></source>
+  <target><ph id="0">&lt;b&gt;${differentUser}&lt;/b&gt;</ph> diferente</target>
+</trans-unit>
 </body>
 </file>
 </xliff>

--- a/packages/localize-tools/testdata/placeholder-errors/goldens/foo.ts
+++ b/packages/localize-tools/testdata/placeholder-errors/goldens/foo.ts
@@ -11,6 +11,8 @@ const name = 'Friend';
 
 msg(`Hello World`, {id: 'extra-expression'});
 msg(str`Hello ${name}`, {id: 'missing-expression'});
+// Changed expression used to be considered errors but no longer are
+// See https://github.com/lit/lit/issues/4502
 msg(str`Hello ${name}`, {id: 'changed-expression'});
 msg(html`<b>Hello World</b>`, {id: 'missing-html'});
 msg(html`<b>Hello World</b>`, {id: 'changed-html'});

--- a/packages/localize-tools/testdata/placeholder-errors/goldens/foo.ts
+++ b/packages/localize-tools/testdata/placeholder-errors/goldens/foo.ts
@@ -11,8 +11,5 @@ const name = 'Friend';
 
 msg(`Hello World`, {id: 'extra-expression'});
 msg(str`Hello ${name}`, {id: 'missing-expression'});
-// Changed expression used to be considered errors but no longer are
-// See https://github.com/lit/lit/issues/4502
-msg(str`Hello ${name}`, {id: 'changed-expression'});
 msg(html`<b>Hello World</b>`, {id: 'missing-html'});
 msg(html`<b>Hello World</b>`, {id: 'changed-html'});

--- a/packages/localize-tools/testdata/placeholder-errors/goldens/xliff/es-419.xlf
+++ b/packages/localize-tools/testdata/placeholder-errors/goldens/xliff/es-419.xlf
@@ -10,10 +10,6 @@
   <source>Hello <ph id="0">${name}</ph></source>
   <target>Hola Mundo</target>
 </trans-unit>
-<trans-unit id="changed-expression">
-  <source>Hello <ph id="0">${name}</ph></source>
-  <target>Hola <ph id="0">${alert("evil") || name}</ph></target>
-</trans-unit>
 <trans-unit id="missing-html">
   <source><ph id="0">&lt;b></ph>Hello World<ph id="1">&lt;/b></ph></source>
   <target>Hola Mundo</target>

--- a/packages/localize-tools/testdata/placeholder-errors/input/foo.ts
+++ b/packages/localize-tools/testdata/placeholder-errors/input/foo.ts
@@ -11,6 +11,8 @@ const name = 'Friend';
 
 msg(`Hello World`, {id: 'extra-expression'});
 msg(str`Hello ${name}`, {id: 'missing-expression'});
+// Changed expression used to be considered errors but no longer are
+// See https://github.com/lit/lit/issues/4502
 msg(str`Hello ${name}`, {id: 'changed-expression'});
 msg(html`<b>Hello World</b>`, {id: 'missing-html'});
 msg(html`<b>Hello World</b>`, {id: 'changed-html'});

--- a/packages/localize-tools/testdata/placeholder-errors/input/foo.ts
+++ b/packages/localize-tools/testdata/placeholder-errors/input/foo.ts
@@ -11,8 +11,5 @@ const name = 'Friend';
 
 msg(`Hello World`, {id: 'extra-expression'});
 msg(str`Hello ${name}`, {id: 'missing-expression'});
-// Changed expression used to be considered errors but no longer are
-// See https://github.com/lit/lit/issues/4502
-msg(str`Hello ${name}`, {id: 'changed-expression'});
 msg(html`<b>Hello World</b>`, {id: 'missing-html'});
 msg(html`<b>Hello World</b>`, {id: 'changed-html'});

--- a/packages/localize-tools/testdata/placeholder-errors/input/xliff/es-419.xlf
+++ b/packages/localize-tools/testdata/placeholder-errors/input/xliff/es-419.xlf
@@ -10,10 +10,6 @@
   <source>Hello <ph id="0">${name}</ph></source>
   <target>Hola Mundo</target>
 </trans-unit>
-<trans-unit id="changed-expression">
-  <source>Hello <ph id="0">${name}</ph></source>
-  <target>Hola <ph id="0">${alert("evil") || name}</ph></target>
-</trans-unit>
 <trans-unit id="missing-html">
   <source><ph id="0">&lt;b></ph>Hello World<ph id="1">&lt;/b></ph></source>
   <target>Hola Mundo</target>


### PR DESCRIPTION
Fixes https://github.com/lit/lit/issues/4502

## How it used to be before #2405
In the past, the expressions in the translated message placeholder were directly used in generating the output code in transform mode.

##### foo.ts (source)
```js
msg(str`Hello ${user}!`);
```

##### es-419.xlf (translation)
```xml
<trans-unit id="s00ad08ebae1e0f74">
  <source>Hello <x id="0" equiv-text="${user}"/>!</source>
  <target>Hola <x id="0" equiv-text="${user}"/>!</target>
</trans-unit>
```
used the actual `equiv-text="${user}"` value from `<target>` to generate

##### foo.js (output)
```js
`Hello ${user}!`;
```


This meant it was possible for faulty or malicious JS expression to be injected to the output if translation placeholders were modified.

##### es-419.xlf (translation)
```xml
<trans-unit id="s00ad08ebae1e0f74">
  <source>Hello <x id="0" equiv-text="${user}"/>!</source>
  <target>Hola <x id="0" equiv-text="${alert('evil') || user}"/>!</target>
</trans-unit>
```
could produce

##### foo.js (output)
```js
`Hola ${alert('evil') || user}!`;
```

Runtime mode never had this issue since expressions are replaced by numbers in the output anyway and swap them with values given during runtime.

##### es-419.ts (runtime mode output)

```js
export const templates = {
  s00ad08ebae1e0f74: str`Hola ${0}!`,
}
```

## After #2405 

https://github.com/lit/lit/pull/2405 made it so that multiple `msg()` calls with different expressions can map to the same translation unit.

##### foo.ts (source)
```js
msg(str`Hello ${user}!`);
msg(str`Hello ${username}!`);
```
resulted in a single translation unit.
##### es-419.xlf (translation)
```xml
<trans-unit id="s00ad08ebae1e0f74">
  <source>Hello <x id="0" equiv-text="${user}"/>!</source>
  <target>Hola <x id="0" equiv-text="${user}"/>!</target>
</trans-unit>
```
The value of `equiv-text` is based on which expression is encountered first.

As such, it also made it so that we never use the expression from translation directly instead always grab the expression from the source code so that we'll produce the appropriate output (both `${user}` and `${username}` in above example). **This means strict validation of expressions in placeholders are now unnecessary.**

However, there remained some validation logic that would check that expressions in placeholders exactly as they are in the source code. If the source code were modified or the order of the template encountered changes while placeholders in the translations are not updated, errors like the follow would show up during build, even though the translations are still perfectly valid to use.

```
Placeholder error in es-419 localization of s00ad08ebae1e0f74: unexpected "${username}"
Placeholder error in es-419 localization of s00ad08ebae1e0f74: missing "${user}"
```


## What this PR does

The validation logic is now updated to replace all expressions to `"expr"` before comparison so a different expression wouldn't cause it to fail. We still want to make sure the rest of the string matches since placeholders can also include HTML that won't be translated, and placeholders without expressions are still used in output generation for runtime mode.