### PR TITLE
[lab/analyzer] Dual-publish as CommonJS and standard modules

### DIFF
--- a/.changeset/tidy-dragons-return.md
+++ b/.changeset/tidy-dragons-return.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/analyzer': minor
+---
+
+Dual publish as CommonJS and standard modules

--- a/.eslintignore
+++ b/.eslintignore
@@ -179,6 +179,8 @@ packages/ts-transformers/internal/
 packages/ts-transformers/tests/
 packages/labs/analyzer/lib/
 packages/labs/analyzer/test/
+packages/labs/analyzer/commonjs/*
+!packages/labs/analyzer/commonjs/package.json
 
 packages/labs/analyzer/**/index.js
 packages/labs/analyzer/**/index.js.map

--- a/.prettierignore
+++ b/.prettierignore
@@ -165,6 +165,8 @@ packages/ts-transformers/internal/
 packages/ts-transformers/tests/
 packages/labs/analyzer/lib/
 packages/labs/analyzer/test/
+packages/labs/analyzer/commonjs/*
+!packages/labs/analyzer/commonjs/package.json
 
 packages/labs/analyzer/**/index.js
 packages/labs/analyzer/**/index.js.map

--- a/packages/labs/analyzer/.gitignore
+++ b/packages/labs/analyzer/.gitignore
@@ -1,5 +1,7 @@
 /lib/
 /test/
+/commonjs/*
+!commonjs/package.json
 
 index.js
 index.js.map

--- a/packages/labs/analyzer/commonjs/package.json
+++ b/packages/labs/analyzer/commonjs/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/packages/labs/analyzer/package.json
+++ b/packages/labs/analyzer/package.json
@@ -25,6 +25,12 @@
   },
   "wireit": {
     "build": {
+      "dependencies": [
+        "build:ts",
+        "build:commonjs"
+      ]
+    },
+    "build:ts": {
       "command": "tsc --build --pretty",
       "dependencies": [
         "../../lit:build"
@@ -52,6 +58,18 @@
       "output": [
         "test/browser/typescript.js"
       ]
+    },
+    "build:commonjs": {
+      "command": "tsc --pretty --project tsconfig.commonjs.json",
+      "files": [
+        "src/**/*.ts",
+        "tsconfig.commonjs.json"
+      ],
+      "output": [
+        "commonjs",
+        "tsconfig.commonjs.tsbuildinfo"
+      ],
+      "clean": "if-file-deleted"
     },
     "test": {
       "dependencies": [
@@ -109,13 +127,22 @@
   "files": [
     "index.*",
     "package-analyzer.*",
-    "/lib/",
-    "!/lib/.tsbuildinfo"
+    "/commonjs/",
+    "/lib/"
   ],
   "exports": {
-    ".": "./index.js",
-    "./package-analyzer.js": "./package-analyzer.js",
-    "./lib/*.js": "./lib/*.js"
+    ".": {
+      "import": "./index.js",
+      "require": "./commonjs/index.js"
+    },
+    "./package-analyzer.js": {
+      "import": "./package-analyzer.js",
+      "require": "./commonjs/package-analyzer.js"
+    },
+    "./lib/*.js": {
+      "import": "./lib/*.js",
+      "require": "./commonjs/lib/*.js"
+    }
   },
   "dependencies": {
     "package-json-type": "^1.0.3",

--- a/packages/labs/analyzer/tsconfig.commonjs.json
+++ b/packages/labs/analyzer/tsconfig.commonjs.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "./commonjs",
+    "rootDir": "src",
+    "tsBuildInfoFile": "tsconfig.commonjs.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/test/**/*"]
+}


### PR DESCRIPTION
Some contexts where we want to use the analyzer, like tsserver plugins, are Common JS and sync everywhere, making it very difficult to consume standard modules. The easiest solution to dual-publish the analyzer.

`require(esm)` just landed in Node 23, and will eventually make it's way into Electron and VS Code, but that'll take quite a while.