### PR TITLE
fix source repository for published packages

### DIFF
--- a/packages/benchmarks/generator/package.json
+++ b/packages/benchmarks/generator/package.json
@@ -5,7 +5,7 @@
   "description": "Template benchmark generator",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lit/lit.git",
+    "url": "git+https://github.com/lit/lit.git",
     "directory": "packages/benchmarks"
   },
   "author": "Google LLC",

--- a/packages/benchmarks/package.json
+++ b/packages/benchmarks/package.json
@@ -6,7 +6,7 @@
   "license": "BSD-3-Clause",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lit/lit.git",
+    "url": "git+https://github.com/lit/lit.git",
     "directory": "packages/benchmarks"
   },
   "author": "Google LLC",

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://lit.dev/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lit/lit.git",
+    "url": "git+https://github.com/lit/lit.git",
     "directory": "packages/context"
   },
   "type": "module",

--- a/packages/internal-scripts/package.json
+++ b/packages/internal-scripts/package.json
@@ -5,8 +5,8 @@
   "description": "Internal scripts for the Lit monorepo",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lit/lit.git",
-    "directory": "packages/@lit-internal/scripts"
+    "url": "git+https://github.com/lit/lit.git",
+    "directory": "packages/internal-scripts"
   },
   "author": "Google LLC",
   "license": "BSD-3-Clause",

--- a/packages/labs/analyzer/package.json
+++ b/packages/labs/analyzer/package.json
@@ -10,7 +10,7 @@
   "homepage": "https://github.com/lit/lit/tree/main/packages/labs/analyzer",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lit/lit.git",
+    "url": "git+https://github.com/lit/lit.git",
     "directory": "packages/labs/analyzer"
   },
   "main": "index.js",

--- a/packages/labs/cli-localize/package.json
+++ b/packages/labs/cli-localize/package.json
@@ -10,7 +10,11 @@
   "bugs": "https://github.com/lit/lit/issues",
   "type": "module",
   "main": "lib/index.js",
-  "repository": "lit/lit",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lit/lit.git",
+    "directory": "packages/labs/cli-localize"
+  },
   "scripts": {
     "build": "wireit",
     "test": "wireit",

--- a/packages/labs/cli/package.json
+++ b/packages/labs/cli/package.json
@@ -13,7 +13,11 @@
   "bugs": "https://github.com/lit/lit/issues",
   "type": "module",
   "main": "lib/index.js",
-  "repository": "lit/lit",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lit/lit.git",
+    "directory": "packages/labs/cli"
+  },
   "scripts": {
     "build": "wireit",
     "test": "wireit",

--- a/packages/labs/compiler/package.json
+++ b/packages/labs/compiler/package.json
@@ -3,7 +3,7 @@
   "description": "Compiler to prepare Lit templates at build time",
   "version": "1.1.1",
   "author": "Google LLC",
-  "homepage": "https://github.com/Lit/Lit/tree/main/packages/labs/compiler",
+  "homepage": "https://github.com/lit/lit/tree/main/packages/labs/compiler",
   "license": "BSD-3-Clause",
   "type": "module",
   "main": "index.js",
@@ -20,7 +20,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Lit/Lit.git",
+    "url": "git+https://github.com/lit/lit.git",
     "directory": "packages/labs/compiler"
   },
   "bugs": {

--- a/packages/labs/context/package.json
+++ b/packages/labs/context/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://lit.dev/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lit/lit.git",
+    "url": "git+https://github.com/lit/lit.git",
     "directory": "packages/labs/context"
   },
   "type": "module",

--- a/packages/labs/eleventy-plugin-lit/package.json
+++ b/packages/labs/eleventy-plugin-lit/package.json
@@ -7,7 +7,7 @@
   "homepage": "https://lit.dev/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lit/lit.git",
