### PR TITLE
fix(lit-html): runtime error when passing undefined to ref

### DIFF
--- a/.changeset/sweet-hotels-love.md
+++ b/.changeset/sweet-hotels-love.md
@@ -1,0 +1,7 @@
+---
+'lit-html': minor
+'lit': minor
+'lit-element': minor
+---
+
+Fix issue when ref set to undefined is disconnected, or a ref that was set to function is set to undefined.

--- a/packages/lit-html/src/directives/ref.ts
+++ b/packages/lit-html/src/directives/ref.ts
@@ -95,8 +95,8 @@ class RefDirective extends AsyncDirective {
       if (element !== undefined) {
         this._ref.call(this._context, element);
       }
-    } else {
-      (this._ref as RefInternal)!.value = element;
+    } else if (this._ref !== undefined) {
+      (this._ref as RefInternal).value = element;
     }
   }
 

--- a/packages/lit-html/src/test/directives/ref_test.ts
+++ b/packages/lit-html/src/test/directives/ref_test.ts
@@ -354,6 +354,29 @@ suite('ref', () => {
     assert.deepEqual(bCalls, ['DIV', undefined]);
   });
 
+  test('callback passed to ref directive changes to undefined', () => {
+    const calls: Array<string | undefined> = [];
+    const callback = (el: Element | undefined) => calls.push(el?.tagName);
+
+    const go = (cb: ((el: Element | undefined) => void) | undefined) =>
+      render(html`<div ${ref(cb)}></div>`, container);
+
+    assert.doesNotThrow(() => go(callback));
+    assert.deepEqual(calls, ['DIV']);
+
+    assert.doesNotThrow(() => go(undefined));
+    assert.deepEqual(calls, ['DIV', undefined]);
+
+    assert.doesNotThrow(() => go(undefined));
+    assert.deepEqual(calls, ['DIV', undefined]);
+  });
+
+  test('does not throw when ref set to undefined, then disconnected', () => {
+    const go = () => render(html`<div ${ref(undefined)}></div>`, container);
+    const part = go();
+    assert.doesNotThrow(() => part.setConnected(false));
+  });
+
   test('new callback created each render', () => {
     const calls: Array<string | undefined> = [];
     const go = () =>


### PR DESCRIPTION
Fixes #4953 

This PR fixes #4953 by adding a check for undefined `this._ref` before setting `this._ref.value`.

Two tests have been added, reflecting two scenarios for triggering this error:

- Disconnect an element with `ref(undefined)`
- Render `ref(undefined)` on an element that previously had `ref(someFunc)`