### PR TITLE
perf(context): skip expensive computation of Event.composedPath()

### DIFF
--- a/.changeset/ninety-dogs-dance.md
+++ b/.changeset/ninety-dogs-dance.md
@@ -1,0 +1,5 @@
+---
+'@lit/context': patch
+---
+
+Avoid calling Event.composedPath() when it is not needed

--- a/packages/context/src/lib/context-request-event.ts
+++ b/packages/context/src/lib/context-request-event.ts
@@ -30,6 +30,7 @@ export type ContextCallback<ValueType> = (
  */
 export interface ContextRequest<C extends Context<unknown, unknown>> {
   readonly context: C;
+  readonly contextTarget: Element;
   readonly callback: ContextCallback<ContextType<C>>;
   readonly subscribe?: boolean;
 }
@@ -52,22 +53,26 @@ export class ContextRequestEvent<C extends Context<unknown, unknown>>
   implements ContextRequest<C>
 {
   readonly context: C;
+  readonly contextTarget: Element;
   readonly callback: ContextCallback<ContextType<C>>;
   readonly subscribe?: boolean;
 
   /**
    *
    * @param context the context key to request
+   * @param contextTarget the original context target of the requester
    * @param callback the callback that should be invoked when the context with the specified key is available
    * @param subscribe when, true indicates we want to subscribe to future updates
    */
   constructor(
     context: C,
+    contextTarget: Element,
     callback: ContextCallback<ContextType<C>>,
     subscribe?: boolean
   ) {
     super('context-request', {bubbles: true, composed: true});
     this.context = context;
+    this.contextTarget = contextTarget;
     this.callback = callback;
     this.subscribe = subscribe ?? false;
   }

--- a/packages/context/src/lib/context-root.ts
+++ b/packages/context/src/lib/context-root.ts
@@ -97,7 +97,8 @@ export class ContextRoot {
     // Note, it's important to use the initial target
     // since that's the requesting element and the event may be re-targeted
     // to an outer host element.
-    const element = event.contextTarget as HTMLElement;
+    const element = (event.contextTarget ??
+      event.composedPath()[0]) as HTMLElement;
     const callback = event.callback;
 
     let pendingContextRequests = this.pendingContextRequests.get(event.context);

--- a/packages/context/src/lib/context-root.ts
+++ b/packages/context/src/lib/context-root.ts
@@ -80,7 +80,7 @@ export class ContextRoot {
       } else {
         // Re-dispatch if we still have the element and callback
         element.dispatchEvent(
-          new ContextRequestEvent(event.context, callback, true)
+          new ContextRequestEvent(event.context, element, callback, true)
         );
       }
     }

--- a/packages/context/src/lib/context-root.ts
+++ b/packages/context/src/lib/context-root.ts
@@ -94,10 +94,10 @@ export class ContextRoot {
       return;
     }
 
-    // Note, it's important to use the initial target via composedPath()
+    // Note, it's important to use the initial target
     // since that's the requesting element and the event may be re-targeted
     // to an outer host element.
-    const element = event.composedPath()[0] as HTMLElement;
+    const element = event.contextTarget as HTMLElement;
     const callback = event.callback;
 
     let pendingContextRequests = this.pendingContextRequests.get(event.context);

--- a/packages/context/src/lib/controllers/context-consumer.ts
+++ b/packages/context/src/lib/controllers/context-consumer.ts
@@ -91,7 +91,12 @@ export class ContextConsumer<
 
   private dispatchRequest() {
     this.host.dispatchEvent(
-      new ContextRequestEvent(this.context, this._callback, this.subscribe)
+      new ContextRequestEvent(
+        this.context,
+        this.host,
+        this._callback,
+        this.subscribe
+      )
     );
   }
 

--- a/packages/context/src/lib/controllers/context-provider.ts
+++ b/packages/context/src/lib/controllers/context-provider.ts
@@ -97,23 +97,13 @@ export class ContextProvider<
     if (ev.context !== this.context) {
       return;
     }
-    let consumerHost: Element | undefined;
     // Also, in case an element is a consumer AND a provider
     // of the same context, we want to avoid the element to self-register.
-    if (ev.target === this.host) {
-      // The check on composedPath (on top of ev.target) is to cover cases
-      // where the consumer is in the shadowDom of the provider.
-      consumerHost = ev.composedPath()[0] as Element;
-      if (consumerHost === this.host) {
-        return;
-      }
+    if (ev.contextTarget === this.host) {
+      return;
     }
     ev.stopPropagation();
-    this.addCallback(
-      ev.callback,
-      consumerHost ?? (ev.target as Element),
-      ev.subscribe
-    );
+    this.addCallback(ev.callback, ev.contextTarget, ev.subscribe);
   };
 
   /**
@@ -162,7 +152,7 @@ export class ContextProvider<
       }
       seen.add(callback);
       consumerHost.dispatchEvent(
-        new ContextRequestEvent(this.context, callback, true)
+        new ContextRequestEvent(this.context, consumerHost, callback, true)
       );
     }
     ev.stopPropagation();

--- a/packages/context/src/lib/controllers/context-provider.ts
+++ b/packages/context/src/lib/controllers/context-provider.ts
@@ -97,19 +97,23 @@ export class ContextProvider<
     if (ev.context !== this.context) {
       return;
     }
+    let consumerHost: Element | undefined;
     // Also, in case an element is a consumer AND a provider
     // of the same context, we want to avoid the element to self-register.
     if (ev.target === this.host) {
-      return;
-    }
-    // The check on composedPath (on top of ev.target) is to cover cases
-    // where the consumer is in the shadowDom of the provider.
-    const consumerHost = ev.composedPath()[0] as Element;
-    if (consumerHost === this.host) {
-      return;
+      // The check on composedPath (on top of ev.target) is to cover cases
+      // where the consumer is in the shadowDom of the provider.
+      consumerHost = ev.composedPath()[0] as Element;
+      if (consumerHost === this.host) {
+        return;
+      }
     }
     ev.stopPropagation();
-    this.addCallback(ev.callback, consumerHost, ev.subscribe);
+    this.addCallback(
+      ev.callback,
+      consumerHost ?? (ev.target as Element),
+      ev.subscribe
+    );
   };
 
   /**

--- a/packages/context/src/lib/controllers/context-provider.ts
+++ b/packages/context/src/lib/controllers/context-provider.ts
@@ -99,9 +99,11 @@ export class ContextProvider<
     }
     // Also, in case an element is a consumer AND a provider
     // of the same context, we want to avoid the element to self-register.
-    // The check on composedPath (as opposed to ev.target) is to cover cases
-    // where the consumer is in the shadowDom of the provider (in which case,
-    // event.target === this.host because of event retargeting).
+    if (ev.target === this.host) {
+      return;
+    }
+    // The check on composedPath (on top of ev.target) is to cover cases
+    // where the consumer is in the shadowDom of the provider.
     const consumerHost = ev.composedPath()[0] as Element;
     if (consumerHost === this.host) {
       return;
@@ -125,9 +127,11 @@ export class ContextProvider<
     }
     // Also, in case an element is a consumer AND a provider
     // of the same context it shouldn't provide to itself.
-    // We use composedPath (as opposed to ev.target) to cover cases
-    // where the consumer is in the shadowDom of the provider (in which case,
-    // event.target === this.host because of event retargeting).
+    if (ev.target === this.host) {
+      return;
+    }
+    // We use composedPath (on top of ev.target) to cover cases
+    // where the consumer is in the shadowDom of the provider.
     const childProviderHost = ev.composedPath()[0] as Element;
     if (childProviderHost === this.host) {
       return;

--- a/packages/context/src/lib/controllers/context-provider.ts
+++ b/packages/context/src/lib/controllers/context-provider.ts
@@ -94,13 +94,16 @@ export class ContextProvider<
     ev: ContextRequestEvent<Context<unknown, unknown>>
   ): void => {
     // Only call the callback if the context matches.
+    if (ev.context !== this.context) {
+      return;
+    }
     // Also, in case an element is a consumer AND a provider
     // of the same context, we want to avoid the element to self-register.
     // The check on composedPath (as opposed to ev.target) is to cover cases
     // where the consumer is in the shadowDom of the provider (in which case,
     // event.target === this.host because of event retargeting).
     const consumerHost = ev.composedPath()[0] as Element;
-    if (ev.context !== this.context || consumerHost === this.host) {
+    if (consumerHost === this.host) {
       return;
     }
     ev.stopPropagation();
@@ -117,13 +120,16 @@ export class ContextProvider<
     ev: ContextProviderEvent<Context<unknown, unknown>>
   ): void => {
     // Ignore events when the context doesn't match.
+    if (ev.context !== this.context) {
+      return;
+    }
     // Also, in case an element is a consumer AND a provider
     // of the same context it shouldn't provide to itself.
     // We use composedPath (as opposed to ev.target) to cover cases
     // where the consumer is in the shadowDom of the provider (in which case,
     // event.target === this.host because of event retargeting).
     const childProviderHost = ev.composedPath()[0] as Element;
-    if (ev.context !== this.context || childProviderHost === this.host) {
+    if (childProviderHost === this.host) {
       return;
     }
     // Re-parent all of our subscriptions in case this new child provider

--- a/packages/context/src/lib/controllers/context-provider.ts
+++ b/packages/context/src/lib/controllers/context-provider.ts
@@ -26,14 +26,17 @@ export class ContextProviderEvent<
   C extends Context<unknown, unknown>,
 > extends Event {
   readonly context: C;
+  readonly contextTarget: Element;
 
   /**
    *
    * @param context the context which this provider can provide
+   * @param contextTarget the original context target of the provider
    */
-  constructor(context: C) {
+  constructor(context: C, contextTarget: Element) {
     super('context-provider', {bubbles: true, composed: true});
     this.context = context;
+    this.contextTarget = contextTarget;
   }
 }
 
@@ -121,13 +124,7 @@ export class ContextProvider<
     }
     // Also, in case an element is a consumer AND a provider
     // of the same context it shouldn't provide to itself.
-    if (ev.target === this.host) {
-      return;
-    }
-    // We use composedPath (on top of ev.target) to cover cases
-    // where the consumer is in the shadowDom of the provider.
-    const childProviderHost = ev.composedPath()[0] as Element;
-    if (childProviderHost === this.host) {
+    if (ev.contextTarget === this.host) {
       return;
     }
     // Re-parent all of our subscriptions in case this new child provider
@@ -165,6 +162,6 @@ export class ContextProvider<
 
   hostConnected(): void {
     // emit an event to signal a provider is available for this context
-    this.host.dispatchEvent(new ContextProviderEvent(this.context));
+    this.host.dispatchEvent(new ContextProviderEvent(this.context, this.host));
   }
 }

--- a/packages/context/src/lib/controllers/context-provider.ts
+++ b/packages/context/src/lib/controllers/context-provider.ts
@@ -102,11 +102,12 @@ export class ContextProvider<
     }
     // Also, in case an element is a consumer AND a provider
     // of the same context, we want to avoid the element to self-register.
