### PR TITLE
[labs/ssr-dom-shim] Patch localName and tagName with customElements.define call

### DIFF
--- a/.changeset/lovely-suits-rescue.md
+++ b/.changeset/lovely-suits-rescue.md
@@ -1,0 +1,6 @@
+---
+'@lit-labs/ssr-dom-shim': patch
+---
+
+This change extends the CustomElementRegistryShim to patch localName and tagName into the web component, when calling define.
+This allows instances to call `this.localName` and `this.tagName` accordingly.

--- a/.changeset/lovely-suits-rescue.md
+++ b/.changeset/lovely-suits-rescue.md
@@ -2,5 +2,4 @@
 '@lit-labs/ssr-dom-shim': patch
 ---
 
-This change extends the CustomElementRegistryShim to patch localName and tagName into the web component, when calling define.
-This allows instances to call `this.localName` and `this.tagName` accordingly.
+Implement Element.localName and Element.tagName. Fixes [3375](https://github.com/lit/lit/issues/3375).

--- a/packages/labs/ssr-dom-shim/src/index.ts
+++ b/packages/labs/ssr-dom-shim/src/index.ts
@@ -148,6 +148,17 @@ const CustomElementRegistryShim = class CustomElementRegistry {
         );
       }
     }
+    // Polyfill tagName and localName for the component.
+    Object.defineProperties(ctor.prototype, {
+      localName: {
+        value: name,
+        writable: false,
+      },
+      tagName: {
+        value: name.toUpperCase(),
+        writable: false,
+      },
+    });
     this.__definitions.set(name, {
       ctor,
       // Note it's important we read `observedAttributes` in case it is a getter

--- a/packages/labs/ssr-dom-shim/src/test/element-shim_test.ts
+++ b/packages/labs/ssr-dom-shim/src/test/element-shim_test.ts
@@ -7,7 +7,7 @@
 import {suite} from 'uvu';
 // eslint-disable-next-line import/extensions
 import * as assert from 'uvu/assert';
-import {HTMLElement} from '@lit-labs/ssr-dom-shim';
+import {customElements, HTMLElement} from '@lit-labs/ssr-dom-shim';
 
 const test = suite('Element Shim');
 
@@ -43,6 +43,15 @@ test('setAttribute silently casts values to a string', () => {
   // silently convert it to a string.
   shimmedEl.setAttribute('tomato', {} as unknown as string);
   assert.equal(shimmedEl.getAttribute('tomato'), '[object Object]');
+});
+
+test('localName and tagName should be available', () => {
+  const elementName = 'lit-test';
+  customElements.define(elementName, class extends HTMLElement {});
+  const LitTest = customElements.get(elementName)!;
+  const shimmedEl = new LitTest();
+  assert.equal(shimmedEl.localName, elementName);
+  assert.equal(shimmedEl.tagName, elementName.toUpperCase());
 });
 
 test.run();

--- a/packages/labs/ssr-dom-shim/src/test/element-shim_test.ts
+++ b/packages/labs/ssr-dom-shim/src/test/element-shim_test.ts
@@ -45,13 +45,32 @@ test('setAttribute silently casts values to a string', () => {
   assert.equal(shimmedEl.getAttribute('tomato'), '[object Object]');
 });
 
-test('localName and tagName should be available', () => {
-  const elementName = 'lit-test';
+test('localName and tagName should be available with constructor from customElements registry', () => {
+  const elementName = 'lit-test-registry';
   customElements.define(elementName, class extends HTMLElement {});
-  const LitTest = customElements.get(elementName)!;
-  const shimmedEl = new LitTest();
+  const LitTestRegistry = customElements.get(elementName)!;
+
+  const shimmedEl = new LitTestRegistry();
   assert.equal(shimmedEl.localName, elementName);
   assert.equal(shimmedEl.tagName, elementName.toUpperCase());
+});
+
+test('localName and tagName should be available when registering with customElements', () => {
+  const elementName = 'lit-test-local';
+  class LitTestLocal extends HTMLElement {}
+  customElements.define(elementName, LitTestLocal);
+
+  const shimmedEl = new LitTestLocal();
+  assert.equal(shimmedEl.localName, elementName);
+  assert.equal(shimmedEl.tagName, elementName.toUpperCase());
+});
+
+test('localName and tagName usage should return undefined if not registered', () => {
+  class LitTestUnregistered extends HTMLElement {}
+
+  const shimmedEl = new LitTestUnregistered();
+  assert.equal(shimmedEl.localName, undefined);
+  assert.equal(shimmedEl.tagName, undefined);
 });
 
 test.run();


### PR DESCRIPTION
This change extends the CustomElementRegistryShim to patch localName and tagName into the web component, when calling define.
This allows instances to call `this.localName` and `this.tagName` accordingly.

Fixes #3375