### PR TITLE
[labs/analyzer] Handle class private fields in LitElement analysis

### DIFF
--- a/.changeset/tall-dodos-double.md
+++ b/.changeset/tall-dodos-double.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/analyzer': patch
+---
+
+Properly ignore class private fields when analyzing LitElement reactive properties.

--- a/packages/labs/analyzer/src/lib/javascript/classes.ts
+++ b/packages/labs/analyzer/src/lib/javascript/classes.ts
@@ -165,7 +165,9 @@ export const getClassMembers = (
             node: member,
             message:
               '@lit-labs/analyzer only supports analyzing class properties ' +
-              'named with plain identifiers. This property was ignored.',
+              'named with plain identifiers, or private class fields. This ' +
+              'property was ignored: ' +
+              member.name.getText(),
             category: typescript.DiagnosticCategory.Warning,
             code: DiagnosticCode.UNSUPPORTED,
           })

--- a/packages/labs/analyzer/src/lib/lit-element/properties.ts
+++ b/packages/labs/analyzer/src/lib/lit-element/properties.ts
@@ -37,13 +37,14 @@ export const getProperties = (
   let staticProperties;
 
   for (const prop of propertyDeclarations) {
-    if (!ts.isIdentifier(prop.name)) {
+    if (!ts.isIdentifier(prop.name) && !ts.isPrivateIdentifier(prop.name)) {
       analyzer.addDiagnostic(
         createDiagnostic({
           typescript: ts,
           node: prop,
           message:
-            '@lit-labs/analyzer only supports analyzing class properties named with plain identifiers. This ' +
+            '@lit-labs/analyzer only supports analyzing class properties ' +
+            'named with plain identifiers, or private class fields. This ' +
             'property was ignored.',
           category: ts.DiagnosticCategory.Warning,
           code: DiagnosticCode.UNSUPPORTED,

--- a/packages/labs/analyzer/src/lib/lit-element/properties.ts
+++ b/packages/labs/analyzer/src/lib/lit-element/properties.ts
@@ -45,7 +45,8 @@ export const getProperties = (
           message:
             '@lit-labs/analyzer only supports analyzing class properties ' +
             'named with plain identifiers, or private class fields. This ' +
-            'property was ignored.',
+            'property was ignored: ' +
+            prop.name.getText(),
           category: ts.DiagnosticCategory.Warning,
           code: DiagnosticCode.UNSUPPORTED,
         })

--- a/packages/labs/analyzer/test-files/ts/properties/src/element-a.ts
+++ b/packages/labs/analyzer/test-files/ts/properties/src/element-a.ts
@@ -5,7 +5,7 @@
  */
 
 import {LitElement} from 'lit';
-import {customElement, property} from 'lit/decorators.js';
+import {customElement, property, state} from 'lit/decorators.js';
 import {ImportedClass} from './external.js';
 
 export class LocalClass {
@@ -98,6 +98,11 @@ export class ElementA extends LitElement {
 
   @property()
   union: LocalClass | HTMLElement | ImportedClass;
+
+  @state()
+  private _stateField: number;
+
+  #privateField = 0;
 
   /**
    * This signature only works with strings.


### PR DESCRIPTION
Fixes https://github.com/lit/lit/issues/4745

This change allows private fields to be handled, but because they're not likely to be reactive properties, they're effectively ignored in this code path.