### PR TITLE
[labs/virtualizer] Fix case where items in a hidden Virtualizer were being rendered

### DIFF
--- a/.changeset/honest-ties-mix.md
+++ b/.changeset/honest-ties-mix.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/virtualizer': patch
+---
+
+Fix case where items in a hidden Virtualizer were being rendered

--- a/packages/labs/virtualizer/src/Virtualizer.ts
+++ b/packages/labs/virtualizer/src/Virtualizer.ts
@@ -678,8 +678,8 @@ export class Virtualizer {
       const scrollTop = top - hostElementBounds.top + hostElement.scrollTop;
       const scrollLeft = left - hostElementBounds.left + hostElement.scrollLeft;
 
-      const height = bottom - top;
-      const width = right - left;
+      const height = Math.max(0, bottom - top);
+      const width = Math.max(0, right - left);
 
       layout.viewportSize = {width, height};
       layout.viewportScroll = {top: scrollTop, left: scrollLeft};

--- a/packages/labs/virtualizer/src/test/scenarios/hidden.test.ts
+++ b/packages/labs/virtualizer/src/test/scenarios/hidden.test.ts
@@ -12,6 +12,7 @@ import {expect, fixture} from '@open-wc/testing';
 
 /*
   This file contains regression tests for https://github.com/lit/lit/issues/3815
+  and https://github.com/lit/lit/issues/4672
 */
 
 type Item = {label: number};
@@ -58,6 +59,23 @@ describe("Don't render any children if the virtualizer is hidden", () => {
     const el = await fixture<VirtualizerHider>(html`
       <virtualizer-hider></virtualizer-hider>
     `);
+    const virtualizer = el.shadowRoot!.querySelector('lit-virtualizer')!;
+    await virtualizer.layoutComplete;
+    expect(virtualizer.children.length).to.be.greaterThan(0);
+
+    el.hidden = true;
+    await virtualizer.layoutComplete;
+    expect(virtualizer.children.length).to.equal(0);
+  });
+
+  // Issue #4672
+  it('should not render any children when hidden and nested beneath a clipping ancestor', async () => {
+    const clipper = await fixture<HTMLDivElement>(html`
+      <div style="overflow: hidden;">
+        <virtualizer-hider></virtualizer-hider>
+      </div>
+    `);
+    const el = clipper.querySelector('virtualizer-hider')! as VirtualizerHider;
     const virtualizer = el.shadowRoot!.querySelector('lit-virtualizer')!;
     await virtualizer.layoutComplete;
     expect(virtualizer.children.length).to.be.greaterThan(0);

--- a/playground/p/issues/4672/_import.info.json
+++ b/playground/p/issues/4672/_import.info.json
@@ -1,0 +1,11 @@
+{
+  "source": "https://lit.dev/playground/#gist=aece301df423847e72b1a85e1e9caf75",
+  "originalPackageJSON": {
+    "dependencies": {
+      "lit": "^3.0.0",
+      "@lit/reactive-element": "^2.0.0",
+      "lit-element": "^4.0.0",
+      "lit-html": "^3.0.0"
+    }
+  }
+}

--- a/playground/p/issues/4672/index.html
+++ b/playground/p/issues/4672/index.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<head>
+  <script type="module" src="./simple-list.js"></script>
+</head>
+<body>
+  <simple-list></simple-list>
+</body>

--- a/playground/p/issues/4672/package.json
+++ b/playground/p/issues/4672/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/playground/p/issues/4672/simple-list.ts
+++ b/playground/p/issues/4672/simple-list.ts
@@ -1,0 +1,71 @@
+import {html, css, LitElement} from 'lit';
+import {customElement, property, query} from 'lit/decorators.js';
+import '@lit-labs/virtualizer';
+
+@customElement('simple-list')
+export class SimpleList extends LitElement {
+  static styles = css`
+    :host {
+      display: flex;
+      flex-direction: column;
+      max-height: 400px;
+    }
+    [hidden] {
+      display: none !important;
+    }
+    .parent {
+      flex: 1;
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+    }
+    main {
+      overflow: auto;
+      border: 1px solid green;
+    }
+  `;
+
+  _interval: number;
+
+  @property({attribute: false})
+  items = Array.from({length: 1000 - 1 + 1}, (_, i) => i + 1);
+
+  @property({type: Number})
+  childCount = 0;
+
+  @query('lit-virtualizer')
+  list;
+
+  @property({type: Boolean})
+  hideList = false;
+
+  connectedCallback() {
+    super.connectedCallback();
+
+    this._interval = setInterval(() => {
+      this.childCount = this.list.querySelectorAll('div').length;
+    }, 250) as unknown as number;
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    clearInterval(this._interval);
+  }
+
+  render() {
+    return html` <button @click=${this._hide}>Toggle visible</button>
+      <div>Number of rendered items: ${this.childCount}</div>
+      <div class="parent">
+        <main .hidden=${this.hideList}>
+          <lit-virtualizer
+            .items=${this.items}
+            .renderItem=${(item) => html`<div class"item">${item}</div>`}
+          ></lit-virtualizer>
+        </main>
+      </div>`;
+  }
+
+  _hide() {
+    this.hideList = !this.hideList;
+  }
+}


### PR DESCRIPTION
Fixes #4672.

The math for calculating the portion of a Virtualizer that's currently visible can result in negative dimensions if a hidden Virtualizer has clipping ancestors, and our layout logic doesn't guard against negative dimensions.

After exploring a specific fix that would have specifically tried to detect the observed problem case, I opted to simply constrain the calculated dimensions to be >= 0. There's a chance that this approach will make it somewhat harder to debug some future issue, but I think the simplicity of the fix and its conceptual soundness (there are no circumstances in which negative dimensions make sense) make it a good, pragmatic choice.

Reviewers: to observe the bug, check out the second-to-last commit in detached HEAD state and run the automated tests and/or the monorepo playground example, then check out the branch and run them again to verify the fix.