### PR TITLE
Use a WeakMap for ssr template cache

### DIFF
--- a/.changeset/rude-pillows-mate.md
+++ b/.changeset/rude-pillows-mate.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/ssr': patch
+---
+
+Use `WeakMap` for template cache. This prevents memory leaks when templates are dynamically created e.g. in combination with `unsafeHTML()`.

--- a/packages/labs/ssr/src/lib/render-value.ts
+++ b/packages/labs/ssr/src/lib/render-value.ts
@@ -107,7 +107,7 @@ const patchAnyDirectives = (
   }
 };
 
-const templateCache = new Map<TemplateStringsArray, Array<Op>>();
+const templateCache = new WeakMap<TemplateStringsArray, Array<Op>>();
 
 // This is a map for which slots exist for a given custom element.
 // With a named slot, it is represented as a string with the name


### PR DESCRIPTION
This change mitigates potential memory leaks resulting from server-only templates that improperly use `unsafe`. A similar change was made for Lit HTML itself in https://github.com/lit/lit/pull/1647 to fix https://github.com/lit/lit/issues/1646.

The following code snippet is a minimal reproduction of a memory leak found in Reddit's code when attempting to migrate to Lit SSR -- note the instructions in the comment block:
```
/*
  This script re-creates a memory leak when using Lit SSR. Specifically, filling the template cache with a lot of nearly
  identical strings due to improper usage of "unsafe". To see this happening, do the following:

  1. Open "node_modules/@lit-labs/ssr/lib/render-value.js"
  2. Navigate to line 385 (as of the time of this comment)
  3. Add "console.log('Adding to cache:', result.strings)" right before "templateCache.set(result.strings, ops);"
  4. Run this script as-is and notice the output showing a bunch of nearly identical cache entries being added
  5. Run this script with the "unsafe" call removed from "templatedFragment" and notice the redundant cache entries are no longer present
*/

import { html as serverHtml, render } from '@lit-labs/ssr';
import { html } from 'lit';
import { unsafeHTML as unsafe } from 'lit/directives/unsafe-html.js';

export const templatedFragment = (fragment) => {
  const res = concatTemplate(fragment);
  return html`${unsafe(res)}`;
};

export const concatTemplate = (rendered) => {
  let result = '';
  for (const chunk of rendered) {
    result += chunk;
  }
  return result;
};

function renderFoo() {
  return html`
    <div>
      <div>Foo</div>
      <div>${templatedFragment(renderBar('Jim'))}</div>
      <div>${templatedFragment(renderBar('Erin'))}</div>
      <div>${templatedFragment(renderBar('Dave'))}</div>
    </div>
  `;
}

function renderBar(name) {
  return render(html`Hello ${name}`);
}

const result = render(serverHtml`${renderFoo()}`);

for (const r of result) {
  // no-op just to iterate the templates
}
```

Migrating to a `WeakMap` should allow these near-identical templates to get GC'd after they are no longer used.