### PR TITLE
[labs/testing] Add option for init script for ssr worker to allow registering Node.js hooks

### DIFF
--- a/.changeset/wicked-rules-repeat.md
+++ b/.changeset/wicked-rules-repeat.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/testing': patch
+---
+
+Add option for init script for ssr worker to allow registering Node.js hooks

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@rollup/plugin-virtual": "^3.0.2",
         "@types/chai": "^4.3.1",
         "@types/mocha": "^9.1.1",
-        "@types/node": "^16.11.44",
+        "@types/node": "^18.19.44",
         "@typescript-eslint/eslint-plugin": "^6.4.1",
         "@typescript-eslint/parser": "^6.4.1",
         "@web/dev-server": "^0.1.32",
@@ -8876,9 +8876,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "16.18.74",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.74.tgz",
-      "integrity": "sha512-eEn8RkzZFcT0gb8qyi0CcfSOQnLE+NbGLIIaxGGmjn/N35v/C3M8ohxcpSlNlCv+H8vPpMGmrGDdCkzr8xu2tQ=="
+      "version": "18.19.44",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.44.tgz",
+      "integrity": "sha512-ZsbGerYg72WMXUIE9fYxtvfzLEuq6q8mKERdWFnqTmOvudMxnz+CBNRoOwJ2kNpFOncrKjT1hZwxjlFgQ9qvQA==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -9535,15 +9538,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/@wdio/config/node_modules/@types/node": {
-      "version": "18.19.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.8.tgz",
-      "integrity": "sha512-g1pZtPhsvGVTwmeVoexWZLTQaOvXwoSq//pTL0DHeNzUDrFnir4fgETdhjhIxjVnN+hKOuh98+E1eMLnUXstFg==",
-      "dev": true,
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
     "node_modules/@wdio/config/node_modules/@wdio/types": {
       "version": "7.26.0",
       "dev": true,
@@ -9742,15 +9736,6 @@
       },
       "engines": {
         "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@wdio/utils/node_modules/@types/node": {
-      "version": "18.19.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.8.tgz",
-      "integrity": "sha512-g1pZtPhsvGVTwmeVoexWZLTQaOvXwoSq//pTL0DHeNzUDrFnir4fgETdhjhIxjVnN+hKOuh98+E1eMLnUXstFg==",
-      "dev": true,
-      "dependencies": {
-        "undici-types": "~5.26.4"
       }
     },
     "node_modules/@wdio/utils/node_modules/@wdio/types": {
@@ -14483,15 +14468,6 @@
       "version": "0.0.981744",
       "dev": true,
       "license": "BSD-3-Clause"
-    },
-    "node_modules/devtools/node_modules/@types/node": {
-      "version": "18.19.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.8.tgz",
-      "integrity": "sha512-g1pZtPhsvGVTwmeVoexWZLTQaOvXwoSq//pTL0DHeNzUDrFnir4fgETdhjhIxjVnN+hKOuh98+E1eMLnUXstFg==",
-      "dev": true,
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
     },
     "node_modules/devtools/node_modules/@wdio/types": {
       "version": "7.26.0",
@@ -28331,6 +28307,12 @@
         "typescript-json-schema": "bin/typescript-json-schema"
       }
     },
+    "node_modules/typescript-json-schema/node_modules/@types/node": {
+      "version": "16.18.105",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.105.tgz",
+      "integrity": "sha512-w2d0Z9yMk07uH3+Cx0N8lqFyi3yjXZxlbYappPj+AsOlT02OyxyiuNoNHdGt6EuiSm8Wtgp2YV7vWg+GMFrvFA==",
+      "dev": true
+    },
     "node_modules/typescript-json-schema/node_modules/ansi-regex": {
       "version": "5.0.1",
       "dev": true,
@@ -29108,15 +29090,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/webdriver/node_modules/@types/node": {
-      "version": "18.19.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.8.tgz",
-      "integrity": "sha512-g1pZtPhsvGVTwmeVoexWZLTQaOvXwoSq//pTL0DHeNzUDrFnir4fgETdhjhIxjVnN+hKOuh98+E1eMLnUXstFg==",
-      "dev": true,
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
     "node_modules/webdriver/node_modules/@wdio/types": {
       "version": "7.26.0",
       "dev": true,
@@ -29186,15 +29159,6 @@
       },
       "engines": {
         "node": ">=12.0.0"
-      }
-    },
-    "node_modules/webdriverio/node_modules/@types/node": {
-      "version": "18.19.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.8.tgz",
-      "integrity": "sha512-g1pZtPhsvGVTwmeVoexWZLTQaOvXwoSq//pTL0DHeNzUDrFnir4fgETdhjhIxjVnN+hKOuh98+E1eMLnUXstFg==",
-      "dev": true,
-      "dependencies": {
-        "undici-types": "~5.26.4"
       }
     },
     "node_modules/webdriverio/node_modules/@wdio/types": {
@@ -30118,6 +30082,11 @@
         "@types/marked": "^4.0.3",
         "@types/puppeteer": "^5.4.6"
       }
+    },
+    "packages/internal-scripts/node_modules/@types/node": {
+      "version": "16.18.105",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.105.tgz",
+      "integrity": "sha512-w2d0Z9yMk07uH3+Cx0N8lqFyi3yjXZxlbYappPj+AsOlT02OyxyiuNoNHdGt6EuiSm8Wtgp2YV7vWg+GMFrvFA=="
     },
     "packages/labs/analyzer": {
       "name": "@lit-labs/analyzer",
@@ -31163,6 +31132,11 @@
       "dependencies": {
         "undici-types": "~5.26.4"
       }
+    },
+    "packages/labs/ssr/node_modules/@types/node": {
+      "version": "16.18.105",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.105.tgz",
+      "integrity": "sha512-w2d0Z9yMk07uH3+Cx0N8lqFyi3yjXZxlbYappPj+AsOlT02OyxyiuNoNHdGt6EuiSm8Wtgp2YV7vWg+GMFrvFA=="
     },
     "packages/labs/ssr/node_modules/parse5": {
       "version": "7.1.2",

--- a/package.json
+++ b/package.json
@@ -270,7 +270,7 @@
     "@rollup/plugin-virtual": "^3.0.2",
     "@types/chai": "^4.3.1",
     "@types/mocha": "^9.1.1",
-    "@types/node": "^16.11.44",
+    "@types/node": "^18.19.44",
     "@typescript-eslint/eslint-plugin": "^6.4.1",
     "@typescript-eslint/parser": "^6.4.1",
     "@web/dev-server": "^0.1.32",

--- a/packages/labs/testing/README.md
+++ b/packages/labs/testing/README.md
@@ -43,9 +43,7 @@ Signature
 `litSsrPlugin(options: LitSsrPluginOptions = {}): TestRunnerPlugin<Payload>`
 
 - `options: object` - Options object containing the following properties
-  - `workerInitModules: string` - Relative paths to modules to be loaded before
-    the fixture modules.
-    This allows registering e.g. Node.js ESM hooks or general setup.
+  - `workerInitModules: string` - Modules to be loaded before the fixture modules. This allows registering e.g. Node.js ESM hooks or general setup. Accepts absolute paths, paths relative to the working directory, or external package modules.
 
 ### Fixtures
 

--- a/packages/labs/testing/README.md
+++ b/packages/labs/testing/README.md
@@ -38,6 +38,15 @@ export default {
 };
 ```
 
+Signature
+
+`litSsrPlugin(options: LitSsrPluginOptions = {}): TestRunnerPlugin<Payload>`
+
+- `options: object` - Options object containing the following properties
+  - `workerInitModules: string` - Relative paths to modules to be loaded before
+    the fixture modules.
+    This allows registering e.g. Node.js ESM hooks or general setup.
+
 ### Fixtures
 
 The package exports functions that will generate fixtures by passing the

--- a/packages/labs/testing/src/test/init-script-hooks.ts
+++ b/packages/labs/testing/src/test/init-script-hooks.ts
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {existsSync, readFileSync} from 'node:fs';
+import type {LoadHook, ResolveHook} from 'node:module';
+import {fileURLToPath} from 'node:url';
+
+import * as ts from 'typescript';
+
+/**
+ * Note: This is not a performant hook implementation,
+ * but serves its purpose for testing.
+ */
+
+const root = new URL('../', import.meta.url).href;
+const tsconfigPath = new URL('./tsconfig.json', root).href;
+const tsconfig = ts.getParsedCommandLineOfConfigFile(
+  fileURLToPath(tsconfigPath),
+  {},
+  ts.sys as unknown as ts.ParseConfigFileHost
+);
+
+const exists = (url: string) => existsSync(fileURLToPath(url));
+const assertTypeScriptFilePath = (
+  url: string,
+  tsUrl = url.replace(/.js$/, '.ts')
+) => (tsUrl && url && !exists(url) && exists(tsUrl) ? tsUrl : null);
+
+export const resolve: ResolveHook = (specifier, context, nextResolve) => {
+  const url =
+    (specifier.startsWith('.') || specifier.startsWith(root)) &&
+    !specifier.includes('/node_modules/') &&
+    context.parentURL?.startsWith(root)
+      ? assertTypeScriptFilePath(new URL(specifier, context.parentURL).href)
+      : null;
+  return url
+    ? {format: 'module', shortCircuit: true, url}
+    : nextResolve(specifier, context);
+};
+
+export const load: LoadHook = (url, context, nextLoad) => {
+  if (
+    url.startsWith(root) &&
+    !url.includes('/node_modules/') &&
+    url.endsWith('.ts')
+  ) {
+    const source = readFileSync(fileURLToPath(url), 'utf8');
+    const result = ts.transpileModule(source, {
+      compilerOptions: tsconfig?.options,
+    });
+    return {format: 'module', shortCircuit: true, source: result.outputText};
+  }
+  return nextLoad(url, context);
+};

--- a/packages/labs/testing/src/test/init-script-hooks.ts
+++ b/packages/labs/testing/src/test/init-script-hooks.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2022 Google LLC
+ * Copyright 2024 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/labs/testing/src/test/init-script.ts
+++ b/packages/labs/testing/src/test/init-script.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2022 Google LLC
+ * Copyright 2024 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/labs/testing/src/test/init-script.ts
+++ b/packages/labs/testing/src/test/init-script.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {register} from 'node:module';
+
+register(new URL('./init-script-hooks.js', import.meta.url));

--- a/packages/labs/testing/src/test/init-script_test.ts
+++ b/packages/labs/testing/src/test/init-script_test.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2022 Google LLC
+ * Copyright 2024 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/labs/testing/src/test/init-script_test.ts
+++ b/packages/labs/testing/src/test/init-script_test.ts
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {
+  ssrNonHydratedFixture,
+  ssrHydratedFixture,
+  cleanupFixtures,
+} from '../fixtures.js';
+
+import {html} from 'lit';
+import {assert} from '@open-wc/testing';
+
+import './good-element.js';
+
+teardown(() => {
+  cleanupFixtures();
+});
+
+for (const fixture of [ssrNonHydratedFixture, ssrHydratedFixture]) {
+  suite(`init-script rendered with ${fixture.name}`, () => {
+    test('renders good-element', async () => {
+      const el = await fixture(html`<good-element></good-element>`, {
+        base: import.meta.url,
+        modules: ['../src/test/good-element.ts'],
+      });
+      assert.shadowDom.equal(
+        el,
+        `
+          <h1>Hello, World!</h1>
+          <button part="button">Click Count: 0</button>
+          <slot></slot>
+        `
+      );
+    });
+  });
+}

--- a/packages/labs/testing/src/web-test-runner-ssr-plugin.ts
+++ b/packages/labs/testing/src/web-test-runner-ssr-plugin.ts
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-export {litSsrPlugin} from './lib/lit-ssr-plugin.js';
+export {litSsrPlugin, LitSsrPluginOptions} from './lib/lit-ssr-plugin.js';

--- a/packages/labs/testing/tsconfig.json
+++ b/packages/labs/testing/tsconfig.json
@@ -19,7 +19,8 @@
     "tsBuildInfoFile": ".tsbuildinfo",
     "allowSyntheticDefaultImports": true,
     "experimentalDecorators": true,
-    "types": ["mocha"]
+    "types": ["mocha"],
+    "skipLibCheck": true
   },
   "include": ["src/**/*"],
   "exclude": ["src/index.ts", "src/lib/utils.ts"]

--- a/packages/labs/testing/web-test-runner.config.js
+++ b/packages/labs/testing/web-test-runner.config.js
@@ -28,7 +28,7 @@ const config = {
       timeout: '60000',
     },
   },
-  plugins: [litSsrPlugin()],
+  plugins: [litSsrPlugin({workerInitModules: ['./test/init-script.js']})],
 };
 
 export default config;


### PR DESCRIPTION
This PR adds an option to the `litSsrPlugin` to allow defining worker init modules, which are sequentially imported at the start of the SSR worker. This allows registering Node.js hooks (https://nodejs.org/api/module.html#customization-hooks) or general setup.