### PR TITLE
[labs/virtualizer] Optionally suppress logging of ignored errors

### DIFF
--- a/.changeset/soft-queens-complain.md
+++ b/.changeset/soft-queens-complain.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/virtualizer': minor
+---
+
+Add option to suppress logging of errors ignored during tests


### PR DESCRIPTION
Virtualizer provides some helpers for ignoring errors during testing. We use these to prevent certain benign `ResizeObserver` errors from causing our tests to fail; we also export them for customers to use in their own tests as needed.

Currently, ignored errors are still logged to the console, however, which can result in noisy test output. By request, this PR adds an option to suppress logging if desired.