### PR TITLE
[@lit/reactive-element] Provide ElementInternalHost mixin for attaching element internals

### DIFF
--- a/.changeset/purple-foxes-turn.md
+++ b/.changeset/purple-foxes-turn.md
@@ -1,0 +1,6 @@
+---
+'@lit/reactive-element': minor
+'lit': minor
+---
+
+Provide ElementInternalHost mixin for attaching element internals

--- a/.eslintignore
+++ b/.eslintignore
@@ -41,6 +41,7 @@ packages/internal-scripts/lib/
 packages/lit/decorators/
 packages/lit/development/
 packages/lit/directives/
+packages/lit/mixins/
 packages/lit/node_modules/
 packages/lit/test/
 
@@ -142,6 +143,7 @@ packages/react/use-controller.*
 packages/reactive-element/decorators/
 packages/reactive-element/development/
 packages/reactive-element/legacy-decorators/
+packages/reactive-element/mixins/
 packages/reactive-element/node/
 packages/reactive-element/std-decorators/
 packages/reactive-element/test/

--- a/.prettierignore
+++ b/.prettierignore
@@ -41,6 +41,7 @@ packages/internal-scripts/lib/
 packages/lit/decorators/
 packages/lit/development/
 packages/lit/directives/
+packages/lit/mixins/
 packages/lit/node_modules/
 packages/lit/test/
 
@@ -128,6 +129,7 @@ packages/react/use-controller.*
 packages/reactive-element/decorators/
 packages/reactive-element/development/
 packages/reactive-element/legacy-decorators/
+packages/reactive-element/mixins/
 packages/reactive-element/node/
 packages/reactive-element/std-decorators/
 packages/reactive-element/test/

--- a/packages/lit/.gitignore
+++ b/packages/lit/.gitignore
@@ -1,6 +1,7 @@
 /decorators/
 /development/
 /directives/
+/mixins/
 /node_modules/
 /test/
 

--- a/packages/lit/package.json
+++ b/packages/lit/package.json
@@ -161,6 +161,10 @@
       "types": "./development/html.d.ts",
       "default": "./html.js"
     },
