### PR TITLE
[@lit-labs/preact-signals]: Fix memory leak after disconnected element updates.

### DIFF
--- a/.changeset/cool-shirts-teach.md
+++ b/.changeset/cool-shirts-teach.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/preact-signals': patch
+---
+
+Fix memory leak after disconnected element updates

--- a/packages/labs/preact-signals/src/test/signal-watcher_test.ts
+++ b/packages/labs/preact-signals/src/test/signal-watcher_test.ts
@@ -139,4 +139,95 @@ suite('SignalWatcher', () => {
     await el.updateComplete;
     assert.equal(el.shadowRoot?.querySelector('p')?.textContent, 'count: 1');
   });
+
+  test('subscribes to a signal on disconnected element update', async () => {
+    let readCount = 0;
+    const count = signal(0);
+    const countPlusOne = computed(() => {
+      readCount++;
+      return count.value + 1;
+    });
+
+    class TestElement extends SignalWatcher(LitElement) {
+      override render() {
+        return html`<p>count: ${countPlusOne.value}</p>`;
+      }
+    }
+    customElements.define(generateElementName(), TestElement);
+    const el = new TestElement();
+    container.append(el);
+
+    // First render, expect one read of the signal
+    await el.updateComplete;
+    assert.equal(el.shadowRoot?.querySelector('p')?.textContent, 'count: 1');
+    assert.equal(readCount, 1);
+
+    // Disconnect the element
+    el.remove();
+
+    // Force an update; resubscribes to signals
+    el.requestUpdate();
+    await el.updateComplete;
+
+    // Expect reads if updated after disconnected
+    count.value = 1;
+    await el.updateComplete;
+    assert.equal(el.shadowRoot?.querySelector('p')?.textContent, 'count: 2');
+    assert.equal(readCount, 2);
+  });
+
+  ((window as any).gc ? test : test.skip)(
+    'unsubscribes to a signal when element is not reachable',
+    async () => {
+      let tries = 0;
+      const forceGc = async () => {
+        tries++;
+        if (tries > 3) {
+          return false;
+        }
+        const largeArray = [];
+        for (let i = 0; i < 1e6; i++) {
+          largeArray.push(new Array(1e3).fill(i));
+        }
+        await new Promise((r) => setTimeout(r));
+        for (let i = 0; i < 10; i++) {
+          (window as any).gc();
+        }
+        return true;
+      };
+
+      const count = signal(0);
+      const countPlusOne = computed(() => {
+        return count.value + 1;
+      });
+
+      class TestElement extends SignalWatcher(LitElement) {
+        override render() {
+          return html`<p>count: ${countPlusOne.value}</p>`;
+        }
+      }
+      customElements.define(generateElementName(), TestElement);
+      let el: TestElement | undefined = new TestElement();
+      container.append(el);
+      await el.updateComplete;
+      el.remove();
+
+      // Force element to update to resubscribe to signal
+      el.requestUpdate();
+      await el.updateComplete;
+
+      // Track if element is reachable
+      const ref = new WeakRef(el);
+      el = undefined;
+      assert.ok(ref.deref());
+
+      // Attempt to force garbage collection
+      while (ref.deref() && (await forceGc())) {
+        count.value++;
+      }
+
+      // Test if element is reachable
+      assert.isUndefined(ref.deref());
+    }
+  );
 });

--- a/packages/labs/preact-signals/tsconfig.json
+++ b/packages/labs/preact-signals/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
     "composite": true,
-    "target": "es2019",
+    "target": "es2021",
     "module": "NodeNext",
-    "lib": ["es2020", "DOM", "DOM.Iterable"],
+    "lib": ["es2021", "DOM", "DOM.Iterable"],
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,


### PR DESCRIPTION
 Fixes #4735. The signal effect in `SignalWatcher` references the element weakly, and the signal subscription in `watch` also does so for the directive. This is accomplished via [WeakRef](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakRef), which is widely supported.