### PR TITLE
[labs/router] Extend lit-router to support hash-based routing

### DIFF
--- a/packages/labs/router/src/router.ts
+++ b/packages/labs/router/src/router.ts
@@ -68,8 +68,7 @@ export class Router extends Routes {
     e.preventDefault();
     if (href !== location.href) {
       window.history.pushState({}, '', href);
-      anchor
-      this.goto(new URL(origin + anchor.pathname + anchor.search + window.location.hash));
+      this.goto(new URL(origin + anchor.pathname + anchor.search + anchor.hash));
     }
   };
 

--- a/packages/labs/router/src/router.ts
+++ b/packages/labs/router/src/router.ts
@@ -25,7 +25,7 @@ export class Router extends Routes {
     window.addEventListener('click', this._onClick);
     window.addEventListener('popstate', this._onPopState);
     // Kick off routed rendering by going to the current URL
-    this.goto(window.location.pathname);
+    this.goto(new URL(origin + window.location.pathname + window.location.search + window.location.hash));
   }
 
   override hostDisconnected() {
@@ -68,11 +68,12 @@ export class Router extends Routes {
     e.preventDefault();
     if (href !== location.href) {
       window.history.pushState({}, '', href);
-      this.goto(anchor.pathname);
+      anchor
+      this.goto(new URL(origin + anchor.pathname + anchor.search + window.location.hash));
     }
   };
 
   private _onPopState = (_e: PopStateEvent) => {
-    this.goto(window.location.pathname);
+    this.goto(new URL(origin + window.location.pathname + window.location.search + window.location.hash));
   };
 }


### PR DESCRIPTION
lit-router currently only uses the `pathname` to perform the routing. This change extends the routing to `search` and `hash` part of an URL.

This should fix lit/lit#3517 and allow `urlpattern-polyfill` to work correctly (kenchris/urlpattern-polyfill#129) for hash-based routing.

@justinfagnani What are your thoughts on this approach? `tailGroup` has not been adapted yet. I would like to wait for your thoughts before continuing.