### PR TITLE
fix: Widen range for React types to include React 19

### DIFF
--- a/.changeset/rare-cherries-bake.md
+++ b/.changeset/rare-cherries-bake.md
@@ -1,5 +1,0 @@
----
-"@lit/react": patch
----
-
-Widen range to support React 19

--- a/.changeset/rare-cherries-bake.md
+++ b/.changeset/rare-cherries-bake.md
@@ -1,0 +1,5 @@
+---
+"@lit/react": patch
+---
+
+Widen range to support React 19

--- a/.changeset/tidy-badgers-drop.md
+++ b/.changeset/tidy-badgers-drop.md
@@ -1,0 +1,6 @@
+---
+"@lit/react": patch
+"@lit-labs/ssr-react": patch
+---
+
+fix: Widen range for React types to include React 19

--- a/.changeset/tidy-badgers-drop.md
+++ b/.changeset/tidy-badgers-drop.md
@@ -1,6 +1,6 @@
 ---
-"@lit/react": patch
-"@lit-labs/ssr-react": patch
+'@lit/react': patch
+'@lit-labs/ssr-react': patch
 ---
 
 fix: Widen range for React types to include React 19

--- a/package-lock.json
+++ b/package-lock.json
@@ -31843,7 +31843,7 @@
         "react-dom": "^18.2.0"
       },
       "peerDependencies": {
-        "@types/react": "17 || 18"
+        "@types/react": "17 || 18 || 19"
       }
     },
     "packages/reactive-element": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -31120,8 +31120,8 @@
         "uvu": "^0.5.6"
       },
       "peerDependencies": {
-        "@types/react": "17 || 18",
-        "react": "17 || 18"
+        "@types/react": "17 || 18 || 19",
+        "react": "17 || 18 || 19"
       }
     },
     "packages/labs/ssr-react/node_modules/@types/node": {

--- a/packages/labs/ssr-react/package.json
+++ b/packages/labs/ssr-react/package.json
@@ -51,8 +51,8 @@
     "@lit-labs/ssr-client": "^1.1.7"
   },
   "peerDependencies": {
-    "@types/react": "17 || 18",
-    "react": "17 || 18"
+    "@types/react": "17 || 18 || 19",
+    "react": "17 || 18 || 19"
   },
   "scripts": {
     "build": "wireit",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -196,7 +196,7 @@
     "react-dom": "^18.2.0"
   },
   "peerDependencies": {
-    "@types/react": "17 || 18"
+    "@types/react": "17 || 18 || 19"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
This allows using @lit/react with React 19

For #4857