### PR TITLE
Fix syntax typo in code example in the Context README

### DIFF
--- a/.changeset/pretty-papayas-begin.md
+++ b/.changeset/pretty-papayas-begin.md
@@ -1,0 +1,5 @@
+---
+'@lit/context': patch
+---
+
+Fix syntax typo in code example in the Context README

--- a/packages/context/README.md
+++ b/packages/context/README.md
@@ -97,7 +97,7 @@ export class MyApp extends LitElement {
     log: (msg) => {
       console.log(`[my-app] ${msg}`);
     },
-  });
+  };
 
   protected render(): TemplateResult {
     return html`<my-thing></my-thing>`;


### PR DESCRIPTION
Spotted a typo when copy/pasting a code example.