-    if (ev.contextTarget === this.host) {
+    const consumerHost = ev.contextTarget ?? ev.composedPath()[0];
+    if (consumerHost === this.host) {
       return;
     }
     ev.stopPropagation();
-    this.addCallback(ev.callback, ev.contextTarget, ev.subscribe);
+    this.addCallback(ev.callback, consumerHost, ev.subscribe);
   };
 
   /**
@@ -124,7 +125,8 @@ export class ContextProvider<
     }
     // Also, in case an element is a consumer AND a provider
     // of the same context it shouldn't provide to itself.
-    if (ev.contextTarget === this.host) {
+    const childProviderHost = ev.contextTarget ?? ev.composedPath()[0];
+    if (childProviderHost === this.host) {
       return;
     }
     // Re-parent all of our subscriptions in case this new child provider

--- a/packages/context/src/test/protocol-types.ts
+++ b/packages/context/src/test/protocol-types.ts
@@ -50,6 +50,7 @@ export type ContextCallback<ValueType> = (
 export class ContextRequestEvent<T extends UnknownContext> extends Event {
   public constructor(
     public readonly context: T,
+    public readonly contextTarget: Element,
     public readonly callback: ContextCallback<ContextType<T>>,
     public readonly subscribe?: boolean
   ) {


### PR DESCRIPTION
While profiling some Lit components we noticed that `Event#composedPath()` is in the hot path and that the browser spends a significant amount of time computing it.

For a particular use case (initial render of hundreds of components), ~29% of the time is spent in this function alone. A slight change to the bail out logic reduces this to ~17% (basically don't call it unless absolutely necessary). Keeping manual track of the original source of the event reduces this overhead completely.

Furthermore, this will also slightly reduce memory usage and time spent in garbage collection (for the same use case, Firefox Profiler shows a reduction in memory allocated by this function from ~998KB to ~511KB with the bailout logic and the complete elimination of this allocations with the manual tracking of the source of the event).

While this change is unlikely to make a difference for most consumers, it should slightly reduce the overhead of event dispatching, which seems to be non-trivial when lots of components that are both providers and consumers are present in the DOM.

Note that the prospect of `Event#composedPath()` being a potential performance bottleneck was raised in https://github.com/lit/lit/pull/2858#discussion_r873855309, where it was correctly dismissed. But https://github.com/lit/lit/pull/4014 reworked the implementation, and the original dismissal reason ("[...] is limited to host that consume and provide the same context, so it's not called on all events") no longer applies.