### PR TITLE
[labs/preact-signals] Ensure disconnecting a SignalWatcher removes signal subscriptions

### DIFF
--- a/.changeset/slimy-radios-rhyme.md
+++ b/.changeset/slimy-radios-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/preact-signals': patch
+---
+
+Ensure disconnecting a SignalWatcher removes signal subscriptions

--- a/packages/labs/preact-signals/src/lib/signal-watcher.ts
+++ b/packages/labs/preact-signals/src/lib/signal-watcher.ts
@@ -66,6 +66,7 @@ export function SignalWatcher<T extends ReactiveElementConstructor>(
     }
 
     override disconnectedCallback(): void {
+      this.performUpdate();
       super.disconnectedCallback();
       this.__dispose?.();
     }


### PR DESCRIPTION
Fixes #4705 by ensuring any pending update completes before disconnecting the element and removing signal subscriptions.