### PR TITLE
[labs/router] New Router API! 🌟

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -324,6 +324,11 @@ packages/labs/router/lib/
 packages/labs/router/index.*
 packages/labs/router/router.*
 packages/labs/router/routes.*
+packages/labs/router/route.*
+packages/labs/router/lit-router.*
+packages/labs/router/declarations.*
+packages/labs/router/errors.*
+packages/labs/router/utils.*
 
 packages/labs/scoped-registry-mixin/development/
 packages/labs/scoped-registry-mixin/test/

--- a/.prettierignore
+++ b/.prettierignore
@@ -312,6 +312,11 @@ packages/labs/router/lib/
 packages/labs/router/index.*
 packages/labs/router/router.*
 packages/labs/router/routes.*
+packages/labs/router/route.*
+packages/labs/router/lit-router.*
+packages/labs/router/declarations.*
+packages/labs/router/errors.*
+packages/labs/router/utils.*
 
 packages/labs/scoped-registry-mixin/development/
 packages/labs/scoped-registry-mixin/test/

--- a/package-lock.json
+++ b/package-lock.json
@@ -27418,7 +27418,7 @@
     },
     "packages/labs/analyzer": {
       "name": "@lit-labs/analyzer",
-      "version": "0.11.1",
+      "version": "0.12.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "package-json-type": "^1.0.3",
@@ -27431,10 +27431,10 @@
     },
     "packages/labs/cli": {
       "name": "@lit-labs/cli",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/analyzer": "^0.11.0",
+        "@lit-labs/analyzer": "^0.12.0",
         "@lit-labs/gen-utils": "^0.3.0",
         "@lit/localize-tools": "^0.7.0",
         "chalk": "^5.0.1",
@@ -27483,10 +27483,10 @@
     },
     "packages/labs/compiler": {
       "name": "@lit-labs/compiler",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/analyzer": "^0.11.0",
+        "@lit-labs/analyzer": "^0.12.0",
         "@parse5/tools": "^0.3.0",
         "lit-html": "^3.1.2",
         "parse5": "^7.1.2",
@@ -27571,10 +27571,10 @@
     },
     "packages/labs/eslint-plugin": {
       "name": "eslint-plugin-lit",
-      "version": "0.0.0",
+      "version": "0.0.1",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/analyzer": "^0.11.1",
+        "@lit-labs/analyzer": "^0.12.0",
         "@typescript-eslint/utils": "^6.19.0",
         "typescript": "~5.3.3"
       },
@@ -27596,10 +27596,10 @@
     },
     "packages/labs/gen-manifest": {
       "name": "@lit-labs/gen-manifest",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/analyzer": "^0.11.0",
+        "@lit-labs/analyzer": "^0.12.0",
         "@lit-labs/gen-utils": "^0.3.0",
         "custom-elements-manifest": "^2.0.0"
       },
@@ -27620,10 +27620,10 @@
     },
     "packages/labs/gen-utils": {
       "name": "@lit-labs/gen-utils",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/analyzer": "^0.11.0"
+        "@lit-labs/analyzer": "^0.12.0"
       },
       "devDependencies": {
         "@lit-internal/tests": "^0.0.1"
@@ -27634,10 +27634,10 @@
     },
     "packages/labs/gen-wrapper-angular": {
       "name": "@lit-labs/gen-wrapper-angular",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/analyzer": "^0.11.0",
+        "@lit-labs/analyzer": "^0.12.0",
         "@lit-labs/gen-utils": "^0.3.0"
       },
       "devDependencies": {
@@ -27652,10 +27652,10 @@
     },
     "packages/labs/gen-wrapper-react": {
       "name": "@lit-labs/gen-wrapper-react",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/analyzer": "^0.11.0",
+        "@lit-labs/analyzer": "^0.12.0",
         "@lit-labs/gen-utils": "^0.3.0"
       },
       "devDependencies": {
@@ -27667,10 +27667,10 @@
     },
     "packages/labs/gen-wrapper-vue": {
       "name": "@lit-labs/gen-wrapper-vue",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/analyzer": "^0.11.0",
+        "@lit-labs/analyzer": "^0.12.0",
         "@lit-labs/gen-utils": "^0.3.0",
         "@lit-labs/vue-utils": "^0.1.1"
       },
