### PR TITLE
[lit/context] Use `target.set` for setting context values

### DIFF
--- a/.changeset/thirty-shirts-peel.md
+++ b/.changeset/thirty-shirts-peel.md
@@ -2,4 +2,4 @@
 '@lit/context': patch
 ---
 
-Use `target.set` instead of member assignment
+Use `target.set` instead of member assignment in `@consume()` decorator.

--- a/.changeset/thirty-shirts-peel.md
+++ b/.changeset/thirty-shirts-peel.md
@@ -1,0 +1,5 @@
+---
+'@lit/context': patch
+---
+
+Use `target.set` instead of member assignment

--- a/packages/context/src/lib/decorators/consume.ts
+++ b/packages/context/src/lib/decorators/consume.ts
@@ -55,7 +55,7 @@ export function consume<ValueType>({
   ) => {
     if (typeof nameOrContext === 'object') {
       // Standard decorators branch
-      nameOrContext.addInitializer(function (): void {
+      nameOrContext.addInitializer(function () {
         new ContextConsumer(this, {
           context,
           callback: (value) => {

--- a/packages/context/src/lib/decorators/consume.ts
+++ b/packages/context/src/lib/decorators/consume.ts
@@ -47,18 +47,19 @@ export function consume<ValueType>({
   context: Context<unknown, ValueType>;
   subscribe?: boolean;
 }): ConsumeDecorator<ValueType> {
-  return (<C extends ReactiveElement, V extends ValueType>(
-    protoOrTarget: ClassAccessorDecoratorTarget<C, V>,
-    nameOrContext: PropertyKey | ClassAccessorDecoratorContext<C, V>
+  return ((
+    protoOrTarget: ClassAccessorDecoratorTarget<ReactiveElement, ValueType>,
+    nameOrContext:
+      | PropertyKey
+      | ClassAccessorDecoratorContext<ReactiveElement, ValueType>
   ) => {
     if (typeof nameOrContext === 'object') {
       // Standard decorators branch
-      nameOrContext.addInitializer(function (this: ReactiveElement): void {
+      nameOrContext.addInitializer(function (): void {
         new ContextConsumer(this, {
           context,
-          callback: (value: ValueType) => {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (this as any)[nameOrContext.name] = value;
+          callback: (value) => {
+            protoOrTarget.set.call(this, value);
           },
           subscribe,
         });
@@ -69,7 +70,7 @@ export function consume<ValueType>({
         (element: ReactiveElement): void => {
           new ContextConsumer(element, {
             context,
-            callback: (value: ValueType) => {
+            callback: (value) => {
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
               (element as any)[nameOrContext] = value;
             },


### PR DESCRIPTION
`target.set` is the correct way to set values in decorators. It supports nested decorators and private fields.