### PR TITLE
Ensures initial change old value is always `undefined` when using `@property`

### DIFF
--- a/.changeset/good-bags-lie.md
+++ b/.changeset/good-bags-lie.md
@@ -1,0 +1,5 @@
+---
+'@lit/reactive-element': patch
+---
+
+Ensure initial property changed old value is always `undefined`, when using @property decorator

--- a/packages/reactive-element/src/decorators/property.ts
+++ b/packages/reactive-element/src/decorators/property.ts
@@ -127,6 +127,9 @@ export const standardProperty = <C extends Interface<ReactiveElement>, V>(
   if (properties === undefined) {
     globalThis.litPropertyMetadata.set(metadata, (properties = new Map()));
   }
+  if (kind === 'setter') {
+    options = {...options, wrapped: true};
+  }
   properties.set(context.name, options);
 
   if (kind === 'accessor') {

--- a/packages/reactive-element/src/reactive-element.ts
+++ b/packages/reactive-element/src/reactive-element.ts
@@ -1421,12 +1421,11 @@ export abstract class ReactiveElement
         .elementProperties;
       if (elementProperties.size > 0) {
         for (const [p, options] of elementProperties) {
-          if (
-            options.wrapped === true &&
-            !this._$changedProperties.has(p) &&
-            this[p as keyof this] !== undefined
-          ) {
-            this._$changeProperty(p, this[p as keyof this], options);
+          if (options.wrapped === true && this[p as keyof this] !== undefined) {
+            // Note, deleting an existing value here ensures
+            // the initial old value is seeded as `undefined`
+            this._$changedProperties.delete(p);
+            this._$changeProperty(p, undefined, options);
           }
         }
       }

--- a/packages/reactive-element/src/test/decorators-modern/property_test.ts
+++ b/packages/reactive-element/src/test/decorators-modern/property_test.ts
@@ -193,6 +193,46 @@ suite('@property', () => {
     assert.equal(el.getAttribute('foo'), '7');
   });
 
+  test('reports initial changes to properties', async () => {
+    let changedProperties: PropertyValues | undefined;
+
+    class E extends ReactiveElement {
+      @property() accessor unValued = undefined;
+      @property() accessor valued = 'valued';
+      _valuedAccessor = 'valuedAccessor';
+      @property()
+      set valuedAccessor(v) {
+        this._valuedAccessor = v;
+      }
+      get valuedAccessor() {
+        return this._valuedAccessor;
+      }
+
+      _unValuedAccessor?: string;
+      @property()
+      set unValuedAccessor(v) {
+        this._unValuedAccessor = v;
+      }
+      get unValuedAccessor() {
+        return this._unValuedAccessor;
+      }
+
+      override update(changed: PropertyValues) {
+        changedProperties = changed;
+        super.update(changed);
+      }
+    }
+    customElements.define(generateElementName(), E);
+    const el = new E();
+    container.appendChild(el);
+    await el.updateComplete;
+    const expectedChanges = new Map([
+      ['valued', undefined],
+      ['valuedAccessor', undefined],
+    ]);
+    assert.deepEqual(changedProperties, expectedChanges);
+  });
+
   test('can mix property options via decorator and via getter', async () => {
     const hasChanged = (value: any, old: any) =>
       old === undefined || value > old;

--- a/packages/reactive-element/src/test/decorators/property_test.ts
+++ b/packages/reactive-element/src/test/decorators/property_test.ts
@@ -488,6 +488,53 @@ suite('@property', () => {
     assert.deepEqual(el._observedZot2, {value: 'zot', oldValue: ''});
   });
 
+  test('reports initial changes to properties', async () => {
+    let changedProperties: PropertyValues | undefined;
+
+    class E extends ReactiveElement {
+      @property() unValued?: string;
+      @property() valued = 'valued';
+
+      _valuedAccessor = 'valuedAccessor';
+
+      @property()
+      accessor valuedAutoAccessor = 'valuedAutoAccessor';
+
+      @property()
+      set valuedAccessor(v) {
+        this._valuedAccessor = v;
+      }
+      get valuedAccessor() {
+        return this._valuedAccessor;
+      }
+
+      _unValuedAccessor?: string;
+
+      @property()
+      set unValuedAccessor(v) {
+        this._unValuedAccessor = v;
+      }
+      get unValuedAccessor() {
+        return this._unValuedAccessor;
+      }
+
+      override update(changed: PropertyValues) {
+        changedProperties = changed;
+        super.update(changed);
+      }
+    }
+    customElements.define(generateElementName(), E);
+    const el = new E();
+    container.appendChild(el);
+    await el.updateComplete;
+    const expectedChanges = new Map([
+      ['valued', undefined],
+      ['valuedAccessor', undefined],
+      ['valuedAutoAccessor', undefined],
+    ]);
+    assert.deepEqual(changedProperties, expectedChanges);
+  });
+
   test('can handle some unreasonable property declarations', async () => {
     class PropertyOnSetterOnly extends ReactiveElement {
       @property()


### PR DESCRIPTION
Fixes #4721.