### PR TITLE
[chore] Update typescript to 5.3.3

### DIFF
--- a/.changeset/light-moons-taste.md
+++ b/.changeset/light-moons-taste.md
@@ -1,0 +1,9 @@
+---
+'@lit/ts-transformers': patch
+'@lit/localize-tools': patch
+'@lit-labs/analyzer': patch
+'@lit-labs/compiler': patch
+'@lit-labs/cli': patch
+---
+
+Update typescript dependency

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -20,6 +20,6 @@
     "next": "^13.0.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "typescript": "~5.2.0"
+    "typescript": "~5.3.3"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "rollup-plugin-sourcemaps": "^0.6.2",
         "rollup-plugin-summary": "^1.4.3",
         "rollup-plugin-terser": "^7.0.2",
-        "typescript": "~5.2.0",
+        "typescript": "~5.3.3",
         "uvu": "^0.5.6",
         "wireit": "^0.14.0"
       },
@@ -71,7 +71,7 @@
         "next": "^13.0.6",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "typescript": "~5.2.0"
+        "typescript": "~5.3.3"
       }
     },
     "examples/nextjs/node_modules/@types/node": {
@@ -25092,8 +25092,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.2.2",
-      "license": "Apache-2.0",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -26781,7 +26782,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "package-json-type": "^1.0.3",
-        "typescript": "~5.2.0"
+        "typescript": "~5.3.3"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^25.0.7",
@@ -26900,7 +26901,7 @@
         "command-line-commands": "^3.0.2",
         "command-line-usage": "^6.1.1",
         "tslib": "^2.0.3",
-        "typescript": "~5.2.0"
+        "typescript": "~5.3.3"
       },
       "bin": {
         "lit": "bin/lit.js"
@@ -26923,7 +26924,7 @@
         "@lit/localize-tools": "^0.7.0"
       },
       "devDependencies": {
-        "typescript": "~5.2.0"
+        "typescript": "~5.3.3"
       },
       "engines": {
         "node": ">=14.8.0"
@@ -26947,7 +26948,7 @@
         "@parse5/tools": "^0.3.0",
         "lit-html": "^3.0.0",
         "parse5": "^7.1.2",
-        "typescript": "~5.2.0"
+        "typescript": "~5.3.3"
       },
       "devDependencies": {
         "@rollup/plugin-typescript": "11.1.2",
@@ -27241,18 +27242,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "packages/labs/eslint-plugin/node_modules/typescript": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "packages/labs/eslint-plugin/node_modules/yallist": {
@@ -28126,7 +28115,7 @@
         "lit": "^3.0.0"
       },
       "devDependencies": {
-        "typescript": "~5.2.0"
+        "typescript": "~5.3.3"
       }
     },
     "packages/labs/test-projects/test-elements-react": {
@@ -28166,19 +28155,6 @@
       "license": "BSD-3-Clause",
       "devDependencies": {
         "typescript": "^5.3.3"
-      }
-    },
-    "packages/labs/tsserver-plugin/node_modules/typescript": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "packages/labs/virtualizer": {
@@ -28311,7 +28287,7 @@
         "rollup": "^2.73.0",
         "rollup-plugin-summary": "^1.4.3",
         "rollup-plugin-terser": "^7.0.2",
-        "typescript": "~5.2.0"
+        "typescript": "~5.3.3"
       }
     },
     "packages/lit-starter-ts/node_modules/@types/semver": {
@@ -28563,7 +28539,7 @@
         "minimist": "^1.2.5",
         "parse5": "^7.1.1",
         "source-map-support": "^0.5.19",
-        "typescript": "~5.2.0"
+        "typescript": "~5.3.3"
       },
       "bin": {
         "lit-localize": "bin/lit-localize.js"
@@ -28659,7 +28635,7 @@
         "rollup": "^2.70.2",
         "rollup-plugin-summary": "^1.4.3",
         "rollup-plugin-terser": "^7.0.2",
-        "typescript": "~5.2.0"
+        "typescript": "~5.3.3"
       }
     },
     "packages/localize/examples/transform-ts": {
@@ -28677,7 +28653,7 @@
         "rollup": "^2.70.2",
         "rollup-plugin-summary": "^1.4.3",
         "rollup-plugin-terser": "^7.0.2",
-        "typescript": "~5.2.0"
+        "typescript": "~5.3.3"
       }
     },
     "packages/react": {
@@ -28749,7 +28725,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "ts-clone-node": "^3.0.0",
-        "typescript": "~5.2.0"
+        "typescript": "~5.3.3"
       },
       "devDependencies": {
         "@lit/localize": "^0.12.0",

--- a/package.json
+++ b/package.json
@@ -290,7 +290,7 @@
     "rollup-plugin-sourcemaps": "^0.6.2",
     "rollup-plugin-summary": "^1.4.3",
     "rollup-plugin-terser": "^7.0.2",
-    "typescript": "~5.2.0",
+    "typescript": "~5.3.3",
     "uvu": "^0.5.6",
     "wireit": "^0.14.0"
   },