@@ -28411,6 +28411,7 @@
       "version": "0.1.3",
       "license": "BSD-3-Clause",
       "dependencies": {
+        "@lit/task": "^1.0.0",
         "lit": "^2.0.0 || ^3.0.0"
       },
       "devDependencies": {
@@ -28507,7 +28508,7 @@
         "@lit-labs/ssr-client": "^1.1.7"
       },
       "devDependencies": {
-        "@lit/react": "1.0.3",
+        "@lit/react": "1.0.4",
         "@types/react": "^18.0.27",
         "@types/react-dom": "^18.0.10",
         "lit": "^3.1.2",
@@ -28555,10 +28556,10 @@
     },
     "packages/labs/test-projects/test-elements-react": {
       "name": "@lit-internal/test-elements-react",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "dependencies": {
         "@lit-internal/test-element-a": "1.0.1",
-        "@lit/react": "1.0.3"
+        "@lit/react": "1.0.4"
       },
       "peerDependencies": {
         "@types/react": "^17 || ^18",
@@ -28571,7 +28572,7 @@
     },
     "packages/labs/testing": {
       "name": "@lit-labs/testing",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit-labs/ssr": "^3.1.8",
@@ -29500,7 +29501,7 @@
     },
     "packages/react": {
       "name": "@lit/react",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@lit-internal/scripts": "^1.0.1",

--- a/packages/labs/router/.gitignore
+++ b/packages/labs/router/.gitignore
@@ -5,3 +5,8 @@
 /index.*
 /router.*
 /routes.*
+/route.*
+/lit-router.*
+/declarations.*
+/errors.*
+/utils.*

--- a/packages/labs/router/README.md
+++ b/packages/labs/router/README.md
@@ -4,7 +4,10 @@ A router for Lit.
 
 ## Status
 
-🚧 `@lit-labs/router` is part of the Lit Labs set of packages - it is published in order to get feedback on the design and not ready for production. Breaking changes are likely to happen frequently. 🚧
+> [!WARNING]
+> 🚧 `@lit-labs/router` is part of the Lit Labs set of packages - it is published in order to get feedback on the design and not ready for production. Breaking changes are likely to happen frequently. 🚧
+
+> [!TIP] > [**Lit Router**](#lit-router) is a new Router API for Lit that is designed to be more intuitive and powerful than the current API.
 
 This package requires either a native [`URLPattern`](https://developer.mozilla.org/en-US/docs/Web/API/URLPattern) implementation (which is currently only implemented in Chrome, Edge, and other Chromium browsers) or a URLPattern polyfill, like [`urlpattern-polyfill`](https://github.com/kenchris/urlpattern-polyfill).
 
@@ -243,6 +246,226 @@ In this example, the page can handle URLs `/foo`, `/child/foo` and `/child/bar`.
 ### `routes` Array
 
 `Routes` (and `Router`) have a property named `routes` that is an array of the route configurations. This array is mutable, so code an dynamically add and remove routes. Routes match in order of the array, so the array defines the route precedence.
+
+## Lit Router
+
+**Lit Router** is a new **Router API** for Lit that is designed to be more intuitive and powerful than the current API. This new API contains a number of features that are not present in the current API, such as:
+
+- 🛣️ Basic routing.
+- 🚀 Programmatic navigation.
+- 🌳 Nested routing
+- ⏳ Lazy loading.
+- 🔄🔍 Route params & query.
+- 🚧 Route guards.
+
+### Usage
+
+Creating a single-page application with Lit + Lit Router is a piece of cake! 🍰 With Lit, we're building our application using components, and when we add Lit Router to the mix, all we have to do is assign our components to the routes and let Lit Router work its magic to render them in the right place. ✨ Here's a simple example for you:
+
+**HTML**
+
+```html
+<lit-router></lit-router>
+```
+
+**JavaScript/Typescript**
+
+```ts
+// Import Lit Router.
+import {Route} from '@lit-labs/router';
+
+// Import your pages.
+import {HomePage} from './pages/home-page.js';
+import './pages/about-page.js';
+
+// Define your routes.
+const routes: Route[] = [
+  {path: '/', component: HomePage},
+  {path: '/about', component: 'about-page'},
+  {
+    path: '/terms',
+    component: () =>
+      import('./pages/terms-page.js').then((module) => module.TermsPage),
+  },
+];
+
+// Get a router.
+const router = document.querySelector('lit-router');
+
+// Register your routes.
+router.setRoutes(routes);
+```
+
+### Dynamic Routes
+
+Lit Router also provides a simple API to define dynamic routes. We can define dynamic routes of many types. Below are some examples:
+
+```ts
+import {UserPage} from './pages/user-page.js';
+
+const routes: Route[] = [{path: '/users/:id', component: UserPage}];
+```
+
+> [!WARNING]
+> This package requires either a native [`URLPattern`](https://developer.mozilla.org/en-US/docs/Web/API/URLPattern) implementation (which is currently only implemented in Chrome, Edge, and other Chromium browsers) or a URLPattern polyfill, like [`urlpattern-polyfill`](https://github.com/kenchris/urlpattern-polyfill).
+
+### Lazy Loading
+
+Lazy loading is a technique for loading pages on demand. This means that we only load the page when the user navigates to it. This is very useful when we have a large application and we want to improve the performance of our application. Here's an example:
+
+```ts
+const routes: Route[] = [
+  {
+    path: '/',
+    component: () => import('./pages/home-page.js').then((m) => m.HomePage),
+  },
+];
+```
+
+### Nested Routes
+
+Many times we need to define nested because we have a page that has a sidebar and we want to render the content of the sidebar in a specific place. For this we can use the children property. Here's an example:
+
+```ts
+const routes: Route[] = [
+  {
+    path: '/',
+    component: DashboardPage,
+    children: [{path: '/settings', component: SettingsPage}],
+  },
+];
+```
+
+### Displayed 404 Page
+
+When a user navigates to a page that does not exist, we can display a 404 page. This is very useful because it helps the user understand that the page they are looking for does not exist. Here's an example:
+
+```ts
+const routes: Route[] = [
+  {path: '/', component: HomePage},
+  {path: '/about', component: AboutPage},
+  {path: '*', component: NotFoundPage},
+];
+```
+
+### Programmatic Navigation
+
+Lit Router also provides a simple API for programmatic navigation. You can use the navigate method to `navigate()` to a specific route. Here's an example:
+
+```ts
+// First option.
+import {navigate} from '@lit-labs/router';
+
+navigate({path: '/about'});
+
+// Second option.
+const $router = document.querySelector('lit-router');
+
+$router.navigate({path: '/about'});
+```
+
+### Navigate for History
+
+You can also use the `forward()` & `back()` method to navigate for history. Here's an example:
+
+```ts
+// First option.
+import {forward, back} from '@lit-labs/router';
+
+forward();
+back();
+
+// Second option.
+const $router = document.querySelector('lit-router');
+
+$router.forward();
+$router.back();
+
+// Third option.
+window.history.forward();
+window.history.back();
+```
+
+### Route Params & Query
+
+Lit Router also provides a simple API to get route params and query. You can use the `params()` and `query()` property to get route params and query. Here's an example:
+
+```ts
+// Get all queries.
+// Example: /users?name=Ivan&age=23
+$router.qs(); // { name: 'Ivan', age: '23' }
+
+// Get a specific query.
+// Example: /users?name=Ivan&age=23
+$router.qs('name'); // Ivan
+
+// Get all params.
+// Example: /users/1
+$router.params(); // { id: '1' }
+
+// Get a specific param.
+// Example: /users/1
+$router.params('id'); // 1
+```
+
+### Route Guards
+
+The guards are functions that are executed before entering a route. They are very useful when we want to validate that the user has the necessary permissions to enter a route. Here's an example:
+
+```ts
+// Define your guard
+const isAdminGuard = ({navigate}) => {
+  const user = localStorage.getItem('user');
+
+  if (user && user.role === 'admin') {
+    return true;
+  }
+
+  navigate({path: '/login'});
+  return false;
+};
+
+const routes: Route[] = [
+  {
+    path: '/admin',
+    component: AdminPage,
+    // Execute the guard before entering the route
+    beforeEnter: [isAdminGuard],
+  },
+];
+```
+
+### API
+
+Below is a list of all the methods available on the `Lit Router` API.
+
+#### `.routes()`
+
+Returns the list of routes.
+
+#### `.setRoutes(routes: Partial<RouteConfig>[])`
+
+Method responsible for setting application routes. It receives an array of type `RouteConfig` as a parameter.
+
+#### `.navigate(navigation: Partial<Navigation>, options?: Partial<NavigationOptions>)`
+
+Method responsible for navigating to a specific route. It receives an object of type `Navigation` as a parameter.
+
+#### `.forward()`
+
+Method responsible for navigating forward.
+
+#### `.back()`
+
+Method responsible for navigating back.
+
+#### `.qs(name?: string)`
+
+Method responsible for returning all queries or a specific query.
+
+#### `.params(name?: string)`
+
+Method responsible for returning all params or a specific param.
 
 ## TODO
 

--- a/packages/labs/router/README.md
+++ b/packages/labs/router/README.md
@@ -7,7 +7,8 @@ A router for Lit.
 > [!WARNING]
 > 🚧 `@lit-labs/router` is part of the Lit Labs set of packages - it is published in order to get feedback on the design and not ready for production. Breaking changes are likely to happen frequently. 🚧
 
-> [!TIP] > [**Lit Router**](#lit-router) is a new Router API for Lit that is designed to be more intuitive and powerful than the current API.
+> [!TIP]
+> [**Lit Router**](#lit-router) is a new Router API for Lit that is designed to be more intuitive and powerful than the current API.
 
 This package requires either a native [`URLPattern`](https://developer.mozilla.org/en-US/docs/Web/API/URLPattern) implementation (which is currently only implemented in Chrome, Edge, and other Chromium browsers) or a URLPattern polyfill, like [`urlpattern-polyfill`](https://github.com/kenchris/urlpattern-polyfill).
 

--- a/packages/labs/router/README.md
+++ b/packages/labs/router/README.md
@@ -264,22 +264,29 @@ Creating a single-page application with Lit + Lit Router is a piece of cake! üç
 
 **HTML**
 
+Import the `<lit-router>` component in your `index.html` file.
+
 ```html
 <lit-router></lit-router>
 ```
 
 **JavaScript/Typescript**
 
-```ts
-// Import Lit Router.
-import {Route} from '@lit-labs/router';
+Now, let's create a simple example of how to use **Lit Router** in your application.
 
-// Import your pages.
+```ts
+// Import package.
+import '@lit-labs/router';
+
+// Import your static pages.
 import {HomePage} from './pages/home-page.js';
 import './pages/about-page.js';
 
-// Define your routes.
-const routes: Route[] = [
+// Get a router.
+const $router = document.querySelector('lit-router');
+
+// Register your routes.
+$router.setRoutes([
   {path: '/', component: HomePage},
   {path: '/about', component: 'about-page'},
   {
@@ -287,13 +294,7 @@ const routes: Route[] = [
     component: () =>
       import('./pages/terms-page.js').then((module) => module.TermsPage),
   },
-];
-
-// Get a router.
-const router = document.querySelector('lit-router');
-
-// Register your routes.
-router.setRoutes(routes);
+]);
 ```
 
 ### Dynamic Routes
@@ -305,6 +306,9 @@ import {UserPage} from './pages/user-page.js';
 
 const routes: Route[] = [{path: '/users/:id', component: UserPage}];
 ```
+
+> [!NOTE]
+> To capture route parameters, you can see it in the section [Route Params & Query](#route-params--query).
 
 > [!WARNING]
 > This package requires either a native [`URLPattern`](https://developer.mozilla.org/en-US/docs/Web/API/URLPattern) implementation (which is currently only implemented in Chrome, Edge, and other Chromium browsers) or a URLPattern polyfill, like [`urlpattern-polyfill`](https://github.com/kenchris/urlpattern-polyfill).

--- a/packages/labs/router/package.json
+++ b/packages/labs/router/package.json
@@ -164,6 +164,7 @@
     "urlpattern-polyfill": "^5.0.5"
   },
   "dependencies": {
+    "@lit/task": "^1.0.0",
     "lit": "^2.0.0 || ^3.0.0"
   }
 }

--- a/packages/labs/router/src/declarations.ts
+++ b/packages/labs/router/src/declarations.ts
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
 import {LitRouter} from './lit-router.js';
 
 export const TAG_NAME_ROUTER = 'lit-router' as const;

--- a/packages/labs/router/src/declarations.ts
+++ b/packages/labs/router/src/declarations.ts
@@ -1,0 +1,58 @@
+import {LitRouter} from './lit-router.js';
+
+export const TAG_NAME_ROUTER = 'lit-router' as const;
+
+export type HTMLElementConstructor = typeof HTMLElement;
+
+export type Component =
+  | string
+  | HTMLElementConstructor
+  | (() => Promise<HTMLElementConstructor>);
+
+export type BaseRouter = Pick<
+  LitRouter,
+  | 'routes'
+  | 'qs'
+  | 'params'
+  | 'onChange'
+  | 'setRoutes'
+  | 'navigate'
+  | 'forward'
+  | 'back'
+>;
+
+export type CustomRouterGuard = Omit<
+  BaseRouter,
+  'onChange' | 'setRoutes' | 'routes'
+>;
+
+export type Guard = (router: CustomRouterGuard) => boolean | Promise<boolean>;
+
+export interface Suscription {
+  /**
+   * Unsubscribe the suscription.
+   */
+  unsubscribe: () => void;
+}
+
+export interface Navigation {
+  /**
+   * Navigation path.
+   */
+  path: string;
+  /**
+   * Href associated with the navigation path.
+   */
+  href: string;
+  /**
+   * Query associated with the navigation path in the form of key-value pairs.
+   */
+  query: Record<string, string>;
+}
+
+export interface NavigationOptions {
+  /**
+   * Indicates whether 'window.history.pushState' should be enabled.
+   */
+  enableHistoryPushState: boolean;
+}

--- a/packages/labs/router/src/errors.ts
+++ b/packages/labs/router/src/errors.ts
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
 export class RouterError extends Error {
   constructor(message: string) {
     super(message);

--- a/packages/labs/router/src/errors.ts
+++ b/packages/labs/router/src/errors.ts
@@ -1,0 +1,47 @@
+export class RouterError extends Error {
+  constructor(message: string) {
+    super(message);
+
+    this.name = 'RouterError';
+  }
+}
+
+export class MissingPathError extends RouterError {
+  constructor() {
+    super('Missing path.');
+
+    this.name = 'MissingPathError';
+  }
+}
+
+export class MissingComponentError extends RouterError {
+  constructor() {
+    super('Missing component.');
+
+    this.name = 'MissingComponentError';
+  }
+}
+
+export class RouteNotFoundError extends RouterError {
+  constructor(pathname: string) {
+    super(`Route with path "${pathname}" not found.`);
+
+    this.name = 'RouteNotFoundError';
+  }
+}
+
+export class RouteAlreadyExistsError extends RouterError {
+  constructor(pathname: string) {
+    super(`Route with path "${pathname}" already exists.`);
+
+    this.name = 'RouteAlreadyExistsError';
+  }
+}
+
+export class RouterNotFoundError extends RouterError {
+  constructor() {
+    super('Router not found.');
+
+    this.name = 'RouterNotFoundError';
+  }
+}

--- a/packages/labs/router/src/index.ts
+++ b/packages/labs/router/src/index.ts
@@ -5,3 +5,19 @@
  */
 export * from './routes.js';
 export {Router} from './router.js';
+
+import './lit-router.js';
+export {LitRouter} from './lit-router.js';
+
+export {
+  NavigationOptions,
+  CustomRouterGuard,
+  Suscription,
+  Navigation,
+  BaseRouter,
+  Component,
+  Guard,
+} from './declarations.js';
+
+export {RouteConfig, Route} from './route.js';
+export * from './utils.js';

--- a/packages/labs/router/src/lit-router.ts
+++ b/packages/labs/router/src/lit-router.ts
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
 /// <reference types="urlpattern-polyfill" />
 
 import {customElement, state} from 'lit/decorators.js';

--- a/packages/labs/router/src/lit-router.ts
+++ b/packages/labs/router/src/lit-router.ts
@@ -49,17 +49,17 @@ export class LitRouter extends LitElement {
   override connectedCallback(): void {
     super.connectedCallback();
 
-    window.addEventListener('popstate', this._onHandlePopState.bind(this));
+    window.addEventListener('popstate', this._onHandlePopState);
 
-    window.addEventListener('click', this._onHandleAnchorClick.bind(this));
+    window.addEventListener('click', this._onHandleAnchorClick);
   }
 
   override disconnectedCallback(): void {
     super.disconnectedCallback();
 
-    window.removeEventListener('popstate', this._onHandlePopState.bind(this));
+    window.removeEventListener('popstate', this._onHandlePopState);
 
-    window.removeEventListener('click', this._onHandleAnchorClick.bind(this));
+    window.removeEventListener('click', this._onHandleAnchorClick);
   }
 
   /**
@@ -395,7 +395,7 @@ export class LitRouter extends LitElement {
    *
    * @param ev The click event.
    */
-  private _onHandleAnchorClick(ev: MouseEvent): void {
+  private _onHandleAnchorClick = (ev: MouseEvent): void => {
     const isNonNavigationClick =
       ev.button !== 0 || ev.metaKey || ev.ctrlKey || ev.shiftKey;
 
@@ -429,13 +429,13 @@ export class LitRouter extends LitElement {
     if (href === location.href) return;
 
     this.navigate({href});
-  }
+  };
 
-  private async _onHandlePopState(_ev: PopStateEvent): Promise<void> {
+  private _onHandlePopState = async (_ev: PopStateEvent): Promise<void> => {
     const {href} = window.location;
 
     this.navigate({href}, {enableHistoryPushState: false});
-  }
+  };
 
   protected override createRenderRoot() {
     return this;

--- a/packages/labs/router/src/lit-router.ts
+++ b/packages/labs/router/src/lit-router.ts
@@ -1,0 +1,443 @@
+/// <reference types="urlpattern-polyfill" />
+
+import {customElement, state} from 'lit/decorators.js';
+import {LitElement} from 'lit';
+import {Task} from '@lit/task';
+
+import {
+  NavigationOptions,
+  TAG_NAME_ROUTER,
+  Suscription,
+  Navigation,
+} from './declarations.js';
+
+import {
+  RouteAlreadyExistsError,
+  MissingComponentError,
+  RouteNotFoundError,
+  MissingPathError,
+} from './errors.js';
+
+import {Route, RouteConfig} from './route.js';
+import {back, forward} from './utils.js';
+
+declare global {
+  interface HTMLElementTagNameMap {
+    [TAG_NAME_ROUTER]: LitRouter;
+  }
+}
+
+@customElement(TAG_NAME_ROUTER)
+export class LitRouter extends LitElement {
+  @state()
+  private _currentRoute: Route | null = null;
+
+  @state()
+  private readonly _routes: Route[] = [];
+
+  private _renderingTemplateTask = new Task(this, {
+    task: async ([_currentRoute]) => _currentRoute?.resolve(),
+    args: () => [this._currentRoute],
+  });
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+
+    window.addEventListener('popstate', this._onHandlePopState.bind(this));
+
+    window.addEventListener('click', this._onHandleAnchorClick.bind(this));
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+
+    window.removeEventListener('popstate', this._onHandlePopState.bind(this));
+
+    window.removeEventListener('click', this._onHandleAnchorClick.bind(this));
+  }
+
+  /**
+   * List of registered routes.
+   */
+  routes(): Route[] {
+    return this._routes;
+  }
+
+  /**
+   * Get an object containing the query parameters of the current URL.
+   *
+   * @example
+   * ```js
+   * // URL: https://example.com?foo=bar&baz=qux
+   * router.qs() // { foo: 'bar', baz: 'qux' }
+   *
+   * router.qs('foo') // { foo: 'bar' }
+   * ```
+   */
+  qs(name: string = ''): Record<string, string> | string | null {
+    const urlSearchParams = new URLSearchParams(window.location.search);
+
+    return this._extractParameters(urlSearchParams, name);
+  }
+
+  /**
+   * Retrieves an object representing the parameters present in the current route.
+   *
+   * @example
+   * ```js
+   * // URL: https://example.com/users/1
+   * router.params() // { userId: '1' }
+   * ```
+   */
+  params(
+    name?: string
+  ): Record<string, string | undefined> | string | undefined {
+    const {origin, pathname} = window.location;
+
+    const route = this._findRouteByPath(pathname);
+
+    if (!route) return {};
+
+    // Extract parameters from the URL using the route's regular expression
+    const {pathname: pathnameObject} =
+      route.urlPattern.exec(origin + pathname) || {};
+
+    if (!pathnameObject || !pathnameObject.groups) {
+      return {};
+    }
+
+    return name == null ? pathnameObject.groups : pathnameObject.groups[name];
+  }
+
+  /**
+   * Adds a callback function to be invoked when the router state changes.
+   *
+   * @param _callback The callback function to be invoked.
+   * @returns {Suscription} Returns a suscription object that can be used to unsubscribe the callback.
+   * @example
+   * ```js
+   * const suscription = router.onChange((router) => {
+   *   console.log(router)
+   * })
+   *
+   * suscription.unsubscribe()
+   * ```
+   */
+  onChange(_callback: (router: LitRouter) => void): Suscription {
+    const callback = () => _callback(this);
+
+    window.addEventListener('popstate', callback);
+
+    const subscription = {
+      unsubscribe: () => window.removeEventListener('popstate', callback),
+    };
+
+    return subscription;
+  }
+
+  /**
+   * Adds a list of routes to the router configuration.
+   *
+   * @param routes A list of routes.
+   * @example
+   * ```js
+   * const routes = [
+   *   { path: '/', component: HomePage },
+   *   { path: '/about', component: AboutPage }
+   * ]
+   *
+   * router.setRoutes(routes)
+   * ```
+   */
+  setRoutes(routes: Partial<RouteConfig>[]): void {
+    for (const route of routes) {
+      const _route = this._buildNestedRouteFromConfig(route);
+
+      this._routes.push(_route);
+    }
+
+    // We get the current route from the URL and then
+    // navigate to the current route to trigger the rendering.
+    // This is necessary to render the content when the routes
+    // have been set for the first time.
+    const {href} = window.location;
+
+    this.navigate({href});
+  }
+
+  /**
+   * Navigates to a new route based on the provided navigation options.
+   *
+   * @param {Partial<Navigation>} navigation The navigation options, which can include 'name' or 'path'.
+   * @param {Partial<NavigationOptions>} options The navigation options.
+   * @example
+   * ```js
+   * // Navigate to a route by path
+   * router.navigate({ path: '/about' })
+   *
+   * // Navigate to a route include query parameters
+   * router.navigate({ path: '/users', query: { page: 1 } })
+   * ```
+   */
+  async navigate(
+    navigation: Partial<Navigation>,
+    options: Partial<NavigationOptions> = {}
+  ): Promise<void> {
+    const {enableHistoryPushState} = Object.assign(
+      {enableHistoryPushState: true},
+      options
+    );
+
+    const {path, href} = navigation;
+
+    if (!path && !href) {
+      return console.error(new MissingPathError());
+    }
+
+    const urlInstance = new URL(path || href || '', window.location.origin);
+
+    Object.keys(navigation.query || {}).forEach((key) => {
+      const value = navigation.query![key];
+      urlInstance.searchParams.append(key, value);
+    });
+
+    const {pathname} = urlInstance;
+    const route = this._findRouteByPath(pathname);
+
+    if (!route) {
+      return console.warn(new RouteNotFoundError(pathname));
+    }
+
+    // The qs and params methods are wrapped for beforeEnter protection
+    // to ensure that they return the query and parameters of the path
+    // we want to navigate to, not the current one.
+    const qs = (name?: string) =>
+      this._extractParameters(urlInstance.searchParams, name);
+
+    const params = (name?: string) => {
+      const {pathname, origin} = urlInstance;
+
+      const route = this._findRouteByPath(pathname);
+
+      if (!route) return {};
+
+      const {pathname: pathnameObject} =
+        route.urlPattern.exec(origin + pathname) || {};
+
+      if (!pathnameObject || !pathnameObject.groups) {
+        return {};
+      }
+
+      return name == null ? pathnameObject.groups : pathnameObject.groups[name];
+    };
+
+    const isAllowed = await route.resolveRecursiveGuard({
+      navigate: this.navigate.bind(this),
+      forward: this.forward.bind(this),
+      back: this.back.bind(this),
+      qs,
+      params,
+    });
+
+    if (!isAllowed) return;
+
+    this._currentRoute = route;
+
+    if (!enableHistoryPushState) return;
+
+    window.history.pushState({}, '', urlInstance.href);
+  }
+
+  /**
+   * Navigates to the next page in session history.
+   *
+   * @example
+   * ```js
+   * // Navigate to the next page
+   * router.forward()
+   * ```
+   */
+  forward(): void {
+    forward();
+  }
+
+  /**
+   * Navigates to the previous page in session history.
+   *
+   * @example
+   * ```js
+   * // Navigate to the previous page
+   * router.back()
+   * ```
+   */
+  back(): void {
+    back();
+  }
+
+  /**
+   * Find a route in the navigation hierarchy.
+   *
+   * @private
+   * @param {string} path - The path to search for.
+   * @param {Route[]} [routes=this.routes()] - The array of routes to search within.
+   * @param {boolean} [onlyLeafRoute=false] - If true, only consider leaf routes (routes without children).
+   */
+  private _findRouteByPath(
+    path: string,
+    routes: Route[] = this.routes(),
+    onlyLeafRoute: boolean = false
+  ): Route | undefined {
+    const hasLeafRoute = (route: Route) => route.children.length === 0;
+
+    const findInChildRoutes = (path: string, children: Route[]) =>
+      this._findRouteByPath(path, children, onlyLeafRoute);
+
+    for (const route of routes) {
+      if (onlyLeafRoute && route?.match(path)) return route;
+
+      if (onlyLeafRoute && route.match(path) && hasLeafRoute(route))
+        return route;
+
+      if (!onlyLeafRoute && route.match(path)) return route;
+
+      const childRoute = findInChildRoutes(path, route.children as Route[]);
+
+      if (childRoute) return childRoute;
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Creates a new route based on the provided route configuration.
+   *
+   * @param routeConfig The route configuration.
+   * @throws {Error} Throws an error if 'path' or 'component' is missing.
+   */
+  private _createRouteFromConfig(routeConfig: Partial<RouteConfig>): Route {
+    const {path, component} = routeConfig;
+
+    if (!path) {
+      throw new MissingPathError();
+    }
+
+    if (!component) {
+      throw new MissingComponentError();
+    }
+
+    const route = new Route(path, component);
+
+    if (routeConfig.beforeEnter) {
+      route.beforeEnter = routeConfig.beforeEnter;
+    }
+
+    return route;
+  }
+
+  /**
+   * Builds a nested route based on the provided route configuration.
+   *
+   * @param routeConfig The route configuration.
+   */
+  private _buildNestedRouteFromConfig(
+    routeConfig: Partial<RouteConfig>
+  ): Route {
+    const {children} = routeConfig;
+
+    const route = this._createRouteFromConfig(routeConfig);
+
+    (children || []).forEach((child) => {
+      const childRoute = this._buildNestedRouteFromConfig({
+        ...child,
+        path: `${route.path}${child.path}`,
+      });
+
+      childRoute.setParent(route);
+
+      if (
+        this._findRouteByPath(
+          child.path as string,
+          (route.children || []) as Route[]
+        )
+      ) {
+        return console.error(new RouteAlreadyExistsError(child.path as string));
+      }
+
+      route.children.push(childRoute);
+    });
+
+    return route;
+  }
+
+  private _extractParameters(
+    source: URLSearchParams | RegExpExecArray | null | undefined,
+    name?: string
+  ): Record<string, string> | string | null {
+    if (!source) return {};
+
+    if (name) {
+      return source instanceof URLSearchParams ? source.get(name) : null;
+    }
+
+    return source instanceof URLSearchParams
+      ? Object.fromEntries(source.entries())
+      : source.groups || {};
+  }
+
+  /**
+   * Handles the click event on anchor elements.
+   *
+   * @param ev The click event.
+   */
+  private _onHandleAnchorClick(ev: MouseEvent): void {
+    const isNonNavigationClick =
+      ev.button !== 0 || ev.metaKey || ev.ctrlKey || ev.shiftKey;
+
+    if (ev.defaultPrevented || isNonNavigationClick) return;
+
+    const anchor = ev
+      .composedPath()
+      .find((n) => (n as HTMLElement).tagName === 'A') as
+      | HTMLAnchorElement
+      | undefined;
+
+    if (
+      anchor === undefined ||
+      anchor.target !== '' ||
+      anchor.hasAttribute('download') ||
+      anchor.getAttribute('rel') === 'external'
+    ) {
+      return;
+    }
+
+    const href = anchor.href;
+
+    if (href === '' || href.startsWith('mailto:')) return;
+
+    const location = window.location;
+
+    if (anchor.origin !== origin) return;
+
+    ev.preventDefault();
+
+    if (href === location.href) return;
+
+    this.navigate({href});
+  }
+
+  private async _onHandlePopState(_ev: PopStateEvent): Promise<void> {
+    const {href} = window.location;
+
+    this.navigate({href}, {enableHistoryPushState: false});
+  }
+
+  protected override createRenderRoot() {
+    return this;
+  }
+
+  protected override render(): unknown {
+    return this._renderingTemplateTask.render({
+      complete: (template) => template,
+    });
+  }
+}

--- a/packages/labs/router/src/route.ts
+++ b/packages/labs/router/src/route.ts
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
 /// <reference types="urlpattern-polyfill" />
 
 import {

--- a/packages/labs/router/src/route.ts
+++ b/packages/labs/router/src/route.ts
@@ -1,0 +1,175 @@
+/// <reference types="urlpattern-polyfill" />
+
+import {
+  HTMLElementConstructor,
+  CustomRouterGuard,
+  Component,
+  Guard,
+} from './declarations.js';
+
+export type RouteConfig = Pick<
+  Route,
+  'path' | 'component' | 'children' | 'beforeEnter'
+>;
+
+export class Route {
+  /**
+   * The path of route.
+   */
+  readonly path!: string;
+
+  /**
+   * The component of route.
+   *
+   * @example
+   * ```ts
+   * // String
+   * { path: '/foo', component: 'foo-component' }
+   *
+   * // HTMLElement
+   * import { FooComponent } from './foo-component.js'
+   *
+   * { path: '/foo', component: FooComponent }
+   *
+   * // Lazy loading
+   * {
+   *   path: '/foo',
+   *   component: () => import('./foo-component.js').then((m) => m.FooComponent)
+   * }
+   * ```
+   */
+  readonly component!: Component;
+
+  /**
+   * The children of route.
+   *
+   * @example
+   * ```ts
+   * const routeConfig: RouteConfig = {
+   *   path: '/foo',
+   *   component: 'foo-component',
+   *   children: [
+   *     {
+   *       path: '/bar',
+   *       component: 'bar-component'
+   *     }
+   *   ]
+   * }
+   * ```
+   */
+  children: Partial<RouteConfig>[] = [];
+
+  /**
+   * Callback executed before the route is entered.
+   *
+   * @example
+   * ```ts
+   * const routeConfig: RouteConfig = {
+   *   path: '/foo',
+   *   component: 'foo-component',
+   *   beforeEnter: [
+   *     () => {
+   *       // Do something...
+   *       return true
+   *     }
+   *   ]
+   * }
+   * ```
+   */
+  beforeEnter: Guard[] = [];
+
+  private _parent: Route | null = null;
+
+  readonly urlPattern!: URLPattern;
+
+  constructor(path: string, component: Component) {
+    this.path = path;
+    this.component = component;
+
+    this.urlPattern = new URLPattern(this.path, window.location.origin);
+  }
+
+  setParent(parent: Route): void {
+    this._parent = parent;
+  }
+
+  match(path: string): boolean {
+    return this.urlPattern.test(window.location.origin + path);
+  }
+
+  /**
+   * Resolves the provided component and returns an HTMLElement instance.
+   *
+   * This method is used to take a representation of a component
+   * (such as a function that returns a TemplateResult or a promise
+   * that resolves to a custom module) and create an HTMLElement
+   * instance that can be used in the DOM.
+   *
+   * @param component The component to resolve.
+   */
+  private async _resolveComponent(component: Component): Promise<unknown> {
+    // Resolve the tag name of the component.
+    if (typeof component === 'string') {
+      return document.createElement(component);
+    }
+
+    // Resolve a custom element.
+    if (
+      typeof component === 'function' &&
+      component.prototype instanceof HTMLElement
+    ) {
+      return new (component as HTMLElementConstructor)();
+    }
+
+    // Resolve a lazy-loaded module.
+    const Module = await (component as () => Promise<HTMLElementConstructor>)();
+
+    return new Module();
+  }
+
+  async resolveRecursiveGuard(router: CustomRouterGuard): Promise<boolean> {
+    if (!this.beforeEnter.length) {
+      return Promise.resolve(true);
+    }
+
+    const guards = this.beforeEnter.map((guard) => guard(router));
+    const results = await Promise.all(guards);
+
+    const parentGuardResult = this._parent
+      ? await this._parent.resolveRecursiveGuard(router)
+      : true;
+
+    return results.every((result) => result) && parentGuardResult;
+  }
+
+  /**
+   * Resolves a component and, optionally, nests it in a parent
+   * component using the [Chain of Responsibility](https://refactoring.guru/design-patterns/chain-of-responsibility) pattern.
+   *
+   * @param component The component to resolve.
+   * @returns A promise that resolves to an HTMLElement instance.
+   */
+  async resolve(component?: () => HTMLElement): Promise<unknown> {
+    let _component: HTMLElement | null = component ? component() : null;
+
+    if (!_component) {
+      _component = (await this._resolveComponent(
+        this.component
+      )) as unknown as HTMLElement;
+    }
+
+    if (this._parent) {
+      const parent = (await this._resolveComponent(
+        this._parent.component
+      )) as HTMLElement;
+
+      const child = _component;
+
+      parent.appendChild(child as HTMLElement);
+
+      return this._parent.resolve(() => parent);
+    }
+
+    return _component;
+  }
+}

--- a/packages/labs/router/src/test/lit_router_test.ts
+++ b/packages/labs/router/src/test/lit_router_test.ts
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
 import {stripExpressionComments} from '@lit-labs/testing';
 import {assert} from '@esm-bundle/chai';
 

--- a/packages/labs/router/src/test/lit_router_test.ts
+++ b/packages/labs/router/src/test/lit_router_test.ts
@@ -276,4 +276,24 @@ const canTest =
 
     assert.equal(routes.length, 4);
   });
+
+  test('Check navigation using anchor tags', async () => {
+    const $anchor = document.createElement('a');
+    $anchor.href = '/about';
+
+    document.body.appendChild($anchor);
+    $anchor.click();
+
+    await _delay(1000);
+
+    $anchor.remove();
+
+    const $aboutPage = $router.querySelector('about-page');
+
+    assert.isDefined($aboutPage);
+    assert.equal(
+      stripExpressionComments($aboutPage!.shadowRoot!.innerHTML),
+      '<h1>About Page</h1>'
+    );
+  });
 });

--- a/packages/labs/router/src/test/lit_router_test.ts
+++ b/packages/labs/router/src/test/lit_router_test.ts
@@ -1,0 +1,273 @@
+import {stripExpressionComments} from '@lit-labs/testing';
+import {assert} from '@esm-bundle/chai';
+
+import 'urlpattern-polyfill';
+
+import {LitRouter} from '@lit-labs/router';
+import '@lit-labs/router';
+
+// Imports static pages
+import './pages/home-page.js';
+import './pages/about-page.js';
+
+const _delay = (ms: number) =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+const _hasFibonacciNumber = (number: number) => {
+  if (number < 0) return false;
+
+  let a = 0;
+  let b = 1;
+
+  while (b < number) {
+    const temp = b;
+
+    b = a + b;
+    a = temp;
+  }
+
+  return b === number;
+};
+
+const canTest =
+  window.ShadowRoot &&
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  !(window as any).ShadyDOM?.inUse;
+
+(canTest ? suite : suite.skip)('LitRouter', () => {
+  let $router: LitRouter;
+
+  setup(async () => {
+    $router = document.createElement('lit-router') as LitRouter;
+
+    $router.setRoutes([
+      {
+        path: '/',
+        component: 'home-page',
+      },
+      {
+        path: '/about',
+        component: 'about-page',
+      },
+      {
+        path: '/dashboard',
+        component: () =>
+          import('./pages/dashboard-page.js').then((m) => m.DashboardPage),
+        beforeEnter: [
+          ({navigate, qs}) => {
+            const token = qs('token');
+
+            if (!token) {
+              navigate({path: '/'});
+              return false;
+            }
+
+            return true;
+          },
+        ],
+        children: [
+          {
+            path: '/users/:id',
+            component: () =>
+              import('./pages/users-page.js').then((m) => m.UsersPage),
+            beforeEnter: [
+              ({params}) => {
+                const userId = Number(params('id'));
+
+                return _hasFibonacciNumber(userId);
+              },
+            ],
+          },
+        ],
+      },
+      {
+        path: '*',
+        component: () =>
+          import('./pages/not-found-page.js').then((m) => m.NotFoundPage),
+      },
+    ]);
+
+    document.body.appendChild($router);
+
+    await _delay(50);
+  });
+
+  teardown(() => {
+    $router?.remove();
+  });
+
+  test('Check that the initial route is (/)', () => {
+    assert.isDefined($router);
+
+    const $homepage = $router.querySelector('home-page');
+
+    assert.isDefined($homepage);
+    assert.equal(
+      stripExpressionComments($homepage!.shadowRoot!.innerHTML),
+      '<h1>Home Page</h1>'
+    );
+  });
+
+  test('Check that the route changes to (/about)', async () => {
+    $router.navigate({path: '/about'});
+
+    await _delay(50);
+
+    assert.equal($router.querySelector('home-page'), null);
+
+    const $aboutPage = $router.querySelector('about-page');
+
+    assert.isDefined($aboutPage);
+    assert.equal(
+      stripExpressionComments($aboutPage!.shadowRoot!.innerHTML),
+      '<h1>About Page</h1>'
+    );
+  });
+
+  test('Check wildcard routes (404 not found)', async () => {
+    $router.navigate({path: '/random'});
+
+    await _delay(1000);
+
+    const $notFoundPage = $router.querySelector('not-found-page');
+
+    assert.isDefined($notFoundPage);
+    assert.equal(
+      stripExpressionComments($notFoundPage!.shadowRoot!.innerHTML),
+      '<h1>404 | Not Found</h1>'
+    );
+  });
+
+  test('Check the route guards', async () => {
+    $router.navigate({path: '/dashboard'});
+
+    await _delay(100);
+
+    const $homePage = $router.querySelector('home-page');
+    assert.equal(
+      stripExpressionComments($homePage!.shadowRoot!.innerHTML),
+      '<h1>Home Page</h1>'
+    );
+
+    $router.navigate({
+      path: '/dashboard',
+      query: {token: '123'},
+    });
+
+    await _delay(100);
+
+    const $dashboardPage = $router.querySelector('dashboard-page');
+
+    assert.match(
+      stripExpressionComments($dashboardPage!.shadowRoot!.innerHTML),
+      /Dashboard Page/
+    );
+
+    $router.navigate({
+      path: '/dashboard/users/4',
+      query: {token: '123'},
+    });
+
+    await _delay(100);
+
+    assert.equal($router.querySelector('users-page'), null);
+
+    $router.navigate({
+      path: '/dashboard/users/1',
+      query: {token: '123'},
+    });
+
+    await _delay(100);
+
+    const $usersPage = $router.querySelector('users-page');
+
+    assert.equal(
+      stripExpressionComments($usersPage!.shadowRoot!.innerHTML),
+      '<h1>Users Page 1</h1>'
+    );
+  });
+
+  test('Check that back() navigation function', async () => {
+    $router.back();
+
+    await _delay(50);
+
+    const $dashboardPage = $router.querySelector('dashboard-page');
+
+    assert.match(
+      stripExpressionComments($dashboardPage!.shadowRoot!.innerHTML),
+      /<h1>Dashboard Page<\/h1>/
+    );
+  });
+
+  test('Check that forward() navigation function', async () => {
+    $router.forward();
+
+    await _delay(50);
+
+    const $usersPage = $router.querySelector('users-page');
+
+    assert.equal(
+      stripExpressionComments($usersPage!.shadowRoot!.innerHTML),
+      '<h1>Users Page 1</h1>'
+    );
+  });
+
+  test('Check that qs() function', async () => {
+    $router.navigate({
+      path: '/dashboard/users/8',
+      query: {
+        token: '123',
+        name: 'Ivan Guevara',
+        country: 'El Salvador',
+        age: '23',
+      },
+    });
+
+    await _delay(50);
+
+    const queriesObj = $router.qs();
+
+    assert.deepEqual(queriesObj, {
+      token: '123',
+      name: 'Ivan Guevara',
+      country: 'El Salvador',
+      age: '23',
+    });
+
+    const token = $router.qs('token');
+    const name = $router.qs('name');
+    const country = $router.qs('country');
+
+    assert.equal(token, '123');
+    assert.equal(name, 'Ivan Guevara');
+    assert.equal(country, 'El Salvador');
+  });
+
+  test('Check that params() function', async () => {
+    $router.navigate({
+      path: '/dashboard/users/8',
+      query: {
+        token: '123',
+      },
+    });
+
+    await _delay(50);
+
+    const paramsObj = $router.params();
+
+    assert.deepEqual(paramsObj, {
+      id: '8',
+    });
+
+    const id = $router.params('id');
+
+    assert.equal(id, '8');
+  });
+
+  test('Check that routes() function', async () => {
+    const routes = $router.routes();
+
+    assert.equal(routes.length, 4);
+  });
+});

--- a/packages/labs/router/src/test/pages/about-page.ts
+++ b/packages/labs/router/src/test/pages/about-page.ts
@@ -1,0 +1,9 @@
+import {html, LitElement} from 'lit';
+
+export class AboutPage extends LitElement {
+  protected override render(): unknown {
+    return html`<h1>About Page</h1>`;
+  }
+}
+
+window.customElements.define('about-page', AboutPage);

--- a/packages/labs/router/src/test/pages/about-page.ts
+++ b/packages/labs/router/src/test/pages/about-page.ts
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
 import {html, LitElement} from 'lit';
 
 export class AboutPage extends LitElement {

--- a/packages/labs/router/src/test/pages/dashboard-page.ts
+++ b/packages/labs/router/src/test/pages/dashboard-page.ts
@@ -1,0 +1,12 @@
+import {LitElement, html} from 'lit';
+
+export class DashboardPage extends LitElement {
+  protected override render(): unknown {
+    return html`
+      <h1>Dashboard Page</h1>
+      <slot></slot>
+    `;
+  }
+}
+
+window.customElements.define('dashboard-page', DashboardPage);

--- a/packages/labs/router/src/test/pages/dashboard-page.ts
+++ b/packages/labs/router/src/test/pages/dashboard-page.ts
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
 import {LitElement, html} from 'lit';
 
 export class DashboardPage extends LitElement {

--- a/packages/labs/router/src/test/pages/home-page.ts
+++ b/packages/labs/router/src/test/pages/home-page.ts
@@ -1,0 +1,9 @@
+import {html, LitElement} from 'lit';
+
+export class HomePage extends LitElement {
+  protected override render(): unknown {
+    return html`<h1>Home Page</h1>`;
+  }
+}
+
+window.customElements.define('home-page', HomePage);

--- a/packages/labs/router/src/test/pages/home-page.ts
+++ b/packages/labs/router/src/test/pages/home-page.ts
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
 import {html, LitElement} from 'lit';
 
 export class HomePage extends LitElement {

--- a/packages/labs/router/src/test/pages/not-found-page.ts
+++ b/packages/labs/router/src/test/pages/not-found-page.ts
@@ -1,0 +1,9 @@
+import {LitElement, html} from 'lit';
+
+export class NotFoundPage extends LitElement {
+  protected override render(): unknown {
+    return html`<h1>404 | Not Found</h1>`;
+  }
+}
+
+window.customElements.define('not-found-page', NotFoundPage);

--- a/packages/labs/router/src/test/pages/not-found-page.ts
+++ b/packages/labs/router/src/test/pages/not-found-page.ts
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
 import {LitElement, html} from 'lit';
 
 export class NotFoundPage extends LitElement {

--- a/packages/labs/router/src/test/pages/users-page.ts
+++ b/packages/labs/router/src/test/pages/users-page.ts
@@ -1,0 +1,19 @@
+import {LitElement, html} from 'lit';
+
+export class UsersPage extends LitElement {
+  private _getRouter() {
+    const $router = this.closest('lit-router');
+
+    return $router;
+  }
+
+  protected override render(): unknown {
+    const $router = this._getRouter();
+
+    const userId = $router?.params('id');
+
+    return html`<h1>Users Page ${userId}</h1>`;
+  }
+}
+
+window.customElements.define('users-page', UsersPage);

--- a/packages/labs/router/src/test/pages/users-page.ts
+++ b/packages/labs/router/src/test/pages/users-page.ts
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
 import {LitElement, html} from 'lit';
 
 export class UsersPage extends LitElement {

--- a/packages/labs/router/src/utils.ts
+++ b/packages/labs/router/src/utils.ts
@@ -1,0 +1,27 @@
+import {Navigation, TAG_NAME_ROUTER} from './declarations.js';
+import {RouterNotFoundError} from './errors.js';
+
+/**
+ * Navigates to a new route based on the provided navigation options.
+ *
+ * @param {Partial<Navigation>} navigation - The navigation options, which can include 'name' or 'path'.
+ */
+export const navigate = (navigation: Partial<Navigation>) => {
+  const router = document.querySelector(TAG_NAME_ROUTER);
+
+  if (!router) {
+    throw new RouterNotFoundError();
+  }
+
+  router.navigate(navigation);
+};
+
+/**
+ * Moves forward in the browser's history.
+ */
+export const forward = () => window.history.forward();
+
+/**
+ * Moves backward in the browser's history.
+ */
+export const back = () => window.history.back();

--- a/packages/labs/router/src/utils.ts
+++ b/packages/labs/router/src/utils.ts
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
 import {Navigation, TAG_NAME_ROUTER} from './declarations.js';
 import {RouterNotFoundError} from './errors.js';
 


### PR DESCRIPTION
## Context

The `@lit-labs/router` package provides routing functionalities for Single Page Applications (SPAs), but currently, there are areas that could be enhanced:

- Programmatic navigation is not straightforward, requiring developers to come up with creative solutions to address this limitation.
- Route definition can be complex as the router is tightly coupled with components via `ReactiveController`. This can make it challenging to identify routes, especially when nesting them, as accessing each component is necessary.
- Implementing Lazy Loading on some pages may be confusing. Often, the `enter` callback is used to perform multiple tasks, such as loading components lazily, functioning as navigation guards, among others.

To address these improvement points, I've created this pull request proposing a more intuitive API and a more satisfying development experience. The proposed enhancements are based on concepts drawn from other popular routing APIs.

## Solution

This pull request introduces significant enhancements to the `@lit-labs/router` library, aiming to revolutionize the way routes are managed in `Lit` applications. With Lit Router API, developers will have a more intuitive API for defining routes, adding pages through lazy loading, and a set of utilities to enhance the navigation experience.

- **🛣️ Defining Routes️**: Instructions on how to define routes using Lit Router, with examples for both tag names and component classes.
- **⏳ Lazy Loading**: Guide on how to implement lazy loading for improved performance.
- **🌳 Nested Routes**: Explanation and example of defining nested routes.
- **🚀 Programmatic Navigation**: API reference and examples for programmatic navigation.
- **🔄🔍 Query & Params**: API reference and examples for accessing query parameters and route parameters.
- **🚧 Guards**: Explanation and examples of using guards for route authentication.

**Basic Usage**

```ts
// Import package.
import '@lit-labs/router';

// Import your static pages.
import {HomePage} from './pages/home-page.js';
import './pages/about-page.js';

// Get a router.
const $router = document.querySelector('lit-router');

// Register your routes.
$router.setRoutes([
  {path: '/', component: HomePage},
  {path: '/about', component: 'about-page'}
]);
```