+    "url": "git+https://github.com/lit/lit.git",
     "directory": "packages/labs/eleventy-plugin-lit"
   },
   "publishConfig": {

--- a/packages/labs/eslint-plugin/package.json
+++ b/packages/labs/eslint-plugin/package.json
@@ -8,8 +8,8 @@
   "homepage": "https://github.com/lit/lit/tree/main/packages/labs/esling-plugin-lit",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lit/lit.git",
-    "directory": "packages/labs/eslint-plugin-lit"
+    "url": "git+https://github.com/lit/lit.git",
+    "directory": "packages/labs/eslint-plugin"
   },
   "main": "index.js",
   "type": "module",

--- a/packages/labs/gen-manifest/package.json
+++ b/packages/labs/gen-manifest/package.json
@@ -7,7 +7,11 @@
   "bugs": "https://github.com/lit/lit/issues",
   "type": "module",
   "main": "index.js",
-  "repository": "lit/lit",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lit/lit.git",
+    "directory": "packages/labs/gen-manifest"
+  },
   "scripts": {
     "build": "wireit",
     "test": "wireit",

--- a/packages/labs/gen-utils/package.json
+++ b/packages/labs/gen-utils/package.json
@@ -10,7 +10,11 @@
   "bugs": "https://github.com/lit/lit/issues",
   "type": "module",
   "main": "index.js",
-  "repository": "lit/lit",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lit/lit.git",
+    "directory": "packages/labs/gen"
+  },
   "scripts": {
     "build": "wireit",
     "test": "wireit"

--- a/packages/labs/gen-wrapper-angular/package.json
+++ b/packages/labs/gen-wrapper-angular/package.json
@@ -11,7 +11,11 @@
   "bugs": "https://github.com/lit/lit/issues",
   "type": "module",
   "main": "lib/index.js",
-  "repository": "lit/lit",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lit/lit.git",
+    "directory": "packages/labs/gen-wrapper-angular"
+  },
   "scripts": {
     "build": "wireit",
     "test": "wireit",

--- a/packages/labs/gen-wrapper-react/package.json
+++ b/packages/labs/gen-wrapper-react/package.json
@@ -10,7 +10,11 @@
   "bugs": "https://github.com/lit/lit/issues",
   "type": "module",
   "main": "lib/index.js",
-  "repository": "lit/lit",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lit/lit.git",
+    "directory": "packages/labs/gen-wrapper-react"
+  },
   "scripts": {
     "build": "wireit",
     "test": "wireit",

--- a/packages/labs/gen-wrapper-vue/package.json
+++ b/packages/labs/gen-wrapper-vue/package.json
@@ -10,7 +10,11 @@
   "bugs": "https://github.com/lit/lit/issues",
   "type": "module",
   "main": "lib/index.js",
-  "repository": "lit/lit",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lit/lit.git",
+    "directory": "packages/labs/gen-wrapper-vue"
+  },
   "scripts": {
     "build": "wireit",
     "test": "wireit",

--- a/packages/labs/motion/package.json
+++ b/packages/labs/motion/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://lit.dev/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lit/lit.git",
+    "url": "git+https://github.com/lit/lit.git",
     "directory": "packages/labs/motion"
   },
   "type": "module",

--- a/packages/labs/nextjs/package.json
+++ b/packages/labs/nextjs/package.json
@@ -10,7 +10,7 @@
   "homepage": "https://github.com/lit/lit/tree/main/packages/labs/nextjs",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lit/lit.git",
+    "url": "git+https://github.com/lit/lit.git",
     "directory": "packages/labs/nextjs"
   },
   "main": "index.js",

--- a/packages/labs/observers/package.json
+++ b/packages/labs/observers/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://lit.dev/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lit/lit.git",
+    "url": "git+https://github.com/lit/lit.git",
     "directory": "packages/labs/observers"
   },
   "type": "module",

--- a/packages/labs/preact-signals/package.json
+++ b/packages/labs/preact-signals/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://lit.dev/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lit/lit.git",
+    "url": "git+https://github.com/lit/lit.git",
     "directory": "packages/labs/preact-signals"
   },
   "type": "module",

