### PR TITLE
[labs/gen-wrapper-vue] Fix type errors for generated components

### DIFF
--- a/.changeset/clever-bobcats-clap.md
+++ b/.changeset/clever-bobcats-clap.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/gen-wrapper-vue': patch
+---
+
+Move `Slots` type assertion to fix type errors on generated components.

--- a/packages/labs/gen-wrapper-vue/goldens/test-element-a/src/ElementA.vue
+++ b/packages/labs/gen-wrapper-vue/goldens/test-element-a/src/ElementA.vue
@@ -24,7 +24,7 @@ const emit = defineEmits<{
   (e: 'a-changed', payload: CustomEvent<unknown>): void;
 }>();
 
-const slots = useSlots();
+const slots = useSlots() as Slots;
 
 const render = () => {
   const eventProps = {
@@ -42,7 +42,7 @@ const render = () => {
 
   hasRendered = true;
 
-  return h('element-a', props, assignSlotNodes(slots as Slots));
+  return h('element-a', props, assignSlotNodes(slots));
 };
 </script>
 <template><render v-defaults /></template>

--- a/packages/labs/gen-wrapper-vue/goldens/test-element-a/src/ElementEvents.vue
+++ b/packages/labs/gen-wrapper-vue/goldens/test-element-a/src/ElementEvents.vue
@@ -42,7 +42,7 @@ const emit = defineEmits<{
   ): void;
 }>();
 
-const slots = useSlots();
+const slots = useSlots() as Slots;
 
 const render = () => {
   const eventProps = {
@@ -73,7 +73,7 @@ const render = () => {
 
   hasRendered = true;
 
-  return h('element-events', props, assignSlotNodes(slots as Slots));
+  return h('element-events', props, assignSlotNodes(slots));
 };
 </script>
 <template><render v-defaults /></template>

--- a/packages/labs/gen-wrapper-vue/goldens/test-element-a/src/ElementMixins.vue
+++ b/packages/labs/gen-wrapper-vue/goldens/test-element-a/src/ElementMixins.vue
@@ -5,13 +5,13 @@ import '@lit-internal/test-element-a/element-mixins.js';
 
 export interface Props {}
 
-const slots = useSlots();
+const slots = useSlots() as Slots;
 
 const render = () => {
   const eventProps = {};
   const props = eventProps as typeof eventProps & Props;
 
-  return h('element-mixins', props, assignSlotNodes(slots as Slots));
+  return h('element-mixins', props, assignSlotNodes(slots));
 };
 </script>
 <template><render /></template>

--- a/packages/labs/gen-wrapper-vue/goldens/test-element-a/src/ElementProps.vue
+++ b/packages/labs/gen-wrapper-vue/goldens/test-element-a/src/ElementProps.vue
@@ -32,7 +32,7 @@ const emit = defineEmits<{
   (e: 'a-changed', payload: CustomEvent<unknown>): void;
 }>();
 
-const slots = useSlots();
+const slots = useSlots() as Slots;
 
 const render = () => {
   const eventProps = {
@@ -50,7 +50,7 @@ const render = () => {
 
   hasRendered = true;
 
-  return h('element-props', props, assignSlotNodes(slots as Slots));
+  return h('element-props', props, assignSlotNodes(slots));
 };
 </script>
 <template><render v-defaults /></template>

--- a/packages/labs/gen-wrapper-vue/goldens/test-element-a/src/ElementSlots.vue
+++ b/packages/labs/gen-wrapper-vue/goldens/test-element-a/src/ElementSlots.vue
@@ -20,7 +20,7 @@ const vDefaults = {
 
 let hasRendered = false;
 
-const slots = useSlots();
+const slots = useSlots() as Slots;
 
 const render = () => {
   const eventProps = {};
@@ -35,7 +35,7 @@ const render = () => {
 
   hasRendered = true;
 
-  return h('element-slots', props, assignSlotNodes(slots as Slots));
+  return h('element-slots', props, assignSlotNodes(slots));
 };
 </script>
 <template><render v-defaults /></template>

--- a/packages/labs/gen-wrapper-vue/goldens/test-element-a/src/ElementWithoutProps.vue
+++ b/packages/labs/gen-wrapper-vue/goldens/test-element-a/src/ElementWithoutProps.vue
@@ -5,13 +5,13 @@ import '@lit-internal/test-element-a/element-without-props.js';
 
 export interface Props {}
 
-const slots = useSlots();
+const slots = useSlots() as Slots;
 
 const render = () => {
   const eventProps = {};
   const props = eventProps as typeof eventProps & Props;
 
-  return h('element-without-props', props, assignSlotNodes(slots as Slots));
+  return h('element-without-props', props, assignSlotNodes(slots));
 };
 </script>
 <template><render /></template>

--- a/packages/labs/gen-wrapper-vue/goldens/test-element-a/src/sub/ElementSub.vue
+++ b/packages/labs/gen-wrapper-vue/goldens/test-element-a/src/sub/ElementSub.vue
@@ -24,7 +24,7 @@ const emit = defineEmits<{
   (e: 'sub-changed', payload: CustomEvent<unknown>): void;
 }>();
 
-const slots = useSlots();
+const slots = useSlots() as Slots;
 
 const render = () => {
   const eventProps = {
@@ -42,7 +42,7 @@ const render = () => {
 
   hasRendered = true;
 
-  return h('element-sub', props, assignSlotNodes(slots as Slots));
+  return h('element-sub', props, assignSlotNodes(slots));
 };
 </script>
 <template><render v-defaults /></template>

--- a/packages/labs/gen-wrapper-vue/src/lib/wrapper-module-template-sfc.ts
+++ b/packages/labs/gen-wrapper-vue/src/lib/wrapper-module-template-sfc.ts
@@ -162,7 +162,7 @@ const wrapperTemplate = (
           : ''
       }
 
-      const slots = useSlots();
+      const slots = useSlots() as Slots;
 
       const render = () => {
         const eventProps = ${renderEvents(events)};
@@ -173,7 +173,7 @@ const wrapperTemplate = (
         return h(
           '${tagname}',
           props,
-          assignSlotNodes(slots as Slots)
+          assignSlotNodes(slots)
         );
       };
     </script>


### PR DESCRIPTION
This fixes test failures that started happening recently. https://github.com/lit/lit/actions/runs/12586758426/job/35081270464#step:7:67

I suspect some default tsconfig was changed in the the latest `vue-tsc` minor update that started causing this as we do not have a lockfile for the generated test package.