### PR TITLE
[labs/virtualizer] improve type and supporting documentation

### DIFF
--- a/packages/labs/virtualizer/README.md
+++ b/packages/labs/virtualizer/README.md
@@ -427,9 +427,12 @@ The types of values you use to represent your items are entirely up to you, as l
 
 ### `renderItem` property
 
-Type: `(item: T, index?: number) => TemplateResult`
+Type: `(item: T, index: number) => unknown`
+Generic type name: `RenderItemFunction`
 
-A function that returns a Lit `TemplateResult`. It will be used to generate a child element for each item in the `items` array.
+A function which the return value can be rendered by lit. It will be used to generate a child element for each item in the `items` array.
+
+The generic type name may be used to provide a type value for `item`. This helps TypeScript in stricter configurations.
 
 ### `scroller` attribute / property
 

--- a/packages/labs/virtualizer/src/virtualize.ts
+++ b/packages/labs/virtualizer/src/virtualize.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {TemplateResult, ChildPart, html, noChange} from 'lit';
+import {ChildPart, html, noChange} from 'lit';
 import {directive, DirectiveResult, PartInfo, PartType} from 'lit/directive.js';
 import {AsyncDirective} from 'lit/async-directive.js';
 import {repeat, KeyFn} from 'lit/directives/repeat.js';
@@ -40,7 +40,7 @@ export interface VirtualizeDirectiveConfig<T> {
 export type RenderItemFunction<T = unknown> = (
   item: T,
   index: number
-) => TemplateResult;
+) => unknown;
 
 export const defaultKeyFunction: KeyFn<unknown> = (item: unknown) => item;
 export const defaultRenderItem: RenderItemFunction<unknown> = (


### PR DESCRIPTION
First, this fixes the `RenderItemFunction` type so it can return any stringable value. Just as lit expects internally for rendering.

Second, the documentation in the readme is updated to reflect the current type definition. As well as adding extra guidance on using the generic to satisfy more strict TypeScript configurations.

Fixes: #4377