--- a/packages/labs/react/package.json
+++ b/packages/labs/react/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://lit.dev/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lit/lit.git",
+    "url": "git+https://github.com/lit/lit.git",
     "directory": "packages/labs/react"
   },
   "type": "module",

--- a/packages/labs/rollup-plugin-minify-html-literals/package.json
+++ b/packages/labs/rollup-plugin-minify-html-literals/package.json
@@ -24,7 +24,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/lit/lit.git",
+    "url": "git+https://github.com/lit/lit.git",
     "directory": "packages/labs/rollup-plugin-minify-html-literals"
   },
   "scripts": {

--- a/packages/labs/router/package.json
+++ b/packages/labs/router/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://lit.dev/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lit/lit.git",
+    "url": "git+https://github.com/lit/lit.git",
     "directory": "packages/labs/router"
   },
   "publishConfig": {

--- a/packages/labs/scoped-registry-mixin/package.json
+++ b/packages/labs/scoped-registry-mixin/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://lit.dev/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lit/lit.git",
+    "url": "git+https://github.com/lit/lit.git",
     "directory": "packages/labs/scoped-registry-mixin"
   },
   "type": "module",

--- a/packages/labs/signals/package.json
+++ b/packages/labs/signals/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://lit.dev/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lit/lit.git",
+    "url": "git+https://github.com/lit/lit.git",
     "directory": "packages/labs/signals"
   },
   "type": "module",

--- a/packages/labs/ssr-client/package.json
+++ b/packages/labs/ssr-client/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://lit.dev/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lit/lit.git",
+    "url": "git+https://github.com/lit/lit.git",
     "directory": "packages/labs/ssr-client"
   },
   "type": "module",

--- a/packages/labs/ssr-dom-shim/package.json
+++ b/packages/labs/ssr-dom-shim/package.json
@@ -10,7 +10,7 @@
   "homepage": "https://github.com/lit/lit/tree/main/packages/labs/ssr-dom-shim",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lit/lit.git",
+    "url": "git+https://github.com/lit/lit.git",
     "directory": "packages/labs/ssr-dom-shim"
   },
   "main": "index.js",

--- a/packages/labs/ssr-react/package.json
+++ b/packages/labs/ssr-react/package.json
@@ -10,7 +10,7 @@
   "homepage": "https://github.com/lit/lit/tree/main/packages/labs/ssr-react",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lit/lit.git",
+    "url": "git+https://github.com/lit/lit.git",
     "directory": "packages/labs/ssr-react"
   },
   "main": "index.js",

--- a/packages/labs/ssr/package.json
+++ b/packages/labs/ssr/package.json
@@ -200,7 +200,7 @@
   "license": "BSD-3-Clause",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lit/lit.git",
+    "url": "git+https://github.com/lit/lit.git",
     "directory": "packages/labs/ssr"
   },
   "devDependencies": {

--- a/packages/labs/task/package.json
+++ b/packages/labs/task/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://lit.dev/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lit/lit.git",
+    "url": "git+https://github.com/lit/lit.git",
     "directory": "packages/labs/task"
   },
   "type": "module",

--- a/packages/labs/testing/package.json
+++ b/packages/labs/testing/package.json
@@ -10,7 +10,7 @@
   "homepage": "https://github.com/lit/lit/tree/main/packages/labs/testing",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lit/lit.git",
+    "url": "git+https://github.com/lit/lit.git",
     "directory": "packages/labs/testing"
   },
   "main": "index.js",

--- a/packages/labs/tsserver-plugin/package.json
+++ b/packages/labs/tsserver-plugin/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://github.com/lit/lit/tree/main/packages/labs/tsserver-plugin",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lit/lit.git",
+    "url": "git+https://github.com/lit/lit.git",
     "directory": "packages/labs/tsserver-plugin"
   },
   "main": "index.js",

--- a/packages/labs/virtualizer/package.json
+++ b/packages/labs/virtualizer/package.json
@@ -7,7 +7,7 @@
   "homepage": "https://lit.dev/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lit/lit.git",
