### PR TITLE
docs(context): Set correct language identifier

### DIFF
--- a/packages/context/README.md
+++ b/packages/context/README.md
@@ -138,7 +138,7 @@ useful to provide a context provider without introducing a custom element:
 
 #### **`my-app.js`**:
 
-```js
+```ts
 import {ContextProvider} from '@lit/context';
 import {loggerContext, Logger} from './logger.js';
 


### PR DESCRIPTION
`js` -> `ts`

This makes the highlighting of all code blocks equal.