### PR TITLE
Improve performance on trimOuterMarkers in Eleventy Lit plugin

### DIFF
--- a/.changeset/metal-tigers-visit.md
+++ b/.changeset/metal-tigers-visit.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/eleventy-plugin-lit': patch
+---
+
+Improve performance on trimming outer markers from server rendered results.

--- a/packages/labs/eleventy-plugin-lit/src/index.ts
+++ b/packages/labs/eleventy-plugin-lit/src/index.ts
@@ -239,9 +239,35 @@ module.exports = {
 // outer markers (though note there are 2 layers of markers due to the
 // use of the unsafeHTML directive).
 function trimOuterMarkers(renderedContent: string): string {
-  return renderedContent
-    .replace(/^((<!--[^<>]*-->)|(<\?>)|\s)+/, '')
-    .replace(/((<!--[^<>]*-->)|(<\?>)|\s)+$/, '');
+  const q = '<?>';
+  const startMarker = '<!--lit-part '; // e.g. <!--lit-part HeR8tRCwgQQ=-->
+  const endMarker = '<!--/lit-part-->';
+
+  renderedContent = renderedContent.trim();
+
+  let start;
+  let end;
+
+  if (renderedContent.startsWith(q)) {
+    start = q.length;
+  } else if (renderedContent.startsWith(startMarker)) {
+    start = renderedContent.indexOf('-->') + 3;
+  }
+
+  if (renderedContent.endsWith(q)) {
+    end = renderedContent.length - q.length;
+  } else if (renderedContent.endsWith(endMarker)) {
+    end = renderedContent.length - endMarker.length;
+  }
+
+  if (start || end) {
+    // trim one or more
+    return trimOuterMarkers(
+      renderedContent.slice(start ?? 0, end ?? renderedContent.length)
+    );
+  }
+
+  return renderedContent;
 }
 
 // Assuming this is faster than Array.from(iter).join();


### PR DESCRIPTION
Pretty conclusive that there is a hefty RegExp performance cost in the Eleventy Lit plugin, in the `trimOuterMarkers` function here: https://github.com/lit/lit/blob/267d243aeec13a6f0e8184420919db4c519b8caf/packages/labs/eleventy-plugin-lit/src/index.ts#L241-L245

Example Node CPU profile here (about 75% of this Eleventy project’s build is spent here):

<img width="1074" alt="image" src="https://github.com/user-attachments/assets/862742b2-a751-48cd-8c7b-6a3233229a67" />

The regular expressions seem to suggest that markers we’re looking for here are only found at the beginning and end of the content strings so I made some improvements using those assumptions.

Build time dropped significantly with the proposed changes (`20s` -> `~5s`)

cc @KonnorRogers @claviska