### PR TITLE
[@lit/context] Prevent browser API calls during SSR

### DIFF
--- a/.changeset/shiny-fireants-cough.md
+++ b/.changeset/shiny-fireants-cough.md
@@ -1,0 +1,5 @@
+---
+'@lit/context': patch
+---
+
+Prevent browser API calls during SSR

--- a/packages/context/src/lib/controllers/context-provider.ts
+++ b/packages/context/src/lib/controllers/context-provider.ts
@@ -155,8 +155,8 @@ export class ContextProvider<
   };
 
   private attachListeners() {
-    this.host.addEventListener('context-request', this.onContextRequest);
-    this.host.addEventListener('context-provider', this.onProviderRequest);
+    this.host.addEventListener?.('context-request', this.onContextRequest);
+    this.host.addEventListener?.('context-provider', this.onProviderRequest);
   }
 
   hostConnected(): void {


### PR DESCRIPTION
Currently the `ContextProvider` attaches event listeners during its constructor. This will break during SSR, as `addEventListener` is not available.

This would be solved by #4755.