### PR TITLE
feat(ai): add symlinks to copy AI instructions for more formats

### DIFF
--- a/.clinerules
+++ b/.clinerules
@@ -1,0 +1,1 @@
+.github/copilot-instructions.md

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,1 @@
+.github/copilot-instructions.md

--- a/.prettierignore
+++ b/.prettierignore
@@ -438,3 +438,7 @@ package-lock.json
 packages/localize/examples/
 packages/localize-tools/testdata/
 packages/localize-tools/config.schema.json
+.clinerules
+.roorules
+.cursorrules
+CLAUDE.md

--- a/.prettierignore-sync
+++ b/.prettierignore-sync
@@ -11,3 +11,8 @@ package-lock.json
 packages/localize/examples/
 packages/localize-tools/testdata/
 packages/localize-tools/config.schema.json
+# Symlinks
+.clinerules
+.roorules
+.cursorrules
+CLAUDE.md

--- a/.roorules
+++ b/.roorules
@@ -1,0 +1,1 @@
+.github/copilot-instructions.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+.github/copilot-instructions.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+.github/copilot-instructions.md

--- a/package.json
+++ b/package.json
@@ -306,7 +306,7 @@
     }
   },
   "lint-staged": {
-    "**/*.{cjs,html,js,json,md,ts}": "prettier --write",
+    "**/*.{cjs,html,js,json,md,ts}": "prettier --write --no-error-on-unmatched-pattern",
     "{*.{js,ts},!(examples)/**/*.{js,ts}}": "eslint --fix"
   }
 }


### PR DESCRIPTION
Add a symlinks that link to the copilot instructions for

- [Cursor](https://cursor.com/)
- [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview)
- [Roo Code](https://roocode.com/)
- [Cline](https://cline.bot/)<!-- bbranch-comment-start -->

| Parent | Children |
| -- | -- |
| [#4970](https://github.com/lit/lit/pull/4970) |  |

<!-- bbranch-comment-end -->