### PR TITLE
[lit-html, labs/compiler] remove type imports from `trusted-types/lib`

### DIFF
--- a/.changeset/moody-onions-breathe.md
+++ b/.changeset/moody-onions-breathe.md
@@ -1,0 +1,7 @@
+---
+'@lit-labs/compiler': patch
+'lit-html': patch
+'lit': patch
+---
+
+Remove direct imports from `trusted-types/lib` which causes an error in TS 5.8.2 with module resolution node16 or nodenext.

--- a/packages/benchmarks/tsconfig.json
+++ b/packages/benchmarks/tsconfig.json
@@ -19,7 +19,7 @@
     "allowSyntheticDefaultImports": true,
     "experimentalDecorators": true,
     "noImplicitOverride": true,
-    "types": []
+    "types": ["trusted-types"]
   },
   "include": [
     "lit-element/**/*.ts",

--- a/packages/context/tsconfig.json
+++ b/packages/context/tsconfig.json
@@ -20,7 +20,7 @@
     "moduleResolution": "NodeNext",
     "allowSyntheticDefaultImports": true,
     "experimentalDecorators": true,
-    "types": ["mocha"]
+    "types": ["mocha", "trusted-types"]
   },
   "include": ["src/**/*.ts"],
   "exclude": ["src/test/std-decorators/**/*"]

--- a/packages/context/tsconfig.std-decorators-tests.json
+++ b/packages/context/tsconfig.std-decorators-tests.json
@@ -21,7 +21,7 @@
     "allowSyntheticDefaultImports": true,
     "stripInternal": true,
     "noImplicitOverride": true,
-    "types": ["mocha"]
+    "types": ["mocha", "trusted-types"]
   },
   "include": ["src/test/std-decorators/**/*.ts"],
   "exclude": [],

--- a/packages/labs/compiler/src/lib/template-transform.ts
+++ b/packages/labs/compiler/src/lib/template-transform.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import type {TrustedHTML} from 'trusted-types/lib';
 import ts from 'typescript';
 import {_$LH as litHtmlPrivate} from 'lit-html/private-ssr-support.js';
 import {parseFragment, serialize} from 'parse5';

--- a/packages/labs/compiler/tsconfig.json
+++ b/packages/labs/compiler/tsconfig.json
@@ -21,7 +21,7 @@
     "moduleResolution": "NodeNext",
     "allowSyntheticDefaultImports": true,
     "noImplicitOverride": true,
-    "types": ["node"]
+    "types": ["node", "trusted-types"]
   },
   "include": ["src/**/*.ts"],
   "exclude": ["test_files/*.ts"]

--- a/packages/labs/context/tsconfig.json
+++ b/packages/labs/context/tsconfig.json
@@ -20,7 +20,7 @@
     "moduleResolution": "NodeNext",
     "allowSyntheticDefaultImports": true,
     "experimentalDecorators": true,
-    "types": ["mocha"]
+    "types": ["mocha", "trusted-types"]
   },
   "include": ["src/**/*.ts"],
   "exclude": ["src/test/std-decorators/**/*"]

--- a/packages/labs/context/tsconfig.std-decorators-tests.json
+++ b/packages/labs/context/tsconfig.std-decorators-tests.json
@@ -21,7 +21,7 @@
     "allowSyntheticDefaultImports": true,
     "stripInternal": true,
     "noImplicitOverride": true,
-    "types": ["mocha"]
+    "types": ["mocha", "trusted-types"]
   },
   "include": ["src/test/std-decorators/**/*.ts"],
   "exclude": [],

--- a/packages/labs/motion/tsconfig.json
+++ b/packages/labs/motion/tsconfig.json
@@ -21,7 +21,7 @@
     "allowSyntheticDefaultImports": true,
     "experimentalDecorators": true,
     "noImplicitOverride": true,
-    "types": ["mocha"]
+    "types": ["mocha", "trusted-types"]
   },
   "include": ["src/**/*.ts"],
   "exclude": []

--- a/packages/lit-element/tsconfig.json
+++ b/packages/lit-element/tsconfig.json
@@ -23,7 +23,7 @@
     "importHelpers": true,
     "stripInternal": true,
     "noImplicitOverride": true,
-    "types": ["mocha"]
+    "types": ["mocha", "trusted-types"]
   },
   "include": [
     "../../node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.d.ts",

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -6,7 +6,6 @@
 
 // IMPORTANT: these imports must be type-only
 import type {Directive, DirectiveResult, PartInfo} from './directive.js';
-import type {TrustedHTML, TrustedTypesWindow} from 'trusted-types/lib';
 
 const DEV_MODE = true;
 const ENABLE_EXTRA_SECURITY_HOOKS = true;
@@ -250,7 +249,7 @@ const wrap =
     ? (global.ShadyDOM!.wrap as <T extends Node>(node: T) => T)
     : <T extends Node>(node: T) => node;
 
-const trustedTypes = (global as unknown as TrustedTypesWindow).trustedTypes;
+const trustedTypes = (global as unknown as Window).trustedTypes;
 
 /**
  * Our TrustedTypePolicy for HTML which is declared using the html template

--- a/packages/lit-html/tsconfig.json
+++ b/packages/lit-html/tsconfig.json
@@ -21,7 +21,7 @@
     "allowSyntheticDefaultImports": true,
     "stripInternal": true,
     "noImplicitOverride": true,
-    "types": ["mocha", "node"]
+    "types": ["mocha", "node", "trusted-types"]
   },
   "include": [
     "../../node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.d.ts",

--- a/packages/lit-starter-ts/tsconfig.json
+++ b/packages/lit-starter-ts/tsconfig.json
@@ -27,7 +27,7 @@
         "strict": true
       }
     ],
-    "types": ["mocha"]
+    "types": ["mocha", "trusted-types"]
   },
   "include": ["src/**/*.ts"],
   "exclude": []

--- a/packages/lit/tsconfig.json
+++ b/packages/lit/tsconfig.json
@@ -22,7 +22,7 @@
     "experimentalDecorators": true,
     "importHelpers": true,
     "noImplicitOverride": true,
-    "types": ["node"]
+    "types": ["node", "trusted-types"]
   },
   "include": ["src/**/*.ts"],
   "exclude": ["src/polyfill-support.ts"],


### PR DESCRIPTION
Fixes https://github.com/lit/lit/issues/4943

`trusted-types` package works by extending the global module and interfaces within it. I'm not sure why we ever started off having to import the separate types from the lib.