### PR TITLE
feat(labs/ssr): use RegExp.exec to escape HTML

### DIFF
--- a/packages/labs/ssr/src/lib/util/escape-html.ts
+++ b/packages/labs/ssr/src/lib/util/escape-html.ts
@@ -4,22 +4,57 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-const replacements = {
-  '&': '&amp;',
-  '<': '&lt;',
-  '>': '&gt;',
-  '"': '&quot;',
-  // Note &apos; was not defined in the HTML4 spec, and is not supported by very
-  // old browsers like IE8, so a codepoint entity is used instead.
-  "'": '&#39;',
-};
+const escapePattern = /[&<>"']/g;
 
 /**
  * Replaces characters which have special meaning in HTML (&<>"') with escaped
  * HTML entities ("&amp;", "&lt;", etc.).
  */
-export const escapeHtml = (str: string) =>
-  str.replace(
-    /[&<>"']/g,
-    (char) => replacements[char as keyof typeof replacements]
-  );
+export const escapeHtml = (str: string) => {
+  let match = escapePattern.exec(str);
+
+  if (!match) {
+    return str;
+  }
+
+  let escapeStr;
+  let html = '';
+  let lastIndex = 0;
+
+  while (match) {
+    switch (str.charCodeAt(match.index)) {
+      // Character: "
+      case 34:
+        escapeStr = '&quot;';
+        break;
+      // Character: &
+      case 38:
+        escapeStr = '&amp;';
+        break;
+      // Character: '
+      // Note &apos; was not defined in the HTML4 spec, and is not supported by
+      // very old browsers like IE8, so a codepoint entity is used instead.
+      case 39:
+        escapeStr = '&#39;';
+        break;
+      // Character: <
+      case 60:
+        escapeStr = '&lt;';
+        break;
+      // Character: >
+      case 62:
+        escapeStr = '&gt;';
+        break;
+    }
+
+    html += str.substring(lastIndex, match.index) + escapeStr;
+    lastIndex = match.index + 1;
+    match = escapePattern.exec(str);
+  }
+
+  escapePattern.lastIndex = 0;
+
+  return lastIndex !== str.length - 1
+    ? html + str.substring(lastIndex, str.length)
+    : html;
+};


### PR DESCRIPTION
Switches from using `replace(pattern, fn)` to using the `exec` method of a `RegExp` instead.

This is draft until someone can decide if its a sensible thing to do 😬 

basically, i noticed one of the slow downs compared to other libraries in SSR was this function. it seems `replace(pattern, fn)` is _much_ slower than manually iterating over matches.

I've tried 3 different algorithms and loosely benchmarked them.

### Algorithm 1 (current)

1. Return `str.replace(pattern, fn)` where `fn` returns the replacement character

### Algorithm 2 (this PR)

1. Match against the string with `pattern.exec(str)`
2. If no match, return early (no special chars anywhere)
3. Otherwise, consume the preceding text and the escaped character
4. `exec` the pattern again and repeat this process until there are no matches
5. If the last match wasn't the end of the string, consume the remaining text of the string
6. Return the resulting new string

### Algorithm 3 (React)

1. Match against the string with `pattern.exec(str)`
2. If no match, return early (no special chars anywhere)
3. Otherwise, consume the preceding text and the escaped character
4. Iterate through the remaining characters until we reach another special character (**not using regex**)
5. Repeat from step 3
6. Return the resulting new string once we have reached the end

### Performance

I loosely benchmarked it using 3 strings:
- `"foo <div> bar bar </div> baz"`
  - Algorithm 3 seems to win this one
- `"foo bar baz"
  - Algorithm 2 & 3 win this
- `"foo <div> some very long string which does not contain any more special chars ... "`
  - Algorithm 2 wins this

Algorithm 3 is particularly terrible for strings which contain a few special characters but a lot of text (the 3rd string here).

Algorithm 1 seems slower overall.

Algorithm 2 seems fastest overall.