### PR TITLE
fix: widen React peer dependency range to include React 19

### DIFF
--- a/.changeset/orange-oranges-hammer.md
+++ b/.changeset/orange-oranges-hammer.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/gen-wrapper-react': patch
+---
+
+Widen range of React peerdependency to include React 19

--- a/packages/labs/gen-wrapper-react/goldens/test-element-a/package.json
+++ b/packages/labs/gen-wrapper-react/goldens/test-element-a/package.json
@@ -11,8 +11,8 @@
     "@lit/react": "^1.0.0"
   },
   "peerDependencies": {
-    "react": "^17 || ^18",
-    "@types/react": "^17 || ^18"
+    "react": "^17 || ^18 || ^19",
+    "@types/react": "^17 || ^18 || ^19"
   },
   "devDependencies": {
     "typescript": "~5.5.0"

--- a/packages/labs/gen-wrapper-react/src/index.ts
+++ b/packages/labs/gen-wrapper-react/src/index.ts
@@ -96,8 +96,8 @@ const packageJsonTemplate = (
       },
       peerDependencies: {
         // TODO(kschaaf): make react version(s) configurable?
-        react: '^17 || ^18',
-        '@types/react': '^17 || ^18',
+        react: '^17 || ^18 || ^19',
+        '@types/react': '^17 || ^18 || ^19',
       },
       devDependencies: {
         // Use typescript from source package, assuming it exists


### PR DESCRIPTION
Earlier #4865 allows @lit/react to accept React 19 as peerdependency. This patch updates the generated package.json to include this version when using @lit-labs/gen-wrapper-react.