### PR TITLE
[react] Prevent calling HTMLElement.prototype in SSR

### DIFF
--- a/.changeset/fluffy-peaches-appear.md
+++ b/.changeset/fluffy-peaches-appear.md
@@ -1,0 +1,5 @@
+---
+'@lit/react': patch
+---
+
+Prevent calling HTMLElement.prototype in SSR

--- a/packages/react/src/create-component.ts
+++ b/packages/react/src/create-component.ts
@@ -226,7 +226,7 @@ export const createComponent = <
 }: Options<I, E>): ReactWebComponent<I, E> => {
   const eventProps = new Set(Object.keys(events ?? {}));
 
-  if (DEV_MODE) {
+  if (DEV_MODE && !NODE_MODE) {
     for (const p of reservedReactProperties) {
       if (p in elementClass.prototype && !(p in HTMLElement.prototype)) {
         // Note, this effectively warns only for `ref` since the other


### PR DESCRIPTION
Currently in dev mode of the `@lit/react` package, reserved React properties are checked against the prototype of the given custom elements class. This used to work during SSR, as none of reserved keywords were implemented in the HTMLElement shim.
Now with #4553 `localName` is implemented in the shim, which is one of the reserved keywords, which causes `HTMLElement.prototype` to be evaluated in the code path and crashes during SSR.

This PR removes this check during SSR. Injecting the shim for the `node` exports was considered, but dismissed, as there is a potential difference between properties of the shim and the native Browser HTMLElement instance.