### PR TITLE
chore: correct typos

### DIFF
--- a/packages/lit-element/src/lit-element.ts
+++ b/packages/lit-element/src/lit-element.ts
@@ -8,11 +8,11 @@
  * The main LitElement module, which defines the {@linkcode LitElement} base
  * class and related APIs.
  *
- *  LitElement components can define a template and a set of observed
+ * LitElement components can define a template and a set of observed
  * properties. Changing an observed property triggers a re-render of the
  * element.
  *
- *  Import {@linkcode LitElement} and {@linkcode html} from this module to
+ * Import {@linkcode LitElement} and {@linkcode html} from this module to
  * create a component:
  *
  *  ```js

--- a/packages/lit-html/src/directive.ts
+++ b/packages/lit-html/src/directive.ts
@@ -33,7 +33,8 @@ export type DirectiveParameters<C extends Directive> = Parameters<C['render']>;
 export interface DirectiveResult<C extends DirectiveClass = DirectiveClass> {
   /**
    * This property needs to remain unminified.
-   * @internal */
+   * @internal
+   */
   ['_$litDirective$']: C;
   /** @internal */
   values: DirectiveParameters<InstanceType<C>>;

--- a/packages/lit-html/src/directives/class-map.ts
+++ b/packages/lit-html/src/directives/class-map.ts
@@ -111,7 +111,7 @@ class ClassMapDirective extends Directive {
  * This must be used in the `class` attribute and must be the only part used in
  * the attribute. It takes each property in the `classInfo` argument and adds
  * the property name to the element's `classList` if the property value is
- * truthy; if the property value is falsey, the property name is removed from
+ * truthy; if the property value is falsy, the property name is removed from
  * the element's `class`.
  *
  * For example `{foo: bar}` applies the class `foo` if the value of `bar` is

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -672,7 +672,7 @@ export const nothing = Symbol.for('lit-nothing');
 /**
  * The cache of prepared templates, keyed by the tagged TemplateStringsArray
  * and _not_ accounting for the specific template tag used. This means that
- * template tags cannot be dynamic - the must statically be one of html, svg,
+ * template tags cannot be dynamic - they must statically be one of html, svg,
  * or attr. This restriction simplifies the cache lookup, which is on the hot
  * path for rendering.
  */
@@ -745,7 +745,7 @@ function trustFromTemplateString(
   // though we might need to make that check inside of the html and svg
   // functions, because precompiled templates don't come in as
   // TemplateStringArray objects.
-  if (!Array.isArray(tsa) || !tsa.hasOwnProperty('raw')) {
+  if (!isArray(tsa) || !tsa.hasOwnProperty('raw')) {
     let message = 'invalid template strings array';
     if (DEV_MODE) {
       message = `
@@ -1339,8 +1339,8 @@ class ChildPart implements Disconnectable {
   _$parent: Disconnectable | undefined;
   /**
    * Connection state for RootParts only (i.e. ChildPart without _$parent
-   * returned from top-level `render`). This field is unsed otherwise. The
-   * intention would clearer if we made `RootPart` a subclass of `ChildPart`
+   * returned from top-level `render`). This field is unused otherwise. The
+   * intention would be clearer if we made `RootPart` a subclass of `ChildPart`
    * with this field (and a different _$isConnected getter), but the subclass
    * caused a perf regression, possibly due to making call sites polymorphic.
    * @internal
@@ -1516,7 +1516,7 @@ class ChildPart implements Disconnectable {
                 `This is a security risk, as style injection attacks can ` +
                 `exfiltrate data and spoof UIs. ` +
                 `Consider instead using css\`...\` literals ` +
-                `to compose styles, and make do dynamic styling with ` +
+                `to compose styles, and do dynamic styling with ` +
                 `css custom properties, ::parts, <slot>s, ` +
                 `and by mutating the DOM rather than stylesheets.`;
             } else {
@@ -1745,7 +1745,7 @@ class ChildPart implements Disconnectable {
     }
   }
   /**
-   * Implementation of RootPart's `isConnected`. Note that this metod
+   * Implementation of RootPart's `isConnected`. Note that this method
    * should only be called on `RootPart`s (the `ChildPart` returned from a
    * top-level `render()` call). It has no effect on non-root ChildParts.
    * @param isConnected Whether to set
@@ -1789,11 +1789,11 @@ export interface RootPart extends ChildPart {
 
 export type {AttributePart};
 class AttributePart implements Disconnectable {
-  readonly type = ATTRIBUTE_PART as
+  readonly type:
     | typeof ATTRIBUTE_PART
     | typeof PROPERTY_PART
     | typeof BOOLEAN_ATTRIBUTE_PART
-    | typeof EVENT_PART;
+    | typeof EVENT_PART = ATTRIBUTE_PART;
   readonly element: HTMLElement;
   readonly name: string;
   readonly options: RenderOptions | undefined;
@@ -2157,7 +2157,7 @@ class ElementPart implements Disconnectable {
  * external users.
  *
  * We currently do not make a mangled rollup build of the lit-ssr code. In order
- * to keep a number of (otherwise private) top-level exports  mangled in the
+ * to keep a number of (otherwise private) top-level exports mangled in the
  * client side code, we export a _$LH object containing those members (or
  * helper methods for accessing private fields of those members), and then
  * re-export them for use in lit-ssr. This keeps lit-ssr agnostic to whether the

--- a/packages/lit-html/src/static.ts
+++ b/packages/lit-html/src/static.ts
@@ -20,7 +20,7 @@ export interface StaticValue {
 
   /**
    * A value that can't be decoded from ordinary JSON, make it harder for
-   * a attacker-controlled data that goes through JSON.parse to produce a valid
+   * an attacker-controlled data that goes through JSON.parse to produce a valid
    * StaticValue.
    */
   r: typeof brand;

--- a/packages/reactive-element/src/reactive-element.ts
+++ b/packages/reactive-element/src/reactive-element.ts
@@ -1009,7 +1009,7 @@ export abstract class ReactiveElement
       (res) => (this.enableUpdating = res)
     );
     this._$changedProperties = new Map();
-    // This enqueues a microtask that ust run before the first update, so it
+    // This enqueues a microtask that must run before the first update, so it
     // must be called before requestUpdate()
     this.__saveInstanceProperties();
     // ensures first update will be caught by an early access of


### PR DESCRIPTION
I read though the entire source code of the main `lit*` packages and detected a few minor typos