### PR TITLE
fix(lit-html): import `trusted-types/lib` barrel explicitly.

### DIFF
--- a/.changeset/wild-ways-deliver.md
+++ b/.changeset/wild-ways-deliver.md
@@ -1,0 +1,5 @@
+---
+'lit-html': patch
+---
+
+Import barrels explicitly for compatibility with modern Node resolution w/ ESM

--- a/.changeset/wild-ways-deliver.md
+++ b/.changeset/wild-ways-deliver.md
@@ -1,5 +1,6 @@
 ---
 'lit-html': patch
+'lit': patch
 ---
 
 Import barrels explicitly for compatibility with modern Node resolution w/ ESM

--- a/package-lock.json
+++ b/package-lock.json
@@ -6358,6 +6358,10 @@
       "resolved": "packages/tests",
       "link": true
     },
+    "node_modules/@lit-internal/tests-typescript": {
+      "resolved": "packages/tests-typescript",
+      "link": true
+    },
     "node_modules/@lit-labs/analyzer": {
       "resolved": "packages/labs/analyzer",
       "link": true
@@ -31950,6 +31954,27 @@
         "diff": "^5.0.0",
         "dir-compare": "^4.0.0",
         "prettier": "^2.3.2"
+      }
+    },
+    "packages/tests-typescript": {
+      "name": "@lit-internal/tests-typescript",
+      "version": "0.0.1",
+      "dependencies": {
+        "lit": "3.2.1",
+        "typescript": "5.8.2"
+      }
+    },
+    "packages/tests-typescript/node_modules/typescript": {
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "packages/tests/node_modules/prettier": {

--- a/package.json
+++ b/package.json
@@ -160,6 +160,7 @@
         "./packages/localize-tools:test",
         "./packages/react:test",
         "./packages/tests:test",
+        "./packages/tests-typescript:test",
         "./packages/ts-transformers:test",
         "./packages/labs/analyzer:test",
         "./packages/labs/cli:test",

--- a/packages/labs/compiler/src/lib/template-transform.ts
+++ b/packages/labs/compiler/src/lib/template-transform.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import type {TrustedHTML} from 'trusted-types/lib';
+import type {TrustedHTML} from 'trusted-types/lib/index.js';
 import ts from 'typescript';
 import {_$LH as litHtmlPrivate} from 'lit-html/private-ssr-support.js';
 import {parseFragment, serialize} from 'parse5';

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -6,7 +6,7 @@
 
 // IMPORTANT: these imports must be type-only
 import type {Directive, DirectiveResult, PartInfo} from './directive.js';
-import type {TrustedHTML, TrustedTypesWindow} from 'trusted-types/lib';
+import type {TrustedHTML, TrustedTypesWindow} from 'trusted-types/lib/index.js';
 
 const DEV_MODE = true;
 const ENABLE_EXTRA_SECURITY_HOOKS = true;

--- a/packages/tests-typescript/package.json
+++ b/packages/tests-typescript/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "dependencies": {
     "typescript": "5.8.2",
-    "lit": "3.2.1"
+    "lit": "*"
   },
   "scripts": {
     "test": "wireit",
@@ -34,7 +34,7 @@
       ]
     },
     "test:bundler": {
-      "command": "npx tsc --module es2020 --moduleResolution bundler  --lib DOM --noEmit src/test-entry.ts",
+      "command": "npx tsc --module es2020 --moduleResolution bundler --lib DOM --noEmit src/test-entry.ts",
       "dependencies": [
         "../lit:build"
       ]

--- a/packages/tests-typescript/package.json
+++ b/packages/tests-typescript/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@lit-internal/tests-typescript",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "typescript": "5.8.2",
+    "lit": "3.2.1"
+  },
+  "scripts": {
+    "test": "wireit",
+    "test:node": "wireit",
+    "test:nodenext": "wireit",
+    "test:bundler": "wireit"
+  },
+  "wireit": {
+    "test": {
+      "dependencies": [
+        "test:node",
+        "test:nodenext",
+        "test:bundler"
+      ]
+    },
+    "test:node": {
+      "command": "npx tsc --module es2020 --moduleResolution node --lib DOM --noEmit src/test-entry.ts",
+      "dependencies": [
+        "../lit:build"
+      ]
+    },
+    "test:nodenext": {
+      "command": "npx tsc --module nodenext --moduleResolution nodenext --lib DOM --noEmit src/test-entry.ts",
+      "dependencies": [
+        "../lit:build"
+      ]
+    },
+    "test:bundler": {
+      "command": "npx tsc --module es2020 --moduleResolution bundler  --lib DOM --noEmit src/test-entry.ts",
+      "dependencies": [
+        "../lit:build"
+      ]
+    }
+  }
+}

--- a/packages/tests-typescript/src/test-entry.ts
+++ b/packages/tests-typescript/src/test-entry.ts
@@ -1,0 +1,2 @@
+import * as lit from 'lit';
+lit;


### PR DESCRIPTION
Fixes #4943

Import barrels from trusted-types/lib explicitly for compatibility with modern Node resolution.

I added a minimal test project and cover for a few module/moduleResolution pairs that I think are likely to be used with Lit.


This is related in some ways to
https://github.com/lit/lit/blob/main/CONTRIBUTING.md#typescript.
`trusted-types` was imported as an implicit directory index file (aka barrel), which is not supported with the module resolution algorithm of NodeJS (w/ ESM): https://nodejs.org/api/esm.html#mandatory-file-extensions.