### PR TITLE
[labs/testing] Add fallback for call site location detection for webkit

### DIFF
--- a/.changeset/rude-cherries-cover.md
+++ b/.changeset/rude-cherries-cover.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/testing': patch
+---
+
+Add fallback for call site location detection for webkit

--- a/packages/labs/testing/src/lib/fixtures/csr-fixture.ts
+++ b/packages/labs/testing/src/lib/fixtures/csr-fixture.ts
@@ -37,7 +37,24 @@ export async function csrFixture<T extends HTMLElement>(
     // asyncFunctionResume@[native code]
     // @http://localhost:8000/test/my-element_test.js?wtr-session-id=aKWON-wBOBGyzb2CwIvmK:65:37
     const {stack} = new Error();
-    const match = stack?.match(/http:\/\/localhost.+(?=\?wtr-session-id)/);
+    const match =
+      stack?.match(/http:\/\/localhost.+(?=\?wtr-session-id)/) ??
+      // Looking for wtr-session-id might not work in webkit. See https://github.com/lit/lit/issues/4067
+      // As a fallback, we look for the first file which is not inside node_modules and
+      // is not this csr-fixture file.
+      //
+      // Webkit Stack:
+      // @http://localhost:8000/lib/fixtures/ssr-fixture.js:38:36
+      // ssrFixture@http://localhost:8000/lib/fixtures/ssr-fixture.js:19:34
+      // ssrNonHydratedFixture@http://localhost:8000/lib/fixtures/ssr-fixture.js:98:45
+      // @http://localhost:8000/test/my-element_test.js:20:37
+      [...(stack?.matchAll(/http:\/\/localhost:?[^:)]+/gm) ?? [])]
+        .map((m) => m[0])
+        .filter(
+          (u) =>
+            !u.includes('/node_modules/') &&
+            !u.includes('/lib/fixtures/csr-fixture.js')
+        );
     if (!match) {
       throw new Error(
         `Could not find call site for csrFixture in stack:\n${stack}`

--- a/packages/labs/testing/src/test/good-element_test.ts
+++ b/packages/labs/testing/src/test/good-element_test.ts
@@ -28,7 +28,6 @@ for (const fixture of [csrFixture, ssrNonHydratedFixture, ssrHydratedFixture]) {
 
     test('renders with default values', async () => {
       const el = await fixture(html`<good-element></good-element>`, {
-        base: import.meta.url,
         modules: ['./good-element.js'],
       });
       assert.shadowDom.equal(
@@ -45,7 +44,6 @@ for (const fixture of [csrFixture, ssrNonHydratedFixture, ssrHydratedFixture]) {
       const el = await fixture(
         html`<good-element name="Test"></good-element>`,
         {
-          base: import.meta.url,
           modules: ['./good-element.js'],
         }
       );
@@ -63,7 +61,6 @@ for (const fixture of [csrFixture, ssrNonHydratedFixture, ssrHydratedFixture]) {
       const el = await fixture<GoodElement>(
         html`<good-element></good-element>`,
         {
-          base: import.meta.url,
           modules: ['./good-element.js'],
         }
       );
@@ -76,7 +73,6 @@ for (const fixture of [csrFixture, ssrNonHydratedFixture, ssrHydratedFixture]) {
         const el = await fixture<GoodElement>(
           html`<good-element></good-element>`,
           {
-            base: import.meta.url,
             modules: ['./good-element.js'],
           }
         );
@@ -98,7 +94,6 @@ for (const fixture of [csrFixture, ssrNonHydratedFixture, ssrHydratedFixture]) {
   suite(`nested good-element rendered with ${fixture.name}`, () => {
     test('renders with default values', async () => {
       const el = await fixture(html`<div><good-element></good-element></div>`, {
-        base: import.meta.url,
         modules: ['./good-element.js'],
       });
       const goodEl = el.querySelector('good-element');
@@ -117,7 +112,6 @@ for (const fixture of [csrFixture, ssrNonHydratedFixture, ssrHydratedFixture]) {
       const el = await fixture(
         html`<div><good-element name="Test"></good-element></div>`,
         {
-          base: import.meta.url,
           modules: ['./good-element.js'],
         }
       );
@@ -133,7 +127,6 @@ for (const fixture of [csrFixture, ssrNonHydratedFixture, ssrHydratedFixture]) {
 
     test('styling applied', async () => {
       const el = await fixture(html`<div><good-element></good-element></div>`, {
-        base: import.meta.url,
         modules: ['./good-element.js'],
       });
       assert.equal(
@@ -148,7 +141,6 @@ for (const fixture of [csrFixture, ssrNonHydratedFixture, ssrHydratedFixture]) {
         const el = await fixture(
           html`<div><good-element></good-element></div>`,
           {
-            base: import.meta.url,
             modules: ['./good-element.js'],
           }
         );


### PR DESCRIPTION
The fixtures currently look for the wtr-session-id query string. This PR adds a fallback, when wtr-session-id is not found, to look for the first URL that does not contain node_modules or the path to the fixture file.

Fixes #4067