### PR TITLE
Add Task args as argument to Task callbacks

### DIFF
--- a/.changeset/nasty-tomatoes-pretend.md
+++ b/.changeset/nasty-tomatoes-pretend.md
@@ -1,0 +1,5 @@
+---
+'@lit/task': minor
+---
+
+Add Task args to StatusRenderer callbacks


### PR DESCRIPTION
Fixes #4561

This adds the args from the args function as an argument to the callbacks like mentioned here: https://github.com/lit/lit/issues/4561#issuecomment-1964563630

This is my first contribution to the projects, so I tried following CONTRIBUTING.md, but developing on Windows is hard in this project, since executing tests is not possible (other scripts only work in WSL and not natively in windows - at least for me).