### PR TITLE
collectResult "result is not iterable" when recursing non-lit custom elements #4711

### DIFF
--- a/packages/labs/ssr/src/lib/render-result.ts
+++ b/packages/labs/ssr/src/lib/render-result.ts
@@ -24,9 +24,11 @@ export type RenderResult = Iterable<string | Promise<RenderResult>>;
  */
 export const collectResult = async (result: RenderResult): Promise<string> => {
   let value = '';
-  for (const chunk of result) {
-    value +=
-      typeof chunk === 'string' ? chunk : await collectResult(await chunk);
+  if (result) {
+    for (const chunk of result) {
+      value +=
+        typeof chunk === 'string' ? chunk : await collectResult(await chunk);
+    }
   }
   return value;
 };


### PR DESCRIPTION
PR for patch mentioned in https://github.com/lit/lit/issues/4711

Simple check to ensure that if there are web component definitions that fail it still attempts to deliver the template result for those that worked.