+    "url": "git+https://github.com/lit/lit.git",
     "directory": "packages/labs/virtualizer"
   },
   "main": "lit-virtualizer.js",

--- a/packages/labs/vue-utils/package.json
+++ b/packages/labs/vue-utils/package.json
@@ -9,7 +9,7 @@
   "homepage": "https://lit.dev/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lit/lit.git",
+    "url": "git+https://github.com/lit/lit.git",
     "directory": "packages/labs/vue-utils"
   },
   "type": "module",

--- a/packages/lit-element/package.json
+++ b/packages/lit-element/package.json
@@ -8,7 +8,7 @@
   "license": "BSD-3-Clause",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lit/lit.git",
+    "url": "git+https://github.com/lit/lit.git",
     "directory": "packages/lit-element"
   },
   "author": "Google LLC",

--- a/packages/lit-html/package.json
+++ b/packages/lit-html/package.json
@@ -5,7 +5,7 @@
   "license": "BSD-3-Clause",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lit/lit.git",
+    "url": "git+https://github.com/lit/lit.git",
     "directory": "packages/lit-html"
   },
   "author": "Google LLC",

--- a/packages/lit/package.json
+++ b/packages/lit/package.json
@@ -8,7 +8,7 @@
   "license": "BSD-3-Clause",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lit/lit.git",
+    "url": "git+https://github.com/lit/lit.git",
     "directory": "packages/lit"
   },
   "author": "Google LLC",

--- a/packages/localize-tools/package.json
+++ b/packages/localize-tools/package.json
@@ -10,7 +10,7 @@
   "homepage": "https://github.com/lit/lit/tree/main/packages/localize-tools",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lit/lit.git",
+    "url": "git+https://github.com/lit/lit.git",
     "directory": "packages/localize-tools"
   },
   "bin": {

--- a/packages/localize/package.json
+++ b/packages/localize/package.json
@@ -7,10 +7,10 @@
   "description": "Localization client library for lit-html",
   "license": "BSD-3-Clause",
   "author": "Google LLC",
-  "homepage": "https://github.com/Lit/Lit/tree/main/packages/localize",
+  "homepage": "https://github.com/lit/lit/tree/main/packages/localize",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Lit/Lit.git",
+    "url": "git+https://github.com/lit/lit.git",
     "directory": "packages/localize"
   },
   "main": "lit-localize.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://lit.dev/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lit/lit.git",
+    "url": "git+https://github.com/lit/lit.git",
     "directory": "packages/react"
   },
   "type": "module",

--- a/packages/reactive-element/package.json
+++ b/packages/reactive-element/package.json
@@ -8,7 +8,7 @@
   "license": "BSD-3-Clause",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lit/lit.git",
+    "url": "git+https://github.com/lit/lit.git",
     "directory": "packages/reactive-element"
   },
   "author": "Google LLC",

--- a/packages/task/package.json
+++ b/packages/task/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://lit.dev/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lit/lit.git",
+    "url": "git+https://github.com/lit/lit.git",
     "directory": "packages/task"
   },
   "type": "module",

--- a/packages/ts-transformers/package.json
+++ b/packages/ts-transformers/package.json
@@ -10,7 +10,7 @@
   "homepage": "https://github.com/lit/lit/tree/main/packages/ts-transformers",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lit/lit.git",
+    "url": "git+https://github.com/lit/lit.git",
     "directory": "packages/ts-transformers"
   },
   "type": "commonjs",


### PR DESCRIPTION
the addition of npm provenance https://github.com/lit/lit/pull/4853 caused an error during publish due to mismatching repository name https://github.com/lit/lit/actions/runs/13334139101/job/37245336881#step:6:202

i believe only the compiler package was affected from the last release but merging this and re-running release should fix it.

i went through all packages and fixed any incorrect `repository` fields.

i also added `git+` to the urls which is the correct syntax per https://docs.npmjs.com/cli/v11/configuring-npm/package-json#repository. turns out changeset has been fixing those for us during the release script. it's also what you get by running `npm pkg fix` which finds errors in your `package.json` and corrects them.