+    "./mixins/element-internals.js": {
+      "types": "./development/mixins/element-internals.d.ts",
+      "default": "./mixins/element-internals.js"
+    },
     "./polyfill-support.js": {
       "types": "./development/polyfill-support.d.ts",
       "default": "./polyfill-support.js"
@@ -341,6 +345,7 @@
     "/directives/",
     "/development/",
     "!/development/test/",
+    "/mixins/",
     "/logo.svg"
   ],
   "dependencies": {

--- a/packages/lit/rollup.config.js
+++ b/packages/lit/rollup.config.js
@@ -66,6 +66,7 @@ export default litProdConfig({
     'directives/unsafe-svg',
     'directives/until',
     'directives/when',
+    'mixins/element-internals',
     'async-directive',
     'html',
     'index',

--- a/packages/lit/src/mixins/element-internals.ts
+++ b/packages/lit/src/mixins/element-internals.ts
@@ -1,0 +1,7 @@
+/**
+ * @license
+ * Copyright 2017 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+export * from '@lit/reactive-element/mixins/element-internals.js';

--- a/packages/reactive-element/.gitignore
+++ b/packages/reactive-element/.gitignore
@@ -1,6 +1,7 @@
 /decorators/
 /development/
 /legacy-decorators/
+/mixins/
 /node/
 /std-decorators/
 /test/

--- a/packages/reactive-element/package.json
+++ b/packages/reactive-element/package.json
@@ -186,6 +186,19 @@
       "development": "./development/decorators/state.js",
       "default": "./decorators/state.js"
     },
+    "./mixins/element-internals.js": {
+      "types": "./development/mixins/element-internals.d.ts",
+      "browser": {
+        "development": "./development/mixins/element-internals.js",
+        "default": "./mixins/element-internals.js"
+      },
+      "node": {
+        "development": "./node/development/mixins/element-internals.js",
+        "default": "./node/mixins/element-internals.js"
+      },
+      "development": "./development/mixins/element-internals.js",
+      "default": "./mixins/element-internals.js"
+    },
     "./polyfill-support.js": {
       "types": "./development/polyfill-support.d.ts",
       "browser": {
@@ -450,6 +463,7 @@
     "/decorators/",
     "/development/",
     "!/development/test/",
+    "/mixins/",
     "/node/"
   ],
   "dependencies": {

--- a/packages/reactive-element/rollup.config.js
+++ b/packages/reactive-element/rollup.config.js
@@ -23,6 +23,7 @@ export default litProdConfig({
     'decorators/query-assigned-elements',
     'decorators/query-assigned-nodes',
     'decorators/query-async',
+    'mixins/element-internals',
   ],
   external: [],
   bundled: [

--- a/packages/reactive-element/src/mixins/element-internals.ts
+++ b/packages/reactive-element/src/mixins/element-internals.ts
@@ -1,0 +1,71 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import type {ReactiveElement} from '../reactive-element.js';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Constructor<T = object> = abstract new (...args: any[]) => T;
+
+export const elementInternals: unique symbol = Symbol('SignalElementInternals');
+
+export interface ElementInteralsHost extends ReactiveElement {
+  get [elementInternals](): ElementInternals;
+}
+type ElementInteralsHostInterface = ElementInteralsHost;
+
+export interface ElementInteralsHostConstructor {
+  role?: ElementInternals['role'];
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  new (...args: any[]): ElementInteralsHost;
+}
+
+/**
+ * A mixin to apply attaching element internals to the given element class.
+ * The ElementInternals instance can be accessed via `elementInternals` symbol.
+ *
+ * @example
+ *
+ * ```ts
+ * class MyElement extends ElementInternalsHost(ReactiveElement) {
+ *   static override role = 'button';
+ *
+ *   override connectedCallback(): void {
+ *     super.connectedCallback();
+ *     this[elementInternals].ariaPressed = 'false';
+ *   }
+ * }
+ * ```
+ *
+ * @param base The base class to apply the mixin to.
+ * @returns A new class body with attached element internals.
+ */
+export function ElementInternalsHost<T extends Constructor<ReactiveElement>>(
+  base: T
+): T & ElementInteralsHostConstructor {
+  abstract class ElementInternalsHostMixin
+    extends base
+    implements ElementInteralsHostInterface
+  {
+    #internals: ElementInternals;
+
+    get [elementInternals]() {
+      return this.#internals;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    constructor(...args: any[]) {
+      super(...args);
+      const internals = this.attachInternals();
+      this.#internals = internals;
+      internals.role =
+        (this.constructor as ElementInteralsHostConstructor).role ?? null;
+    }
+  }
+  return ElementInternalsHostMixin as unknown as Constructor<ElementInteralsHostInterface> &
+    T &
+    ElementInteralsHostConstructor;
+}

--- a/packages/reactive-element/src/test/mixins/element-internals_test.ts
+++ b/packages/reactive-element/src/test/mixins/element-internals_test.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2017 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {ReactiveElement} from '@lit/reactive-element';
+import {customElement} from '@lit/reactive-element/decorators/custom-element.js';
+import {
+  elementInternals,
+  ElementInternalsHost,
+} from '@lit/reactive-element/mixins/element-internals.js';
+import {assert} from 'chai';
+
+@customElement('my-element-without-role')
+export class MyElementWithoutRole extends ElementInternalsHost(
+  ReactiveElement
+) {}
+@customElement('my-element-with-role')
+export class MyElementWithRole extends ElementInternalsHost(ReactiveElement) {
+  static override role = 'button';
+}
+
+suite('ElementInternalsHost', () => {
+  test('should attach element internals', () => {
+    const element = document.createElement(
+      'my-element-without-role'
+    ) as MyElementWithoutRole;
+    assert.strictEqual(
+      element[elementInternals].shadowRoot,
+      element.shadowRoot
+    );
+  });
+  test('should assign role from static property', () => {
+    const element = document.createElement(
+      'my-element-with-role'
+    ) as MyElementWithRole;
+    assert.equal(element[elementInternals].role, MyElementWithRole.role);
+  });
+});


### PR DESCRIPTION
Based on #4773 and my comment [here](https://github.com/lit/rfcs/pull/45#issuecomment-2504814462), I extracted the ElementInternal usage to its own mixin `ElementInternalsHost`.

```ts
import {ReactiveElement} from '@lit/reactive-element';
import {ElementInternalsHost, elementInternals} from '@lit/reactive-element/mixins/element-internals.js';

class MyElement extends ElementInternalsHost(ReactiveElement) {
  static override role = 'button';

  override connectedCallback(): void {
    super.connectedCallback();
    this[elementInternals].ariaPressed = 'false';
  }
}
```