### PR TITLE
[labs/ssr-dom-shim] Add DOM shim implementation for `MutationObserver`, `ResizeObserver` and `IntersectionObserver`

### DIFF
--- a/.changeset/silver-donkeys-applaud.md
+++ b/.changeset/silver-donkeys-applaud.md
@@ -1,0 +1,6 @@
+---
+'@lit-labs/ssr-dom-shim': minor
+'@lit-labs/ssr': minor
+---
+
+Add DOM shim implementation for `MutationObserver`, `ResizeObserver` and `IntersectionObserver`

--- a/packages/labs/ssr-dom-shim/README.md
+++ b/packages/labs/ssr-dom-shim/README.md
@@ -3,8 +3,9 @@
 ## Overview
 
 This package provides minimal implementations of `Element`, `HTMLElement`,
-`EventTarget`, `Event`, `CustomEvent`, `CustomElementRegistry`, and
-`customElements`, designed to be used when Server Side Rendering (SSR) web
+`EventTarget`, `Event`, `CustomEvent`, `MutationObserver`, `ResizeObserver`,
+`IntersectionObserver`, `CustomElementRegistry`, and `customElements`,
+designed to be used when Server Side Rendering (SSR) web
 components from Node, including Lit components.
 
 ## Usage
@@ -61,6 +62,22 @@ this module.
 - [`customElements`](https://developer.mozilla.org/en-US/docs/Web/API/Window/customElements)
 - [`Event`](https://developer.mozilla.org/en-US/docs/Web/API/Event)
 - [`CustomEvent`](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent)
+- [`MutationObserver`](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver)
+  - [`observe`](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver/observe)
+  - [`takeRecords`](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver/takeRecords)
+  - [`disconnect`](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver/disconnect)
+- [`ResizeObserver`](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver)
+  - [`observe`](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver/observe)
+  - [`unobserve`](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver/unobserve)
+  - [`disconnect`](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver/disconnect)
+- [`IntersectionObserver`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver)
+  - [`root`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/root)
+  - [`rootMargin`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/rootMargin)
+  - [`thresholds`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/thresholds)
+  - [`observe`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/observe)
+  - [`takeRecords`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/takeRecords)
+  - [`unobserve`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/unobserve)
+  - [`disconnect`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/disconnect)
 
 ## Contributing
 

--- a/packages/labs/ssr-dom-shim/README.md
+++ b/packages/labs/ssr-dom-shim/README.md
@@ -3,8 +3,9 @@
 ## Overview
 
 This package provides minimal implementations of `Element`, `HTMLElement`,
-`EventTarget`, `Event`, `CustomEvent`, `CustomElementRegistry`, and
-`customElements`, designed to be used when Server Side Rendering (SSR) web
+`EventTarget`, `Event`, `CustomEvent`, `MutationObserver`, `ResizeObserver`,
+`IntersectionObserver`, `CustomElementRegistry`, and `customElements`,
+designed to be used when Server Side Rendering (SSR) web
 components from Node, including Lit components.
 
 ## Usage
@@ -64,6 +65,22 @@ this module.
 - [`customElements`](https://developer.mozilla.org/en-US/docs/Web/API/Window/customElements)
 - [`Event`](https://developer.mozilla.org/en-US/docs/Web/API/Event)
 - [`CustomEvent`](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent)
+- [`MutationObserver`](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver)
+  - [`observe`](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver/observe)
+  - [`takeRecords`](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver/takeRecords)
+  - [`disconnect`](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver/disconnect)
+- [`ResizeObserver`](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver)
+  - [`observe`](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver/observe)
+  - [`unobserve`](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver/unobserve)
+  - [`disconnect`](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver/disconnect)
+- [`IntersectionObserver`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver)
+  - [`root`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/root)
+  - [`rootMargin`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/rootMargin)
+  - [`thresholds`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/thresholds)
+  - [`observe`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/observe)
+  - [`takeRecords`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/takeRecords)
+  - [`unobserve`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/unobserve)
+  - [`disconnect`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/disconnect)
 - [`MediaList`](https://developer.mozilla.org/en-US/docs/Web/API/MediaList)
 - [`StyleSheet`](https://developer.mozilla.org/en-US/docs/Web/API/StyleSheet)
 - [`CSSRule`](https://developer.mozilla.org/en-US/docs/Web/API/CSSRule)

--- a/packages/labs/ssr-dom-shim/src/index.ts
+++ b/packages/labs/ssr-dom-shim/src/index.ts
@@ -17,6 +17,11 @@ export {
   HYDRATE_INTERNALS_ATTR_PREFIX,
 } from './lib/element-internals.js';
 export {CustomEvent, Event, EventTarget} from './lib/events.js';
+export {
+  IntersectionObserver,
+  MutationObserver,
+  ResizeObserver,
+} from './lib/observers.js';
 
 // In an empty Node.js vm, we need to patch the global context.
 // TODO: Remove these globalThis assignments when we remove support

--- a/packages/labs/ssr-dom-shim/src/index.ts
+++ b/packages/labs/ssr-dom-shim/src/index.ts
@@ -19,6 +19,11 @@ export {
   StyleSheet,
 } from './lib/css.js';
 export {CustomEvent, Event} from './lib/events.js';
+export {
+  IntersectionObserver,
+  MutationObserver,
+  ResizeObserver,
+} from './lib/observers.js';
 
 // In an empty Node.js vm, we need to patch the global context.
 // TODO: Remove these globalThis assignments when we remove support

--- a/packages/labs/ssr-dom-shim/src/lib/observers.ts
+++ b/packages/labs/ssr-dom-shim/src/lib/observers.ts
@@ -1,0 +1,79 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * This is a limited implemenation of the observer family of classes.
+ */
+
+type MutationObserverInterface = MutationObserver;
+
+/**
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver
+ */
+const MutationObserverShim = class MutationObserver
+  implements MutationObserverInterface
+{
+  constructor(_callback: MutationCallback) {}
+  disconnect(): void {}
+  observe(_target: Node, _options?: MutationObserverInit): void {}
+  takeRecords(): MutationRecord[] {
+    return [];
+  }
+};
+const MutationObserverShimWithRealType =
+  MutationObserverShim as object as typeof MutationObserver;
+export {MutationObserverShimWithRealType as MutationObserver};
+
+type ResizeObserverInterface = ResizeObserver;
+
+/**
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver
+ */
+const ResizeObserverShim = class ResizeObserver
+  implements ResizeObserverInterface
+{
+  constructor(_callback: ResizeObserverCallback) {}
+  disconnect(): void {}
+  observe(_target: Element, _options?: ResizeObserverOptions): void {}
+  unobserve(_target: Element): void {}
+};
+const ResizeObserverShimWithRealType =
+  ResizeObserverShim as object as typeof ResizeObserver;
+export {ResizeObserverShimWithRealType as ResizeObserver};
+
+type IntersectionObserverInterface = IntersectionObserver;
+
+/**
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver
+ */
+const IntersectionObserverShim = class IntersectionObserver
+  implements IntersectionObserverInterface
+{
+  constructor(
+    _callback: IntersectionObserverCallback,
+    private __options?: IntersectionObserverInit
+  ) {}
+  get root(): Element | Document | null {
+    return this.__options?.root ?? null;
+  }
+  get rootMargin(): string {
+    return this.__options?.rootMargin ?? '0px 0px 0px 0px';
+  }
+  get thresholds(): readonly number[] {
+    return Array.isArray(this.__options?.threshold)
+      ? this.__options.threshold
+      : [this.__options?.threshold ?? 0];
+  }
+  disconnect(): void {}
+  observe(_target: Element): void {}
+  takeRecords(): IntersectionObserverEntry[] {
+    return [];
+  }
+  unobserve(_target: Element): void {}
+};
+const IntersectionObserverShimWithRealType =
+  IntersectionObserverShim as object as typeof IntersectionObserver;
+export {IntersectionObserverShimWithRealType as IntersectionObserver};

--- a/packages/labs/ssr-dom-shim/src/lib/observers.ts
+++ b/packages/labs/ssr-dom-shim/src/lib/observers.ts
@@ -1,0 +1,82 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * This is a limited implemenation of the observer family of classes.
+ * They are essentially no-op implementations that allow code that uses them to
+ * run without error, but they do not actually perform any observation. This
+ * works in SSR where the observed changes would never occur.
+ */
+
+type MutationObserverInterface = MutationObserver;
+
+/**
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver
+ */
+const MutationObserverShim = class MutationObserver
+  implements MutationObserverInterface
+{
+  constructor(_callback: MutationCallback) {}
+  disconnect(): void {}
+  observe(_target: Node, _options?: MutationObserverInit): void {}
+  takeRecords(): MutationRecord[] {
+    return [];
+  }
+};
+const MutationObserverShimWithRealType =
+  MutationObserverShim as object as typeof MutationObserver;
+export {MutationObserverShimWithRealType as MutationObserver};
+
+type ResizeObserverInterface = ResizeObserver;
+
+/**
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver
+ */
+const ResizeObserverShim = class ResizeObserver
+  implements ResizeObserverInterface
+{
+  constructor(_callback: ResizeObserverCallback) {}
+  disconnect(): void {}
+  observe(_target: Element, _options?: ResizeObserverOptions): void {}
+  unobserve(_target: Element): void {}
+};
+const ResizeObserverShimWithRealType =
+  ResizeObserverShim as object as typeof ResizeObserver;
+export {ResizeObserverShimWithRealType as ResizeObserver};
+
+type IntersectionObserverInterface = IntersectionObserver;
+
+/**
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver
+ */
+const IntersectionObserverShim = class IntersectionObserver
+  implements IntersectionObserverInterface
+{
+  constructor(
+    _callback: IntersectionObserverCallback,
+    private __options?: IntersectionObserverInit
+  ) {}
+  get root(): Element | Document | null {
+    return this.__options?.root ?? null;
+  }
+  get rootMargin(): string {
+    return this.__options?.rootMargin ?? '0px 0px 0px 0px';
+  }
+  get thresholds(): readonly number[] {
+    return Array.isArray(this.__options?.threshold)
+      ? this.__options.threshold
+      : [this.__options?.threshold ?? 0];
+  }
+  disconnect(): void {}
+  observe(_target: Element): void {}
+  takeRecords(): IntersectionObserverEntry[] {
+    return [];
+  }
+  unobserve(_target: Element): void {}
+};
+const IntersectionObserverShimWithRealType =
+  IntersectionObserverShim as object as typeof IntersectionObserver;
+export {IntersectionObserverShimWithRealType as IntersectionObserver};

--- a/packages/labs/ssr/src/lib/dom-shim.ts
+++ b/packages/labs/ssr/src/lib/dom-shim.ts
@@ -20,6 +20,9 @@ import {
   CustomEvent,
   EventTarget,
   CustomElementRegistry,
+  IntersectionObserver,
+  MutationObserver,
+  ResizeObserver,
 } from '@lit-labs/ssr-dom-shim';
 
 /**
@@ -78,9 +81,9 @@ export const getWindow = ({
       fetch(url as unknown as Parameters<typeof fetch>[0], init),
 
     location: new URL('http://localhost'),
-    MutationObserver: class {
-      observe() {}
-    },
+    IntersectionObserver,
+    MutationObserver,
+    ResizeObserver,
 
     // No-op any async tasks
     requestAnimationFrame() {},

--- a/packages/labs/ssr/src/lib/dom-shim.ts
+++ b/packages/labs/ssr/src/lib/dom-shim.ts
@@ -24,6 +24,9 @@ import {
   CSSStyleSheet,
   CustomElementRegistry,
   ShadowRoot,
+  IntersectionObserver,
+  MutationObserver,
+  ResizeObserver,
 } from '@lit-labs/ssr-dom-shim';
 
 /**
@@ -64,9 +67,9 @@ export const getWindow = ({
       fetch(url as unknown as Parameters<typeof fetch>[0], init),
 
     location: new URL('http://localhost'),
-    MutationObserver: class {
-      observe() {}
-    },
+    IntersectionObserver,
+    MutationObserver,
+    ResizeObserver,
 
     // No-op any async tasks
     requestAnimationFrame() {},


### PR DESCRIPTION
Relates to #4882