### PR TITLE
[lit-html] Use Node.moveBefore if it's available

### DIFF
--- a/packages/lit-html/src/directive-helpers.ts
+++ b/packages/lit-html/src/directive-helpers.ts
@@ -164,7 +164,12 @@ export const insertPart = (
       let start: Node | null = part._$startNode;
       while (start !== endNode) {
         const n: Node | null = wrap(start!).nextSibling;
-        wrap(container).insertBefore(start!, refNode);
+        const wrapper = wrap(container);
+        (wrapper.moveBefore ?? wrapper.insertBefore).call(
+          wrapper,
+          start!,
+          refNode
+        );
         start = n;
       }
     }
@@ -172,6 +177,12 @@ export const insertPart = (
 
   return part;
 };
+
+declare global {
+  interface Node {
+    moveBefore<T extends Node>(node: T, child: Node | null): T;
+  }
+}
 
 /**
  * Sets the value of a Part.


### PR DESCRIPTION
`Node.moveBefore()` is an atomic version of `insertBefore` that is available in Chrome Canary behind a flag.

- Explainer: https://github.com/noamr/dom/blob/spm-explainer/moveBefore-explainer.md
- DOM issue: https://github.com/whatwg/dom/issues/1255
- Intent to Ship: https://groups.google.com/a/chromium.org/g/blink-dev/c/YE_xLH6MkRs/m/_7CD0NYMAAAJ

Using `moveBefore()` preserves the state of the element being moved, including focus, selection, iframe state, media state, etc.

We can adopt this API when available to make `repeat()` preserve the state of elements. The one place that needs to change is in `insertPart()` in `directive-helpers.ts`.

`moveBefore()` still calls `disconnectedCallback()` and `connectedCallback()` on the element being moved, so elements should still take care to not over-aggressively free up resources in `disconnectedCallback()`. A common pattern is to delay cleanup for a microtask and check `isConnected` before cleanup - that should still be done.

Another possible change it in `lit-html.ts` when we insert a node into a child part. Adoption `moveBefore()` there would mean that directly binding a node to one of multiple child bindings could be done so that if the binding that the node is in changes, it'll be atomic. That's probably an _very_ rare case today, though this could potentially be done by directives that move nodes between parents as in some drag and drop constructions we've seen (moving items between lists, etc).

https://github.com/lit/lit/blob/1eb179f69d663440fd2ebd3589b6f2808d87494f/packages/lit-html/src/lit-html.ts#L1495

One reason why we might want to try that anyway is perf - we need to test any perf difference between `insertBefore()` and `moveBefore()` but it seems _possible_ at least that `moveBefore()` could be faster if it's skipping work.

One thing to watch out for is that `moveBefore()` can throw in some cases. It doesn't seem like we can hit them in `repeat()`, but maybe in `cache()`. We might need an option to `insertPart()`.

I haven't yet figured out how to enable the feature in Playwright to test this, so do not merge.