### PR TITLE
[labs/nextjs] Fix type of nextjs config wrapper

### DIFF
--- a/.changeset/cold-bees-doubt.md
+++ b/.changeset/cold-bees-doubt.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/nextjs': patch
+---
+
+Fix type of nextjs config wrapper

--- a/packages/labs/nextjs/src/index.ts
+++ b/packages/labs/nextjs/src/index.ts
@@ -16,7 +16,9 @@ interface LitSsrPluginOptions {
   addDeclarativeShadowDomPolyfill?: boolean;
 }
 
-export = (pluginOptions: LitSsrPluginOptions = {}): NextConfig =>
+export = (
+    pluginOptions: LitSsrPluginOptions = {}
+  ): ((nextConfig: NextConfig) => NextConfig) =>
   (nextConfig: NextConfig = {}) => {
     return Object.assign({}, nextConfig, {
       webpack: (config, options) => {


### PR DESCRIPTION
Currently the nextjs config wrapper type mistakenly indicates it returns a NextConfig object. It however returns a callback, which receives and returns a NextConfig object.