### PR TITLE
Allow nonce to be provided in DOM node

### DIFF
--- a/packages/reactive-element/src/css-tag.ts
+++ b/packages/reactive-element/src/css-tag.ts
@@ -178,8 +178,12 @@ export const adoptStyles = (
   } else {
     for (const s of styles) {
       const style = document.createElement('style');
+      
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const nonce = (global as any)['litNonce'];
+      let nonce = (global as any)['litNonce'] 
+      || ((renderRoot as ShadowRoot)?.querySelector("style[nonce]") as HTMLStyleElement)?.nonce 
+      || ((renderRoot as ShadowRoot)?.querySelector("script[nonce]") as HTMLScriptElement)?.nonce;
+
       if (nonce !== undefined) {
         style.setAttribute('nonce', nonce);
       }


### PR DESCRIPTION
Allowing inline script execution is probably an even worse idea than inline styles. 
So to use a global script example like is probably not the nicest approach.
```html
<script>
 window.litNonce = 'abc123';
</script>
```

Suggest to support the nonce via a DOM element instead.
https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/nonce#accessing_nonces_and_nonce_hiding

This PR add the abbility to create a style or script tag with your nonce code and keeps the global litNonce as fallback. 
