### PR TITLE
[localize] Move setup code to own file to resolve import loop

### DIFF
--- a/.changeset/chilly-melons-laugh.md
+++ b/.changeset/chilly-melons-laugh.md
@@ -1,5 +1,5 @@
 ---
-"@lit/localize": patch
+'@lit/localize': patch
 ---
 
 Move localize setup to resolve import loop

--- a/.changeset/chilly-melons-laugh.md
+++ b/.changeset/chilly-melons-laugh.md
@@ -1,0 +1,5 @@
+---
+"@lit/localize": patch
+---
+
+Move localize setup to resolve import loop

--- a/packages/localize/src/init/install.ts
+++ b/packages/localize/src/init/install.ts
@@ -1,7 +1,6 @@
 import type {MsgFn} from '../internal/types.js';
 import {defaultMsg} from '../internal/default-msg.js';
 
-
 /**
  * Make a string or lit-html template localizable.
  *
@@ -13,7 +12,6 @@ import {defaultMsg} from '../internal/default-msg.js';
  *   - desc: Optional description
  */
 export let msg: MsgFn = defaultMsg;
-
 
 let installed = false;
 

--- a/packages/localize/src/init/install.ts
+++ b/packages/localize/src/init/install.ts
@@ -1,0 +1,34 @@
+import type {MsgFn} from '../internal/types.js';
+import {defaultMsg} from '../internal/default-msg.js';
+
+
+/**
+ * Make a string or lit-html template localizable.
+ *
+ * @param template A string, a lit-html template, or a function that returns
+ * either a string or lit-html template.
+ * @param options Optional configuration object with the following properties:
+ *   - id: Optional project-wide unique identifier for this template. If
+ *     omitted, an id will be automatically generated from the template strings.
+ *   - desc: Optional description
+ */
+export let msg: MsgFn = defaultMsg;
+
+
+let installed = false;
+
+/**
+ * Internal only. Do not use this function.
+ *
+ * Installs an implementation of the msg function to replace the default
+ * identity function. Throws if called more than once.
+ *
+ * @internal
+ */
+export function _installMsgImplementation(impl: MsgFn) {
+  if (installed) {
+    throw new Error('lit-localize can only be configured once');
+  }
+  msg = impl;
+  installed = true;
+}

--- a/packages/localize/src/init/reentrant.ts
+++ b/packages/localize/src/init/reentrant.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {_installMsgImplementation} from '../lit-localize.js';
 import {runtimeMsg} from '../internal/runtime-msg.js';
 
 import type {
@@ -13,6 +12,7 @@ import type {
   LocaleModule,
   MsgOptions,
 } from '../internal/types.js';
+import {_installMsgImplementation} from './install.js';
 
 /**
  * Configuration parameters for lit-localize when in reentrant mode.

--- a/packages/localize/src/init/runtime.ts
+++ b/packages/localize/src/init/runtime.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {_installMsgImplementation} from '../lit-localize.js';
 import {Deferred} from '../internal/deferred.js';
 import {LOCALE_STATUS_EVENT} from '../internal/locale-status-event.js';
 import {runtimeMsg} from '../internal/runtime-msg.js';
@@ -17,6 +16,7 @@ import type {
   MsgFn,
   MsgOptions,
 } from '../internal/types.js';
+import {_installMsgImplementation} from './install.js';
 
 /**
  * Configuration parameters for lit-localize when in runtime mode.

--- a/packages/localize/src/init/transform.ts
+++ b/packages/localize/src/init/transform.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {_installMsgImplementation} from '../lit-localize.js';
 import {defaultMsg} from '../internal/default-msg.js';
+import {_installMsgImplementation} from './install.js';
 
 /**
  * Configuration parameters for lit-localize when in transform mode.

--- a/packages/localize/src/lit-localize.ts
+++ b/packages/localize/src/lit-localize.ts
@@ -7,7 +7,7 @@
 export * from './internal/locale-status-event.js';
 export * from './internal/str-tag.js';
 export * from './internal/types.js';
-export { msg } from './init/install.js';
+export {msg} from './init/install.js';
 
 // TODO(aomarks) In a future breaking version, remove these imports so that the
 // bulk of the code isn't included in bundles by default. In particular imagine

--- a/packages/localize/src/lit-localize.ts
+++ b/packages/localize/src/lit-localize.ts
@@ -4,13 +4,10 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {defaultMsg} from './internal/default-msg.js';
-
-import type {MsgFn} from './internal/types.js';
-
 export * from './internal/locale-status-event.js';
 export * from './internal/str-tag.js';
 export * from './internal/types.js';
+export { msg } from './init/install.js';
 
 // TODO(aomarks) In a future breaking version, remove these imports so that the
 // bulk of the code isn't included in bundles by default. In particular imagine
@@ -20,33 +17,3 @@ export * from './internal/localized-controller.js';
 export * from './internal/localized-decorator.js';
 export * from './init/runtime.js';
 export * from './init/transform.js';
-
-/**
- * Make a string or lit-html template localizable.
- *
- * @param template A string, a lit-html template, or a function that returns
- * either a string or lit-html template.
- * @param options Optional configuration object with the following properties:
- *   - id: Optional project-wide unique identifier for this template. If
- *     omitted, an id will be automatically generated from the template strings.
- *   - desc: Optional description
- */
-export let msg: MsgFn = defaultMsg;
-
-let installed = false;
-
-/**
- * Internal only. Do not use this function.
- *
- * Installs an implementation of the msg function to replace the default
- * identity function. Throws if called more than once.
- *
- * @internal
- */
-export function _installMsgImplementation(impl: MsgFn) {
-  if (installed) {
-    throw new Error('lit-localize can only be configured once');
-  }
-  msg = impl;
-  installed = true;
-}


### PR DESCRIPTION
Localize has an import loop because submodules are importing from their root. To resolve the loop, `msg`, `installed` and `_installMsgImplementation` are moved to a new submodule.

Imports to `msg` remain intact, through an explicit export.