--- a/packages/labs/analyzer/package.json
+++ b/packages/labs/analyzer/package.json
@@ -97,7 +97,7 @@
   },
   "dependencies": {
     "package-json-type": "^1.0.3",
-    "typescript": "~5.2.0"
+    "typescript": "~5.3.3"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^25.0.7",

--- a/packages/labs/cli-localize/package.json
+++ b/packages/labs/cli-localize/package.json
@@ -65,7 +65,7 @@
     "@lit/localize-tools": "^0.7.0"
   },
   "devDependencies": {
-    "typescript": "~5.2.0"
+    "typescript": "~5.3.3"
   },
   "engines": {
     "node": ">=14.8.0"

--- a/packages/labs/cli/package.json
+++ b/packages/labs/cli/package.json
@@ -87,7 +87,7 @@
     "command-line-commands": "^3.0.2",
     "command-line-usage": "^6.1.1",
     "tslib": "^2.0.3",
-    "typescript": "~5.2.0"
+    "typescript": "~5.3.3"
   },
   "devDependencies": {
     "@lit-internal/tests": "^0.0.1",

--- a/packages/labs/cli/src/lib/init/element-starter/templates/package.json.ts
+++ b/packages/labs/cli/src/lib/init/element-starter/templates/package.json.ts
@@ -42,7 +42,7 @@ export const generatePackageJson = (
       language !== 'ts'
         ? ''
         : `,
-    "typescript": "~5.2.0"`
+    "typescript": "~5.3.3"`
     }
   },
   "exports": {

--- a/packages/labs/cli/test-goldens/init/ts-named/package.json
+++ b/packages/labs/cli/test-goldens/init/ts-named/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@web/dev-server": "^0.1.32",
-    "typescript": "~5.2.0"
+    "typescript": "~5.3.3"
   },
   "exports": {
     "./lib/el-element.js": {

--- a/packages/labs/compiler/package.json
+++ b/packages/labs/compiler/package.json
@@ -105,7 +105,7 @@
     "@parse5/tools": "^0.3.0",
     "lit-html": "^3.0.0",
     "parse5": "^7.1.2",
-    "typescript": "~5.2.0"
+    "typescript": "~5.3.3"
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "11.1.2",

--- a/packages/labs/gen-wrapper-angular/goldens/test-element-a/package.json
+++ b/packages/labs/gen-wrapper-angular/goldens/test-element-a/package.json
@@ -14,7 +14,7 @@
     "@angular/core": "^13.3.0"
   },
   "devDependencies": {
-    "typescript": "~5.2.0"
+    "typescript": "~5.3.3"
   },
   "files": [
     "element-a.js",

--- a/packages/labs/gen-wrapper-react/goldens/test-element-a/package.json
+++ b/packages/labs/gen-wrapper-react/goldens/test-element-a/package.json
@@ -15,7 +15,7 @@
     "@types/react": "^17 || ^18"
   },
   "devDependencies": {
-    "typescript": "~5.2.0"
+    "typescript": "~5.3.3"
   },
   "files": [
     "element-a.{js,js.map,d.ts,d.ts.map}",

--- a/packages/labs/gen-wrapper-vue/goldens/test-element-a/package.json
+++ b/packages/labs/gen-wrapper-vue/goldens/test-element-a/package.json
@@ -15,7 +15,7 @@
     "@lit-labs/vue-utils": "^0.1.0"
   },
   "devDependencies": {
-    "typescript": "~5.2.0",
+    "typescript": "~5.3.3",
     "@vitejs/plugin-vue": "^3.1.2",
     "@rollup/plugin-typescript": "^9.0.1",
     "vite": "^3.1.8",

--- a/packages/labs/gen-wrapper-vue/test-output/package.json
+++ b/packages/labs/gen-wrapper-vue/test-output/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^2.3.1",
-    "typescript": "~5.2.0",
+    "typescript": "~5.3.3",
     "vite": "^2.9.2",
     "vue-tsc": "^1.8.8"
   },

--- a/packages/labs/test-projects/test-element-a/package.json
+++ b/packages/labs/test-projects/test-element-a/package.json
@@ -21,7 +21,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
-    "typescript": "~5.2.0"
+    "typescript": "~5.3.3"
   },
   "wireit": {
     "build": {

--- a/packages/lit-starter-ts/package.json
+++ b/packages/lit-starter-ts/package.json
@@ -64,7 +64,7 @@
     "rollup": "^2.73.0",
     "rollup-plugin-summary": "^1.4.3",
     "rollup-plugin-terser": "^7.0.2",
-    "typescript": "~5.2.0"
+    "typescript": "~5.3.3"
   },
   "customElements": "custom-elements.json"
 }

--- a/packages/localize-tools/package.json
+++ b/packages/localize-tools/package.json
@@ -140,7 +140,7 @@
     "minimist": "^1.2.5",
     "parse5": "^7.1.1",
     "source-map-support": "^0.5.19",
-    "typescript": "~5.2.0"
+    "typescript": "~5.3.3"
   },
   "devDependencies": {
     "@lit-internal/tests": "0.0.1",

--- a/packages/localize/examples/transform-js/package.json
+++ b/packages/localize/examples/transform-js/package.json
@@ -61,6 +61,6 @@
     "rollup": "^2.70.2",
     "rollup-plugin-summary": "^1.4.3",
     "rollup-plugin-terser": "^7.0.2",
-    "typescript": "~5.2.0"
+    "typescript": "~5.3.3"
   }
 }

--- a/packages/localize/examples/transform-ts/package.json
+++ b/packages/localize/examples/transform-ts/package.json
@@ -64,6 +64,6 @@
     "rollup": "^2.70.2",
     "rollup-plugin-summary": "^1.4.3",
     "rollup-plugin-terser": "^7.0.2",
-    "typescript": "~5.2.0"
+    "typescript": "~5.3.3"
   }
 }

--- a/packages/ts-transformers/package.json
+++ b/packages/ts-transformers/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "ts-clone-node": "^3.0.0",
-    "typescript": "~5.2.0"
+    "typescript": "~5.3.3"
   },
   "devDependencies": {
     "@lit/localize": "^0.12.0",


### PR DESCRIPTION
Seeing if we can update typescript with a smaller blast radius than https://github.com/lit/lit/pull/4520