### PR TITLE
Adds `noBooleanRender` to `RenderOptions`

### DIFF
--- a/.changeset/sweet-fans-decide.md
+++ b/.changeset/sweet-fans-decide.md
@@ -1,0 +1,5 @@
+---
+'lit-html': minor
+---
+
+Adds `noBooleanRender` to `RenderOptions` to prevent booleans from rendering as strings.

--- a/package-lock.json
+++ b/package-lock.json
@@ -28628,7 +28628,7 @@
     },
     "packages/labs/signals": {
       "name": "@lit-labs/signals",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "lit": "^2.0.0 || ^3.0.0",

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -711,6 +711,12 @@ export interface RenderOptions {
    * render to change the connected state of the part.
    */
   isConnected?: boolean;
+  /**
+   * By default boolean values render as strings ("true" or "false") in child
+   * parts. Set to `true` to treat these values as non-rendering, equivalent
+   * to setting `nothing`.
+   */
+  noBooleanRender?: boolean;
 }
 
 const walker = d.createTreeWalker(
@@ -1448,7 +1454,12 @@ class ChildPart implements Disconnectable {
       // Non-rendering child values. It's important that these do not render
       // empty text nodes to avoid issues with preventing default <slot>
       // fallback content.
-      if (value === nothing || value == null || value === '') {
+      if (
+        value === nothing ||
+        value == null ||
+        value === '' ||
+        (this.options?.noBooleanRender && typeof value === 'boolean')
+      ) {
         if (this._$committedValue !== nothing) {
           debugLogEvent &&
             debugLogEvent({

--- a/packages/lit-html/src/test/lit-html_test.ts
+++ b/packages/lit-html/src/test/lit-html_test.ts
@@ -628,6 +628,38 @@ suite('lit-html', () => {
       });
     });
 
+    test('renders a boolean', () => {
+      render(html`<div>${true}</div>`, container);
+      assertContent('<div>true</div>');
+      render(html`<div>${false}</div>`, container);
+      assertContent('<div>false</div>');
+    });
+
+    test('renders a boolean when specifying `noBooleanRender`', () => {
+      render(html`<div>${true}</div>`, container, {noBooleanRender: true});
+      assertContent('<div></div>');
+      render(html`<div>${false}</div>`, container, {noBooleanRender: true});
+      assertContent('<div></div>');
+    });
+
+    test('renders a conditional value', () => {
+      render(html`<div>${true && 'hi'}</div>`, container);
+      assertContent('<div>hi</div>');
+      render(html`<div>${false && 'hi'}</div>`, container);
+      assertContent('<div>false</div>');
+    });
+
+    test('renders a conditional value  when specifying `noBooleanRender`', () => {
+      render(html`<div>${true && 'hi'}</div>`, container, {
+        noBooleanRender: true,
+      });
+      assertContent('<div>hi</div>');
+      render(html`<div>${false && 'hi'}</div>`, container, {
+        noBooleanRender: true,
+      });
+      assertContent('<div></div>');
+    });
+
     test('renders noChange', () => {
       const template = (i: any) => html`<div>${i}</div>`;
       render(template('foo'), container);

--- a/scripts/check-size.js
+++ b/scripts/check-size.js
@@ -9,8 +9,8 @@ import * as fs from 'fs';
 // it's likely that we'll ask you to investigate ways to reduce the size.
 //
 // In either case, update the size here and push a new commit to your PR.
-const expectedLitCoreSize = 15479;
-const expectedLitHtmlSize = 7303;
+const expectedLitCoreSize = 15531;
+const expectedLitHtmlSize = 7355;
 
 const litCoreSrc = fs.readFileSync('packages/lit/lit-core.min.js', 'utf8');
 const litCoreSize = fs.readFileSync('packages/lit/lit-core.min.js').byteLength;


### PR DESCRIPTION
Fixes #4788.

Currently html`${bool && 'hi'}` prints "false" when `bool` is `false`. Setting `noBooleanRender` to `true` in `RenderOptions` changes this behavior so that booleans are treated as a non-rendering value, and html`${bool && 'hi'}` prints nothing. 