### PR TITLE
[lit-html] Remove some redundant code from removePart()

### DIFF
--- a/.changeset/soft-ways-wink.md
+++ b/.changeset/soft-ways-wink.md
@@ -1,0 +1,5 @@
+---
+'lit-html': patch
+---
+
+Remove some redundant code from removePart()

--- a/packages/lit-html/src/directive-helpers.ts
+++ b/packages/lit-html/src/directive-helpers.ts
@@ -233,19 +233,18 @@ export const setCommittedValue = (part: Part, value: unknown = RESET_VALUE) =>
 export const getCommittedValue = (part: ChildPart) => part._$committedValue;
 
 /**
- * Removes a ChildPart from the DOM, including any of its content.
+ * Removes a ChildPart from the DOM, including any of its content and markers.
+ *
+ * Note: The only difference between this and clearPart() is that this also
+ * removes the part's start node. This means that the ChildPart must own its
+ * start node, ie it must be a marker node specifically for this part and not an
+ * anchor from surrounding content.
  *
  * @param part The Part to remove
  */
 export const removePart = (part: ChildPart) => {
-  part._$notifyConnectionChanged?.(false, true);
-  let start: ChildNode | null = part._$startNode;
-  const end: ChildNode | null = wrap(part._$endNode!).nextSibling;
-  while (start !== end) {
-    const n: ChildNode | null = wrap(start!).nextSibling;
-    (wrap(start!) as ChildNode).remove();
-    start = n;
-  }
+  part._$clear();
+  part._$startNode.remove();
 };
 
 export const clearPart = (part: ChildPart) => {

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -1734,8 +1734,8 @@ class ChildPart implements Disconnectable {
    * @param start Start node to clear from, for clearing a subset of the part's
    *     DOM (used when truncating iterables)
    * @param from  When `start` is specified, the index within the iterable from
-   *     which ChildParts are being removed, used for disconnecting directives in
-   *     those Parts.
+   *     which ChildParts are being removed, used for disconnecting directives
+   *     in those Parts.
    *
    * @internal
    */
@@ -1744,12 +1744,16 @@ class ChildPart implements Disconnectable {
     from?: number
   ) {
     this._$notifyConnectionChanged?.(false, true, from);
-    while (start && start !== this._$endNode) {
+    while (start !== this._$endNode) {
+      // The non-null assertion is safe because if _$startNode.nextSibling is
+      // null, then _$endNode is also null, and we would not have entered this
+      // loop.
       const n = wrap(start!).nextSibling;
-      (wrap(start!) as Element).remove();
+      wrap(start!).remove();
       start = n;
     }
   }
+
   /**
    * Implementation of RootPart's `isConnected`. Note that this method
    * should only be called on `RootPart`s (the `ChildPart` returned from a

--- a/packages/lit-html/src/test/directive-helpers_test.ts
+++ b/packages/lit-html/src/test/directive-helpers_test.ts
@@ -215,10 +215,16 @@ suite('directive-helpers', () => {
         // Create two parts and remove the first, then the second to make sure
         // that removing the first doesn't move the second's markers. This
         // fails if the parts accidentally share a marker.
-        const childPart2 = insertPart(part, undefined);
-        const childPart1 = insertPart(part, undefined, childPart2);
+        const childPart2 = insertPart(part);
+        const childPart1 = insertPart(part, childPart2);
+
+        // Check that the test is correctly inserting two different parts:
+        assert.notEqual(childPart1, childPart2);
+        assert.notEqual(childPart1._$endNode, childPart2._$startNode);
+
         removePart(childPart1);
         removePart(childPart2);
+
         return v;
       }
     }
@@ -229,6 +235,31 @@ suite('directive-helpers', () => {
 
     go('A');
     assertContent('<div>A</div>');
+  });
+
+  test('removePart removes the start marker', () => {
+    let testPart: ChildPart | undefined;
+    const testDirective = directive(
+      class TestDirective extends Directive {
+        render(v: unknown) {
+          return v;
+        }
+
+        override update(part: ChildPart, [v]: Parameters<this['render']>) {
+          testPart = part;
+          return v;
+        }
+      }
+    );
+
+    const go = (v: unknown) =>
+      render(html`<div>${testDirective(v)}</div>`, container);
+
+    go('A');
+    assertContent('<div>A</div>');
+    removePart(testPart!);
+    assertContent('<div></div>');
+    assert.strictEqual(container.firstElementChild?.childNodes.length, 0);
   });
 
   test('insertPart keeps connection state in sync', () => {

--- a/packages/lit-html/src/test/directive-helpers_test.ts
+++ b/packages/lit-html/src/test/directive-helpers_test.ts
@@ -220,7 +220,6 @@ suite('directive-helpers', () => {
 
         // Check that the test is correctly inserting two different parts:
         assert.notEqual(childPart1, childPart2);
-        assert.notEqual(childPart1._$endNode, childPart2._$startNode);
 
         removePart(childPart1);
         removePart(childPart2);

--- a/scripts/check-size.js
+++ b/scripts/check-size.js
@@ -9,8 +9,8 @@ import * as fs from 'fs';
 // it's likely that we'll ask you to investigate ways to reduce the size.
 //
 // In either case, update the size here and push a new commit to your PR.
-const expectedLitCoreSize = 15805;
-const expectedLitHtmlSize = 7303;
+const expectedLitCoreSize = 15802;
+const expectedLitHtmlSize = 7300;
 
 const litCoreSrc = fs.readFileSync('packages/lit/lit-core.min.js', 'utf8');
 const litCoreSize = fs.readFileSync('packages/lit/lit-core.min.js').byteLength;


### PR DESCRIPTION
Also fixes a directive-helpers test that was incorrectly constructing its test case.

I noticed that `removePart()` was almost the same as `ChildPart.$_clear()` with the exception of removing the start node. I also optimized `ChildPart.$_clear()` a little and noticed that the `insertPart()` test was wrong.