### PR TITLE
Failing test case for #4831

### DIFF
--- a/packages/labs/observers/src/test/resize-controller_test.ts
+++ b/packages/labs/observers/src/test/resize-controller_test.ts
@@ -99,6 +99,14 @@ if (DEV_MODE) {
   ) => {
     const ctor = defineTestElement(getControllerConfig);
     const el = await renderTestElement(ctor);
+
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+    // Note: Instead of requesting two animation frames, we can also wait 100 ms
+    // to reproduce the issue:
+    //
+    // await new Promise((resolve) => setTimeout(resolve, 100));
+
     return el;
   };
 

--- a/packages/labs/observers/src/test/resize-controller_test.ts
+++ b/packages/labs/observers/src/test/resize-controller_test.ts
@@ -43,6 +43,7 @@ if (DEV_MODE) {
     class A extends ReactiveElement {
       observer: ResizeController;
       observerValue: unknown;
+      private updateCount = 0;
       changeDuringUpdate?: () => void;
       constructor() {
         super();
@@ -62,6 +63,7 @@ if (DEV_MODE) {
 
       override updated() {
         this.observerValue = this.observer.value;
+        this.updateCount++;
       }
 
       resetObserverValue() {
@@ -149,6 +151,7 @@ if (DEV_MODE) {
     }));
 
     // Does not reports initial change when `skipInitial` is set
+    assert.equal((el as any).updateCount, 1);
     assert.isUndefined(el.observerValue);
 
     // Reports subsequent attribute change when `skipInitial` is set


### PR DESCRIPTION
This is a failing test case for #4831 ("labs/observers: ResizeController's skipInitial option has no effect"). It consists of two commits, one to reproduce the issue and another to debug (not sure how useful that one is).

I'm reproducing it by waiting for two animation frames after the initial element render. There are probably better ways to do this, but I wasn't sure how to best do it and waiting for two frames did the trick of reproducing the problem.

In addition to the `skipInitial` issue, this causes two more test failures. I haven't investigated these at all, so I'm not sure if I broke those tests, or if my change surfaced another set of issues.

```
~/src/lit/packages/labs/observers [988ec3] $ npm run test:dev

> @lit-labs/observers@2.0.4 test:dev
> wireit

Browserslist: caniuse-lite is outdated. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme

Chromium: |██████████████████████████████| 0/4 test files | 0 passed, 0 failed
Firefox:  |██████████████████████████████| 0/4 test files | 0 passed, 0 failed
Webkit:   |██████████████████████████████| 0/4 test files | 0 passed, 0 failed

Running tests...

Running 4 test files...

development/test/resize-controller_test.js:

 ❌ ResizeController > skips initial changes when `skipInitial` is `true`
      AssertionError: expected true to equal undefined
        at o.<anonymous> (src/test/resize-controller_test.ts:152:11)

 ❌ ResizeController > observation managed via connection
      AssertionError: expected true to equal undefined
        at o.<anonymous> (src/test/resize-controller_test.ts:174:11)

 ❌ ResizeController > can observe external element
      AssertionError: expected true to equal undefined
        at o.<anonymous> (src/test/resize-controller_test.ts:199:11)

Chromium: |██████████████████████████████| 4/4 test files | 49 passed, 3 failed
Firefox:  |██████████████████████████████| 4/4 test files | 49 passed, 3 failed
Webkit:   |██████████████████████████████| 4/4 test files | 26 passed, 3 failed, 23 skipped

Finished running tests in 3.3s with 9 failed tests.



❌ [test:dev] exited with exit code 1.
❌ 1 script failed.
npm error Lifecycle script `test:dev` failed with error:
npm error Error: command failed
npm error   in workspace: @lit-labs/observers@2.0.4
npm error   at location: /home/ubuntu/src/lit/packages/labs/observers
```
