### PR TITLE
[labs/virtualizer] DRAFT: re-enable skipped scrolling tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30319,10 +30319,10 @@
     },
     "packages/labs/eleventy-plugin-lit": {
       "name": "@lit-labs/eleventy-plugin-lit",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/ssr": "^3.1.8",
+        "@lit-labs/ssr": "^3.3.0",
         "lit": "^2.7.0 || ^3.0.0"
       },
       "devDependencies": {
@@ -30443,7 +30443,7 @@
     },
     "packages/labs/gen-wrapper-vue": {
       "name": "@lit-labs/gen-wrapper-vue",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit-labs/analyzer": "^0.13.0",
@@ -30471,7 +30471,7 @@
     },
     "packages/labs/nextjs": {
       "name": "@lit-labs/nextjs",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit-labs/ssr-react": "^0.3.0",
@@ -31065,11 +31065,11 @@
     },
     "packages/labs/ssr": {
       "name": "@lit-labs/ssr",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit-labs/ssr-client": "^1.1.7",
-        "@lit-labs/ssr-dom-shim": "^1.2.0",
+        "@lit-labs/ssr-dom-shim": "^1.3.0",
         "@lit/reactive-element": "^2.0.4",
         "@parse5/tools": "^0.3.0",
         "@types/node": "^16.0.0",
@@ -31119,19 +31119,19 @@
     },
     "packages/labs/ssr-dom-shim": {
       "name": "@lit-labs/ssr-dom-shim",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "license": "BSD-3-Clause"
     },
     "packages/labs/ssr-react": {
       "name": "@lit-labs/ssr-react",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/ssr": "^3.2.2",
+        "@lit-labs/ssr": "^3.3.0",
         "@lit-labs/ssr-client": "^1.1.7"
       },
       "devDependencies": {
-        "@lit/react": "1.0.6",
+        "@lit/react": "1.0.7",
         "@types/node": "^20.11.25",
         "@types/react": "^18.0.27",
         "@types/react-dom": "^18.0.10",
@@ -31194,10 +31194,10 @@
     },
     "packages/labs/test-projects/test-elements-react": {
       "name": "@lit-internal/test-elements-react",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "dependencies": {
         "@lit-internal/test-element-a": "1.0.1",
-        "@lit/react": "1.0.6"
+        "@lit/react": "1.0.7"
       },
       "peerDependencies": {
         "@types/react": "^17 || ^18",
@@ -31210,10 +31210,10 @@
     },
     "packages/labs/testing": {
       "name": "@lit-labs/testing",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/ssr": "^3.1.8",
+        "@lit-labs/ssr": "^3.3.0",
         "@lit-labs/ssr-client": "^1.1.4",
         "@web/test-runner-commands": "^0.6.1",
         "@webcomponents/template-shadowroot": "^0.1.0",
@@ -31233,7 +31233,7 @@
     },
     "packages/labs/virtualizer": {
       "name": "@lit-labs/virtualizer",
-      "version": "2.0.14",
+      "version": "2.0.15",
       "license": "BSD-3-Clause",
       "dependencies": {
         "lit": "^3.2.0",
@@ -31241,9 +31241,35 @@
       },
       "devDependencies": {
         "@open-wc/testing": "^3.1.6",
+        "@types/mocha": "^10.0.10",
+        "@types/node": "^22.10.7",
         "@web/dev-server-esbuild": "^0.3.0",
         "tachometer": "^0.7.0"
       }
+    },
+    "packages/labs/virtualizer/node_modules/@types/mocha": {
+      "version": "10.0.10",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
+      "integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/labs/virtualizer/node_modules/@types/node": {
+      "version": "22.10.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.7.tgz",
+      "integrity": "sha512-V09KvXxFiutGp6B7XkpaDXlNadZxrzajcY50EuoLIpQ6WWYCSvf19lVIazzfIzQvhUN2HjX12spLojTnhuKlGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.20.0"
+      }
+    },
+    "packages/labs/virtualizer/node_modules/undici-types": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/labs/vue-utils": {
       "name": "@lit-labs/vue-utils",
@@ -31852,7 +31878,7 @@
     },
     "packages/react": {
       "name": "@lit/react",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@lit-internal/scripts": "^1.0.1",
@@ -31928,7 +31954,7 @@
     },
     "packages/task": {
       "name": "@lit/task",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit/reactive-element": "^1.0.0 || ^2.0.0"

--- a/packages/labs/virtualizer/package.json
+++ b/packages/labs/virtualizer/package.json
@@ -162,6 +162,8 @@
   ],
   "devDependencies": {
     "@open-wc/testing": "^3.1.6",
+    "@types/mocha": "^10.0.10",
+    "@types/node": "^22.10.7",
     "@web/dev-server-esbuild": "^0.3.0",
     "tachometer": "^0.7.0"
   },

--- a/packages/labs/virtualizer/src/test/scenarios/scrolling.test.ts
+++ b/packages/labs/virtualizer/src/test/scenarios/scrolling.test.ts
@@ -126,7 +126,7 @@ function testBasicScrolling(fixtureOptions: VirtualizerFixtureOptions) {
 // Commenting out these tests until we can investigate further, so that
 // we can get the rest of the tests running on CI without interfering
 // with the overall lit release pipeline.
-describe.skip('basic scrolling functionality, via scrollTo()', () => {
+describe('basic scrolling functionality, via scrollTo()', () => {
   describe('vertical', () => {
     describe('using <lit-virtualizer>...', () => {
       describe('...and window scrolling', () => {

--- a/packages/labs/virtualizer/src/test/scenarios/scrolling.test.ts
+++ b/packages/labs/virtualizer/src/test/scenarios/scrolling.test.ts
@@ -126,7 +126,11 @@ function testBasicScrolling(fixtureOptions: VirtualizerFixtureOptions) {
 // Commenting out these tests until we can investigate further, so that
 // we can get the rest of the tests running on CI without interfering
 // with the overall lit release pipeline.
-describe('basic scrolling functionality, via scrollTo()', () => {
+describe('basic scrolling functionality, via scrollTo()', function () {
+  before(function () {
+    if (globalThis.process?.env?.CI) this.skip();
+  });
+
   describe('vertical', () => {
     describe('using <lit-virtualizer>...', () => {
       describe('...and window scrolling', () => {

--- a/packages/labs/virtualizer/tsconfig.json
+++ b/packages/labs/virtualizer/tsconfig.json
@@ -22,7 +22,7 @@
     "experimentalDecorators": true,
     "importHelpers": true,
     "tsBuildInfoFile": ".tsbuildinfo",
-    "types": ["mocha"]
+    "types": ["mocha", "node"]
   },
   "include": ["src/**/*.ts"],
   "exclude": ["*.d.ts", "**/*.d.ts"]

--- a/packages/labs/virtualizer/web-test-runner.config.js
+++ b/packages/labs/virtualizer/web-test-runner.config.js
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+import {chromeLauncher} from '@web/test-runner-chrome';
+
 export default {
   concurrency: 1,
   testFramework: {
@@ -16,4 +18,20 @@ export default {
       rootHooks: [],
     },
   },
+  browsers: [
+    chromeLauncher({
+      async createPage({context}) {
+        const page = await context.newPage();
+        await page.evaluateOnNewDocument((CI) => {
+          // eslint-disable-next-line no-undef
+          globalThis.process = {
+            env: {
+              CI,
+            },
+          };
+        }, process.env.CI);
+        return page;
+      },
+    }),
+  ],
 };


### PR DESCRIPTION
Checking to see whether Virtualizer's scrolling tests are less flaky in CI now than they were previously