### PR TITLE
feat(lit): make disabling dev mode warnings simpler

### DIFF
--- a/packages/lit-element/src/lit-element.ts
+++ b/packages/lit-element/src/lit-element.ts
@@ -279,9 +279,11 @@ export const _$LE = {
 // This line will be used in regexes to search for LitElement usage.
 (globalThis.litElementVersions ??= []).push('4.1.1');
 if (DEV_MODE && globalThis.litElementVersions.length > 1) {
-  issueWarning!(
-    'multiple-versions',
-    `Multiple versions of Lit loaded. Loading multiple versions ` +
-      `is not recommended.`
-  );
+  queueMicrotask(() => {
+    issueWarning!(
+      'multiple-versions',
+      `Multiple versions of Lit loaded. Loading multiple versions ` +
+        `is not recommended.`
+    );
+  });
 }

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -228,10 +228,12 @@ if (DEV_MODE) {
     }
   };
 
-  issueWarning(
-    'dev-mode',
-    `Lit is in dev mode. Not recommended for production!`
-  );
+  queueMicrotask(() => {
+    issueWarning(
+      'dev-mode',
+      `Lit is in dev mode. Not recommended for production!`
+    );
+  });
 }
 
 const wrap =
@@ -2197,11 +2199,13 @@ polyfillSupport?.(Template, ChildPart);
 // This line will be used in regexes to search for lit-html usage.
 (global.litHtmlVersions ??= []).push('3.2.1');
 if (DEV_MODE && global.litHtmlVersions.length > 1) {
-  issueWarning!(
-    'multiple-versions',
-    `Multiple versions of Lit loaded. ` +
-      `Loading multiple versions is not recommended.`
-  );
+  queueMicrotask(() => {
+    issueWarning!(
+      'multiple-versions',
+      `Multiple versions of Lit loaded. ` +
+        `Loading multiple versions is not recommended.`
+    );
+  });
 }
 
 /**

--- a/packages/reactive-element/src/reactive-element.ts
+++ b/packages/reactive-element/src/reactive-element.ts
@@ -94,19 +94,21 @@ if (DEV_MODE) {
     }
   };
 
-  issueWarning(
-    'dev-mode',
-    `Lit is in dev mode. Not recommended for production!`
-  );
-
-  // Issue polyfill support warning.
-  if (global.ShadyDOM?.inUse && polyfillSupport === undefined) {
+  queueMicrotask(() => {
     issueWarning(
-      'polyfill-support-missing',
-      `Shadow DOM is being polyfilled via \`ShadyDOM\` but ` +
-        `the \`polyfill-support\` module has not been loaded.`
+      'dev-mode',
+      `Lit is in dev mode. Not recommended for production!`
     );
-  }
+
+    // Issue polyfill support warning.
+    if (global.ShadyDOM?.inUse && polyfillSupport === undefined) {
+      issueWarning(
+        'polyfill-support-missing',
+        `Shadow DOM is being polyfilled via \`ShadyDOM\` but ` +
+          `the \`polyfill-support\` module has not been loaded.`
+      );
+    }
+  });
 }
 
 /**
@@ -1671,9 +1673,11 @@ if (DEV_MODE) {
 // This line will be used in regexes to search for ReactiveElement usage.
 (global.reactiveElementVersions ??= []).push('2.0.4');
 if (DEV_MODE && global.reactiveElementVersions.length > 1) {
-  issueWarning!(
-    'multiple-versions',
-    `Multiple versions of Lit loaded. Loading multiple versions ` +
-      `is not recommended.`
-  );
+  queueMicrotask(() => {
+    issueWarning!(
+      'multiple-versions',
+      `Multiple versions of Lit loaded. Loading multiple versions ` +
+        `is not recommended.`
+    );
+  });
 }


### PR DESCRIPTION
Makes it much easier to work around https://github.com/lit/lit/issues/4877.
By adding queueMicrotask, the warnings are no longer emitted in the global scope, which makes disabling them much easier (see referenced issue for details).

With this change, I am able to add code for disabling this warning to my runtime code - with that, the warning is be disabled for all consumers of my library without them having to do anything special in their test setup files.

The warning is still enabled by default in vanilla Lit for those who prefer it.

The original discussion was only about the "Lit is in dev mode" warning, but I made this change for other global scope warnings too for consistency.

## Testing

Verified that after this change I am able to silence Lit's dev mode warning regardless of the order of imports.