### PR TITLE
[labs/testing] Fix fixture base url resolution when running browsers in containers

### DIFF
--- a/.changeset/smooth-deers-wave.md
+++ b/.changeset/smooth-deers-wave.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/testing': patch
+---
+
+Fix fixture base url resolution when running browsers in containers

--- a/packages/labs/testing/src/lib/fixtures/csr-fixture.ts
+++ b/packages/labs/testing/src/lib/fixtures/csr-fixture.ts
@@ -37,8 +37,11 @@ export async function csrFixture<T extends HTMLElement>(
     // asyncFunctionResume@[native code]
     // @http://localhost:8000/test/my-element_test.js?wtr-session-id=aKWON-wBOBGyzb2CwIvmK:65:37
     const {stack} = new Error();
+    // host.containers.internal represents the host address when running browser/tests inside a container.
     const match =
-      stack?.match(/http:\/\/localhost.+(?=\?wtr-session-id)/) ??
+      stack?.match(
+        /http:\/\/(localhost|host\.containers\.internal).+(?=\?wtr-session-id)/
+      ) ??
       // Looking for wtr-session-id might not work in webkit. See https://github.com/lit/lit/issues/4067
       // As a fallback, we look for the first file which is not inside node_modules and
       // is not this csr-fixture file.
@@ -48,7 +51,11 @@ export async function csrFixture<T extends HTMLElement>(
       // ssrFixture@http://localhost:8000/lib/fixtures/ssr-fixture.js:19:34
       // ssrNonHydratedFixture@http://localhost:8000/lib/fixtures/ssr-fixture.js:98:45
       // @http://localhost:8000/test/my-element_test.js:20:37
-      [...(stack?.matchAll(/http:\/\/localhost:?[^:)]+/gm) ?? [])]
+      [
+        ...(stack?.matchAll(
+          /http:\/\/(localhost|host\.containers\.internal):?[^:)]+/gm
+        ) ?? []),
+      ]
         .map((m) => m[0])
         .filter(
           (u) =>

--- a/packages/labs/testing/src/lib/fixtures/ssr-fixture.ts
+++ b/packages/labs/testing/src/lib/fixtures/ssr-fixture.ts
@@ -53,6 +53,7 @@ export async function ssrFixture<T extends HTMLElement>(
     // asyncFunctionResume@[native code]
     // @http://localhost:8000/test/my-element_test.js?wtr-session-id=aKWON-wBOBGyzb2CwIvmK:65:37
     const {stack} = new Error();
+    // host.containers.internal represents the host address when running browser/tests inside a container.
     const match =
       stack?.match(
         /http:\/\/(localhost|host\.containers\.internal).+(?=\?wtr-session-id)/

--- a/packages/labs/testing/src/lib/fixtures/ssr-fixture.ts
+++ b/packages/labs/testing/src/lib/fixtures/ssr-fixture.ts
@@ -55,7 +55,7 @@ export async function ssrFixture<T extends HTMLElement>(
     const {stack} = new Error();
     const match =
       stack?.match(
-        /http:\/\/(localhost|host.containers.internal).+(?=\?wtr-session-id)/
+        /http:\/\/(localhost|host\.containers\.internal).+(?=\?wtr-session-id)/
       ) ??
       // Looking for wtr-session-id might not work in webkit. See https://github.com/lit/lit/issues/4067
       // As a fallback, we look for the first file which is not inside node_modules and
@@ -68,7 +68,7 @@ export async function ssrFixture<T extends HTMLElement>(
       // @http://localhost:8000/test/my-element_test.js:20:37
       [
         ...(stack?.matchAll(
-          /http:\/\/(localhost|host.containers.internal):?[^:)]+/gm
+          /http:\/\/(localhost|host\.containers\.internal):?[^:)]+/gm
         ) ?? []),
       ]
         .map((m) => m[0])

--- a/packages/labs/testing/src/lib/fixtures/ssr-fixture.ts
+++ b/packages/labs/testing/src/lib/fixtures/ssr-fixture.ts
@@ -54,7 +54,9 @@ export async function ssrFixture<T extends HTMLElement>(
     // @http://localhost:8000/test/my-element_test.js?wtr-session-id=aKWON-wBOBGyzb2CwIvmK:65:37
     const {stack} = new Error();
     const match =
-      stack?.match(/http:\/\/localhost.+(?=\?wtr-session-id)/) ??
+      stack?.match(
+        /http:\/\/(localhost|host.containers.internal).+(?=\?wtr-session-id)/
+      ) ??
       // Looking for wtr-session-id might not work in webkit. See https://github.com/lit/lit/issues/4067
       // As a fallback, we look for the first file which is not inside node_modules and
       // is not this ssr-fixture file.
@@ -64,7 +66,11 @@ export async function ssrFixture<T extends HTMLElement>(
       // ssrFixture@http://localhost:8000/lib/fixtures/ssr-fixture.js:19:34
       // ssrNonHydratedFixture@http://localhost:8000/lib/fixtures/ssr-fixture.js:98:45
       // @http://localhost:8000/test/my-element_test.js:20:37
-      [...(stack?.matchAll(/http:\/\/localhost:?[^:)]+/gm) ?? [])]
+      [
+        ...(stack?.matchAll(
+          /http:\/\/(localhost|host.containers.internal):?[^:)]+/gm
+        ) ?? []),
+      ]
         .map((m) => m[0])
         .filter(
           (u) =>


### PR DESCRIPTION
Currently when running browsers in a container (e.g. playwright), the resolution to localhost will fail.
This PR adds `host.containers.internal`, additionally to `localhost`, to the base resolution regex.
`host.containers.internal` is available per default in [Podman](https://podman.io/) and can easily be added to Docker (`docker run --add-host=host.containers.internal=host-gateway ...`).