### PR TITLE
Expose `parentNode` on `ElementPart`

### DIFF
--- a/.changeset/dirty-moose-happen.md
+++ b/.changeset/dirty-moose-happen.md
@@ -1,0 +1,5 @@
+---
+'lit-html': patch
+---
+
+Expose `parentNode` on `ElementPart`

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -2083,7 +2083,7 @@ class ElementPart implements Disconnectable {
   _$committedValue: undefined;
 
   /** @internal */
-  _$parent!: Disconnectable;
+  _$parent!: TemplateInstance;
 
   /** @internal */
   _$disconnectableChildren?: Set<Disconnectable> = undefined;
@@ -2092,7 +2092,7 @@ class ElementPart implements Disconnectable {
 
   constructor(
     public element: Element,
-    parent: Disconnectable,
+    parent: TemplateInstance,
     options: RenderOptions | undefined,
   ) {
     this._$parent = parent;
@@ -2102,6 +2102,25 @@ class ElementPart implements Disconnectable {
   // See comment in Disconnectable interface for why this is a getter
   get _$isConnected() {
     return this._$parent._$isConnected;
+  }
+
+  /**
+   * The parent node into which the element containing this part renders its
+   * content.
+   */
+  get parentNode(): Node {
+    let parentNode: Node = wrap(this.element).parentNode!;
+    const parent = this._$parent;
+    if (
+      parent !== undefined &&
+      parentNode?.nodeType === 11 /* Node.DOCUMENT_FRAGMENT */
+    ) {
+      // If the parentNode is a DocumentFragment, it may be because the DOM is
+      // still in the cloned fragment during initial render; if so, get the real
+      // parentNode the part will be committed into by asking the parent.
+      parentNode = parent.parentNode;
+    }
+    return parentNode;
   }
 
   _$setValue(value: unknown): void {


### PR DESCRIPTION
If an element directive needs to dispatch a bubbling event, then there may be a problem because the element may not have rendered and is still in a DocumentFragment. Exposing the parentNode will allow users to dispatch bubbling events into the rendered DOM tree.