### PR TITLE
update playwright

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,11 +49,11 @@ jobs:
 
       # - uses: google/wireit@setup-github-actions-caching/v2
 
-      - name: Install playwright deps
-        run: npx playwright install-deps
-
       - name: NPM install
         run: npm ci
+
+      - name: Install playwright browsers
+        run: npx playwright install --with-deps
 
       - name: Build
         run: npm run build
@@ -83,6 +83,9 @@ jobs:
 
       - name: NPM install
         run: npm ci
+
+      - name: Install playwright browsers
+        run: npx playwright install --with-deps
 
       - name: Test
         env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -23279,29 +23279,50 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.37.0",
+      "version": "1.49.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.1.tgz",
+      "integrity": "sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==",
       "dev": true,
-      "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.37.0"
+        "playwright-core": "1.49.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.37.0",
+      "version": "1.49.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.1.tgz",
+      "integrity": "sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/please-upgrade-node": {


### PR DESCRIPTION
test workflows started failing recently due to missing playwright dependencies. e.g. https://github.com/lit/lit/actions/runs/12402309845/job/34623900088

this appears to be due to mismatch of the playwright deps install step which uses the latest version of playwright, and the actual version of playwright used by our test.

making the dependency install use our current old version of playwright seems to also fail as it has trouble finding old deps, tested here: https://github.com/lit/lit/pull/4875

so i updated the playwright we use to latest and updated the workflows to install playwright browsers and deps after npm install, as recommended in their docs: https://playwright.dev/docs/ci-intro