### PR TITLE
chore: update TypeScript dependencies to version 5.9 with related ARIAMixin changes

### DIFF
--- a/.changeset/tasty-planes-cheat.md
+++ b/.changeset/tasty-planes-cheat.md
@@ -1,0 +1,20 @@
+---
+'@lit-internal/test-element-a': patch
+'@lit-internal/localize-examples-transform-js': patch
+'@lit-internal/localize-examples-transform-ts': patch
+'@lit-labs/gen-wrapper-angular': patch
+'@lit-labs/gen-wrapper-react': patch
+'@lit-labs/gen-wrapper-vue': patch
+'@lit-labs/tsserver-plugin': patch
+'eslint-plugin-lit': patch
+'@lit-labs/cli-localize': patch
+'@lit-labs/ssr-dom-shim': patch
+'@lit-internal/tests-typescript': patch
+'@lit/lit-starter-ts': patch
+'@lit/localize-tools': patch
+'@lit-labs/analyzer': patch
+'@lit-labs/compiler': patch
+'@lit-labs/cli': patch
+---
+
+Update TypeScript dependencies to version 5.8 with related ARIAMixin changes (ariaColIndexText, ariaRelevant and ariaRowIndexText)

--- a/examples/nextjs-v13/package.json
+++ b/examples/nextjs-v13/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@lit-labs/nextjs": "^0.2.0",
     "@lit/react": "^1.0.0",
-    "@types/node": "^18.11.11",
+    "@types/node": "^22.17.0",
     "@types/react": "^18.0.26",
     "@types/react-dom": "^18.0.9",
     "eslint": "^8.29.0",

--- a/examples/nextjs-v14-app/package.json
+++ b/examples/nextjs-v14-app/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@lit-labs/nextjs": "^0.2.0",
     "@lit/react": "^1.0.0",
-    "@types/node": "^18.11.11",
+    "@types/node": "^22.17.0",
     "@types/react": "^18.0.26",
     "@types/react-dom": "^18.0.9",
     "eslint": "^8.29.0",

--- a/examples/nextjs-v14/package.json
+++ b/examples/nextjs-v14/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@lit-labs/nextjs": "^0.2.0",
     "@lit/react": "^1.0.0",
-    "@types/node": "^18.11.11",
+    "@types/node": "^22.17.0",
     "@types/react": "^18.0.26",
     "@types/react-dom": "^18.0.9",
     "eslint": "^8.29.0",

--- a/examples/nextjs-v15-app/package.json
+++ b/examples/nextjs-v15-app/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@lit-labs/nextjs": "^0.2.0",
     "@lit/react": "^1.0.0",
-    "@types/node": "^18.11.11",
+    "@types/node": "^22.17.0",
     "@types/react": "18.3.12",
     "@types/react-dom": "18.3.1",
     "eslint": "^8.29.0",

--- a/examples/nextjs-v15/package.json
+++ b/examples/nextjs-v15/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@lit-labs/nextjs": "^0.2.0",
     "@lit/react": "^1.0.0",
-    "@types/node": "^18.11.11",
+    "@types/node": "^22.17.0",
     "@types/react": "18.3.12",
     "@types/react-dom": "18.3.1",
     "eslint": "^8.29.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "rollup-plugin-sourcemaps": "^0.6.3",
         "rollup-plugin-summary": "^2.0.1",
         "rollup-plugin-terser": "^7.0.2",
-        "typescript": "~5.5.0",
+        "typescript": "~5.8.0",
         "uvu": "^0.5.6",
         "wireit": "^0.14.12"
       },
@@ -28302,9 +28302,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.2.tgz",
-      "integrity": "sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -28490,6 +28490,48 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/typescript5_5": {
+      "name": "typescript",
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript5_6": {
+      "name": "typescript",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript5_7": {
+      "name": "typescript",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/typical": {
@@ -30120,7 +30162,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "package-json-type": "^1.0.3",
-        "typescript": "~5.5.0"
+        "typescript": "~5.8.0"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^25.0.7",
@@ -30220,7 +30262,7 @@
         "command-line-commands": "^3.0.2",
         "command-line-usage": "^6.1.1",
         "tslib": "^2.0.3",
-        "typescript": "~5.5.0"
+        "typescript": "~5.8.0"
       },
       "bin": {
         "lit": "bin/lit.js"
@@ -30243,7 +30285,7 @@
         "@lit/localize-tools": "^0.8.0"
       },
       "devDependencies": {
-        "typescript": "~5.5.0"
+        "typescript": "~5.8.0"
       },
       "engines": {
         "node": ">=14.8.0"
@@ -30268,7 +30310,7 @@
         "@parse5/tools": "^0.3.0",
         "lit-html": "^3.2.0",
         "parse5": "^7.1.2",
-        "typescript": "~5.5.0"
+        "typescript": "~5.8.0"
       },
       "devDependencies": {
         "@rollup/plugin-typescript": "11.1.6",
@@ -30346,7 +30388,7 @@
       "dependencies": {
         "@lit-labs/analyzer": "^0.13.0",
         "@typescript-eslint/utils": "^6.19.0",
-        "typescript": "~5.5.0"
+        "typescript": "~5.8.0"
       },
       "devDependencies": {
         "@types/node": "^20.11.5",
@@ -31194,7 +31236,7 @@
         "lit": "file:../../../lit"
       },
       "devDependencies": {
-        "typescript": "~5.5.0"
+        "typescript": "~5.8.0"
       }
     },
     "packages/labs/test-projects/test-elements-react": {
@@ -31233,7 +31275,7 @@
       "version": "0.0.1",
       "license": "BSD-3-Clause",
       "devDependencies": {
-        "typescript": "~5.5.0"
+        "typescript": "~5.8.0"
       }
     },
     "packages/labs/virtualizer": {
@@ -31419,7 +31461,7 @@
         "rimraf": "^3.0.2",
         "rollup": "^4.18.0",
         "rollup-plugin-summary": "^2.0.1",
-        "typescript": "~5.5.0"
+        "typescript": "~5.8.0"
       }
     },
     "packages/lit-starter-ts/node_modules/@open-wc/scoped-elements": {
@@ -31725,7 +31767,7 @@
         "minimist": "^1.2.5",
         "parse5": "^7.1.1",
         "source-map-support": "^0.5.19",
-        "typescript": "~5.5.0"
+        "typescript": "~5.8.0"
       },
       "bin": {
         "lit-localize": "bin/lit-localize.js"
@@ -31821,7 +31863,7 @@
         "@web/dev-server": "^0.1.22",
         "rollup": "^4.18.0",
         "rollup-plugin-summary": "^2.0.1",
-        "typescript": "~5.5.0"
+        "typescript": "~5.8.0"
       }
     },
     "packages/localize/examples/transform-js/node_modules/typescript": {
@@ -31852,7 +31894,7 @@
         "@web/dev-server": "^0.1.22",
         "rollup": "^4.18.0",
         "rollup-plugin-summary": "^2.0.1",
-        "typescript": "~5.5.0"
+        "typescript": "~5.8.0"
       }
     },
     "packages/react": {
@@ -31962,7 +32004,10 @@
       "version": "0.0.1",
       "dependencies": {
         "lit": "*",
-        "typescript": "5.8.2"
+        "typescript": "5.8.2",
+        "typescript5_5": "npm:typescript@~5.5.0",
+        "typescript5_6": "npm:typescript@~5.6.0",
+        "typescript5_7": "npm:typescript@~5.7.0"
       }
     },
     "packages/tests-typescript/node_modules/typescript": {
@@ -32031,7 +32076,7 @@
     "playground": {
       "name": "@lit-internal/playground",
       "devDependencies": {
-        "typescript": "~5.5.0",
+        "typescript": "~5.8.0",
         "vite": "^5.3.4"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@rollup/plugin-virtual": "^3.0.2",
         "@types/chai": "^4.3.1",
         "@types/mocha": "^9.1.1",
-        "@types/node": "^18.19.44",
+        "@types/node": "^22.17.0",
         "@typescript-eslint/eslint-plugin": "^6.4.1",
         "@typescript-eslint/parser": "^6.4.1",
         "@web/dev-server": "^0.1.32",
@@ -49,7 +49,7 @@
         "rollup-plugin-sourcemaps": "^0.6.3",
         "rollup-plugin-summary": "^2.0.1",
         "rollup-plugin-terser": "^7.0.2",
-        "typescript": "~5.8.0",
+        "typescript": "~5.9.0",
         "uvu": "^0.5.6",
         "wireit": "^0.14.12"
       },
@@ -64,7 +64,7 @@
       "dependencies": {
         "@lit-labs/nextjs": "^0.2.0",
         "@lit/react": "^1.0.0",
-        "@types/node": "^18.11.11",
+        "@types/node": "^22.17.0",
         "@types/react": "^18.0.26",
         "@types/react-dom": "^18.0.9",
         "eslint": "^8.29.0",
@@ -103,7 +103,7 @@
       "dependencies": {
         "@lit-labs/nextjs": "^0.2.0",
         "@lit/react": "^1.0.0",
-        "@types/node": "^18.11.11",
+        "@types/node": "^22.17.0",
         "@types/react": "^18.0.26",
         "@types/react-dom": "^18.0.9",
         "eslint": "^8.29.0",
@@ -121,7 +121,7 @@
       "dependencies": {
         "@lit-labs/nextjs": "^0.2.0",
         "@lit/react": "^1.0.0",
-        "@types/node": "^18.11.11",
+        "@types/node": "^22.17.0",
         "@types/react": "^18.0.26",
         "@types/react-dom": "^18.0.9",
         "eslint": "^8.29.0",
@@ -621,7 +621,7 @@
       "dependencies": {
         "@lit-labs/nextjs": "^0.2.0",
         "@lit/react": "^1.0.0",
-        "@types/node": "^18.11.11",
+        "@types/node": "^22.17.0",
         "@types/react": "18.3.12",
         "@types/react-dom": "18.3.1",
         "eslint": "^8.29.0",
@@ -639,7 +639,7 @@
       "dependencies": {
         "@lit-labs/nextjs": "^0.2.0",
         "@lit/react": "^1.0.0",
-        "@types/node": "^18.11.11",
+        "@types/node": "^22.17.0",
         "@types/react": "18.3.12",
         "@types/react-dom": "18.3.1",
         "eslint": "^8.29.0",
@@ -8880,12 +8880,19 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "18.19.44",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.44.tgz",
-      "integrity": "sha512-ZsbGerYg72WMXUIE9fYxtvfzLEuq6q8mKERdWFnqTmOvudMxnz+CBNRoOwJ2kNpFOncrKjT1hZwxjlFgQ9qvQA==",
+      "version": "22.17.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.17.0.tgz",
+      "integrity": "sha512-bbAKTCqX5aNVryi7qXVMi+OkB3w/OyblodicMbvE38blyAz7GxXf6XYhklokijuPwwVg9sDLKRxt0ZHXQwZVfQ==",
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/node/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -9542,6 +9549,16 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/@wdio/config/node_modules/@types/node": {
+      "version": "18.19.121",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.121.tgz",
+      "integrity": "sha512-bHOrbyztmyYIi4f1R0s17QsPs1uyyYnGcXeZoGEd227oZjry0q6XQBQxd82X1I57zEfwO8h9Xo+Kl5gX1d9MwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
     "node_modules/@wdio/config/node_modules/@wdio/types": {
       "version": "7.26.0",
       "dev": true,
@@ -9740,6 +9757,16 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@wdio/utils/node_modules/@types/node": {
+      "version": "18.19.121",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.121.tgz",
+      "integrity": "sha512-bHOrbyztmyYIi4f1R0s17QsPs1uyyYnGcXeZoGEd227oZjry0q6XQBQxd82X1I57zEfwO8h9Xo+Kl5gX1d9MwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "node_modules/@wdio/utils/node_modules/@wdio/types": {
@@ -14472,6 +14499,16 @@
       "version": "0.0.981744",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/devtools/node_modules/@types/node": {
+      "version": "18.19.121",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.121.tgz",
+      "integrity": "sha512-bHOrbyztmyYIi4f1R0s17QsPs1uyyYnGcXeZoGEd227oZjry0q6XQBQxd82X1I57zEfwO8h9Xo+Kl5gX1d9MwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/devtools/node_modules/@wdio/types": {
       "version": "7.26.0",
@@ -28302,9 +28339,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -28525,6 +28562,20 @@
       "version": "5.7.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript5_8": {
+      "name": "typescript",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -29157,6 +29208,16 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/webdriver/node_modules/@types/node": {
+      "version": "18.19.121",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.121.tgz",
+      "integrity": "sha512-bHOrbyztmyYIi4f1R0s17QsPs1uyyYnGcXeZoGEd227oZjry0q6XQBQxd82X1I57zEfwO8h9Xo+Kl5gX1d9MwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
     "node_modules/webdriver/node_modules/@wdio/types": {
       "version": "7.26.0",
       "dev": true,
@@ -29226,6 +29287,16 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/webdriverio/node_modules/@types/node": {
+      "version": "18.19.121",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.121.tgz",
+      "integrity": "sha512-bHOrbyztmyYIi4f1R0s17QsPs1uyyYnGcXeZoGEd227oZjry0q6XQBQxd82X1I57zEfwO8h9Xo+Kl5gX1d9MwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "node_modules/webdriverio/node_modules/@wdio/types": {
@@ -30112,7 +30183,7 @@
     },
     "packages/context": {
       "name": "@lit/context",
-      "version": "1.1.5",
+      "version": "1.1.6",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit/reactive-element": "^1.6.2 || ^2.1.0"
@@ -30127,10 +30198,10 @@
     },
     "packages/internal-scripts": {
       "name": "@lit-internal/scripts",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@types/node": "^16.7.8",
+        "@types/node": "^22.17.0",
         "changelog-parser": "^2.8.1",
         "command-line-args": "^5.2.1",
         "fast-glob": "^3.2.5",
@@ -30162,7 +30233,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "package-json-type": "^1.0.3",
-        "typescript": "~5.8.0"
+        "typescript": "~5.9.0"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^25.0.7",
@@ -30262,7 +30333,7 @@
         "command-line-commands": "^3.0.2",
         "command-line-usage": "^6.1.1",
         "tslib": "^2.0.3",
-        "typescript": "~5.8.0"
+        "typescript": "~5.9.0"
       },
       "bin": {
         "lit": "bin/lit.js"
@@ -30285,7 +30356,7 @@
         "@lit/localize-tools": "^0.8.0"
       },
       "devDependencies": {
-        "typescript": "~5.8.0"
+        "typescript": "~5.9.0"
       },
       "engines": {
         "node": ">=14.8.0"
@@ -30310,7 +30381,7 @@
         "@parse5/tools": "^0.3.0",
         "lit-html": "^3.2.0",
         "parse5": "^7.1.2",
-        "typescript": "~5.8.0"
+        "typescript": "~5.9.0"
       },
       "devDependencies": {
         "@rollup/plugin-typescript": "11.1.6",
@@ -30388,10 +30459,10 @@
       "dependencies": {
         "@lit-labs/analyzer": "^0.13.0",
         "@typescript-eslint/utils": "^6.19.0",
-        "typescript": "~5.8.0"
+        "typescript": "~5.9.0"
       },
       "devDependencies": {
-        "@types/node": "^20.11.5",
+        "@types/node": "^22.17.0",
         "@typescript-eslint/parser": "^6.19.0",
         "@typescript-eslint/rule-tester": "^6.19.0",
         "eslint": "^8.56.0"
@@ -30417,7 +30488,7 @@
       },
       "devDependencies": {
         "@lit-internal/tests": "^0.0.1",
-        "@types/node": "^17.0.31",
+        "@types/node": "^22.17.0",
         "lit": "^3.2.0",
         "uvu": "^0.5.3"
       },
@@ -30439,7 +30510,7 @@
       },
       "devDependencies": {
         "@lit-internal/tests": "^0.0.1",
-        "@types/node": "^20.14.8"
+        "@types/node": "^22.17.0"
       },
       "engines": {
         "node": ">=14.8.0"
@@ -30475,7 +30546,7 @@
     },
     "packages/labs/gen-wrapper-react": {
       "name": "@lit-labs/gen-wrapper-react",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit-labs/analyzer": "^0.13.0",
@@ -30506,7 +30577,7 @@
     },
     "packages/labs/motion": {
       "name": "@lit-labs/motion",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "license": "BSD-3-Clause",
       "dependencies": {
         "lit": "^3.1.2"
@@ -30518,7 +30589,7 @@
     },
     "packages/labs/nextjs": {
       "name": "@lit-labs/nextjs",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit-labs/ssr-react": "^0.3.0",
@@ -30536,7 +30607,7 @@
     },
     "packages/labs/observers": {
       "name": "@lit-labs/observers",
-      "version": "2.0.5",
+      "version": "2.0.6",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit/reactive-element": "^1.0.0 || ^2.0.0",
@@ -30703,7 +30774,7 @@
       "devDependencies": {
         "@types/clean-css": "^4.2.0",
         "@types/html-minifier": "^4.0.5",
-        "@types/node": "^22.4.1",
+        "@types/node": "^22.17.0",
         "@types/sinon": "^5.0.1",
         "c8": "^10.1.2",
         "husky": "^0.14.3",
@@ -31094,7 +31165,7 @@
     },
     "packages/labs/signals": {
       "name": "@lit-labs/signals",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "lit": "^2.0.0 || ^3.0.0",
@@ -31166,20 +31237,20 @@
     },
     "packages/labs/ssr-dom-shim": {
       "name": "@lit-labs/ssr-dom-shim",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "BSD-3-Clause"
     },
     "packages/labs/ssr-react": {
       "name": "@lit-labs/ssr-react",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit-labs/ssr": "^3.3.0",
         "@lit-labs/ssr-client": "^1.1.7"
       },
       "devDependencies": {
-        "@lit/react": "1.0.7",
-        "@types/node": "^20.11.25",
+        "@lit/react": "1.0.8",
+        "@types/node": "^22.17.0",
         "@types/react": "^18.0.27",
         "@types/react-dom": "^18.0.10",
         "lit": "^3.1.2",
@@ -31236,15 +31307,15 @@
         "lit": "file:../../../lit"
       },
       "devDependencies": {
-        "typescript": "~5.8.0"
+        "typescript": "~5.9.0"
       }
     },
     "packages/labs/test-projects/test-elements-react": {
       "name": "@lit-internal/test-elements-react",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "dependencies": {
         "@lit-internal/test-element-a": "1.0.1",
-        "@lit/react": "1.0.7"
+        "@lit/react": "1.0.8"
       },
       "peerDependencies": {
         "@types/react": "^17 || ^18",
@@ -31275,12 +31346,12 @@
       "version": "0.0.1",
       "license": "BSD-3-Clause",
       "devDependencies": {
-        "typescript": "~5.8.0"
+        "typescript": "~5.9.0"
       }
     },
     "packages/labs/virtualizer": {
       "name": "@lit-labs/virtualizer",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "lit": "^3.2.0",
@@ -31294,7 +31365,7 @@
     },
     "packages/labs/vue-utils": {
       "name": "@lit-labs/vue-utils",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "vue": "^3.2.25"
@@ -31305,7 +31376,7 @@
       }
     },
     "packages/lit": {
-      "version": "3.3.0",
+      "version": "3.3.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit/reactive-element": "^2.1.0",
@@ -31321,10 +31392,10 @@
       }
     },
     "packages/lit-element": {
-      "version": "4.2.0",
+      "version": "4.2.1",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.2.0",
+        "@lit-labs/ssr-dom-shim": "^1.4.0",
         "@lit/reactive-element": "^2.1.0",
         "lit-html": "^3.3.0"
       },
@@ -31338,7 +31409,7 @@
       }
     },
     "packages/lit-html": {
-      "version": "3.3.0",
+      "version": "3.3.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
@@ -31461,7 +31532,7 @@
         "rimraf": "^3.0.2",
         "rollup": "^4.18.0",
         "rollup-plugin-summary": "^2.0.1",
-        "typescript": "~5.8.0"
+        "typescript": "~5.9.0"
       }
     },
     "packages/lit-starter-ts/node_modules/@open-wc/scoped-elements": {
@@ -31767,7 +31838,7 @@
         "minimist": "^1.2.5",
         "parse5": "^7.1.1",
         "source-map-support": "^0.5.19",
-        "typescript": "~5.8.0"
+        "typescript": "~5.9.0"
       },
       "bin": {
         "lit-localize": "bin/lit-localize.js"
@@ -31863,7 +31934,7 @@
         "@web/dev-server": "^0.1.22",
         "rollup": "^4.18.0",
         "rollup-plugin-summary": "^2.0.1",
-        "typescript": "~5.8.0"
+        "typescript": "~5.9.0"
       }
     },
     "packages/localize/examples/transform-js/node_modules/typescript": {
@@ -31894,12 +31965,12 @@
         "@web/dev-server": "^0.1.22",
         "rollup": "^4.18.0",
         "rollup-plugin-summary": "^2.0.1",
-        "typescript": "~5.8.0"
+        "typescript": "~5.9.0"
       }
     },
     "packages/react": {
       "name": "@lit/react",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@lit-internal/scripts": "^1.0.1",
@@ -31916,10 +31987,10 @@
     },
     "packages/reactive-element": {
       "name": "@lit/reactive-element",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.2.0"
+        "@lit-labs/ssr-dom-shim": "^1.4.0"
       },
       "devDependencies": {
         "@babel/cli": "^7.22.10",
@@ -31975,7 +32046,7 @@
     },
     "packages/task": {
       "name": "@lit/task",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit/reactive-element": "^1.0.0 || ^2.0.0"
@@ -32004,10 +32075,11 @@
       "version": "0.0.1",
       "dependencies": {
         "lit": "*",
-        "typescript": "5.8.2",
+        "typescript": "5.9.2",
         "typescript5_5": "npm:typescript@~5.5.0",
         "typescript5_6": "npm:typescript@~5.6.0",
-        "typescript5_7": "npm:typescript@~5.7.0"
+        "typescript5_7": "npm:typescript@~5.7.0",
+        "typescript5_8": "npm:typescript@~5.8.0"
       }
     },
     "packages/tests-typescript/node_modules/typescript": {
@@ -32076,7 +32148,7 @@
     "playground": {
       "name": "@lit-internal/playground",
       "devDependencies": {
-        "typescript": "~5.8.0",
+        "typescript": "~5.9.0",
         "vite": "^5.3.4"
       }
     },

--- a/package.json
+++ b/package.json
@@ -271,7 +271,7 @@
     "@rollup/plugin-virtual": "^3.0.2",
     "@types/chai": "^4.3.1",
     "@types/mocha": "^9.1.1",
-    "@types/node": "^18.19.44",
+    "@types/node": "^22.17.0",
     "@typescript-eslint/eslint-plugin": "^6.4.1",
     "@typescript-eslint/parser": "^6.4.1",
     "@web/dev-server": "^0.1.32",
@@ -295,7 +295,7 @@
     "rollup-plugin-sourcemaps": "^0.6.3",
     "rollup-plugin-summary": "^2.0.1",
     "rollup-plugin-terser": "^7.0.2",
-    "typescript": "~5.8.0",
+    "typescript": "~5.9.0",
     "uvu": "^0.5.6",
     "wireit": "^0.14.12"
   },

--- a/package.json
+++ b/package.json
@@ -295,7 +295,7 @@
     "rollup-plugin-sourcemaps": "^0.6.3",
     "rollup-plugin-summary": "^2.0.1",
     "rollup-plugin-terser": "^7.0.2",
-    "typescript": "~5.5.0",
+    "typescript": "~5.8.0",
     "uvu": "^0.5.6",
     "wireit": "^0.14.12"
   },

--- a/packages/internal-scripts/package.json
+++ b/packages/internal-scripts/package.json
@@ -39,7 +39,7 @@
     }
   },
   "dependencies": {
-    "@types/node": "^16.7.8",
+    "@types/node": "^22.17.0",
     "changelog-parser": "^2.8.1",
     "command-line-args": "^5.2.1",
     "fast-glob": "^3.2.5",

--- a/packages/internal-scripts/tsconfig.json
+++ b/packages/internal-scripts/tsconfig.json
@@ -18,7 +18,8 @@
     "allowSyntheticDefaultImports": true,
     "tsBuildInfoFile": "./lib/.tsbuildinfo",
     "noImplicitOverride": true,
-    "types": []
+    "types": [],
+    "skipLibCheck": true
   },
   "include": ["src/**/*.ts"]
 }

--- a/packages/labs/analyzer/package.json
+++ b/packages/labs/analyzer/package.json
@@ -119,7 +119,7 @@
   },
   "dependencies": {
     "package-json-type": "^1.0.3",
-    "typescript": "~5.8.0"
+    "typescript": "~5.9.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^25.0.7",

--- a/packages/labs/analyzer/package.json
+++ b/packages/labs/analyzer/package.json
@@ -119,7 +119,7 @@
   },
   "dependencies": {
     "package-json-type": "^1.0.3",
-    "typescript": "~5.5.0"
+    "typescript": "~5.8.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^25.0.7",

--- a/packages/labs/cli-localize/package.json
+++ b/packages/labs/cli-localize/package.json
@@ -69,7 +69,7 @@
     "@lit/localize-tools": "^0.8.0"
   },
   "devDependencies": {
-    "typescript": "~5.8.0"
+    "typescript": "~5.9.0"
   },
   "engines": {
     "node": ">=14.8.0"

--- a/packages/labs/cli-localize/package.json
+++ b/packages/labs/cli-localize/package.json
@@ -69,7 +69,7 @@
     "@lit/localize-tools": "^0.8.0"
   },
   "devDependencies": {
-    "typescript": "~5.5.0"
+    "typescript": "~5.8.0"
   },
   "engines": {
     "node": ">=14.8.0"

--- a/packages/labs/cli/package.json
+++ b/packages/labs/cli/package.json
@@ -91,7 +91,7 @@
     "command-line-commands": "^3.0.2",
     "command-line-usage": "^6.1.1",
     "tslib": "^2.0.3",
-    "typescript": "~5.5.0"
+    "typescript": "~5.8.0"
   },
   "devDependencies": {
     "@lit-internal/tests": "^0.0.1",

--- a/packages/labs/cli/package.json
+++ b/packages/labs/cli/package.json
@@ -91,7 +91,7 @@
     "command-line-commands": "^3.0.2",
     "command-line-usage": "^6.1.1",
     "tslib": "^2.0.3",
-    "typescript": "~5.8.0"
+    "typescript": "~5.9.0"
   },
   "devDependencies": {
     "@lit-internal/tests": "^0.0.1",

--- a/packages/labs/cli/src/lib/generate/generate.ts
+++ b/packages/labs/cli/src/lib/generate/generate.ts
@@ -135,7 +135,7 @@ export const run = async (
         .map((r, i) =>
           r.status === 'rejected'
             ? `Error generating '${generators[i].name}' wrapper for package '${packageRoot}': ` +
-                (r.reason as Error).stack ?? r.reason
+              ((r.reason as Partial<Error>).stack ?? r.reason)
             : ''
         )
         .filter((e) => e)

--- a/packages/labs/cli/src/lib/init/element-starter/templates/package.json.ts
+++ b/packages/labs/cli/src/lib/init/element-starter/templates/package.json.ts
@@ -42,7 +42,7 @@ export const generatePackageJson = (
       language !== 'ts'
         ? ''
         : `,
-    "typescript": "~5.8.0"`
+    "typescript": "~5.9.0"`
     }
   },
   "exports": {

--- a/packages/labs/cli/src/lib/init/element-starter/templates/package.json.ts
+++ b/packages/labs/cli/src/lib/init/element-starter/templates/package.json.ts
@@ -42,7 +42,7 @@ export const generatePackageJson = (
       language !== 'ts'
         ? ''
         : `,
-    "typescript": "~5.3.3"`
+    "typescript": "~5.8.0"`
     }
   },
   "exports": {

--- a/packages/labs/cli/test-goldens/init/ts-named/package.json
+++ b/packages/labs/cli/test-goldens/init/ts-named/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@web/dev-server": "^0.1.32",
-    "typescript": "~5.8.0"
+    "typescript": "~5.9.0"
   },
   "exports": {
     "./lib/el-element.js": {

--- a/packages/labs/cli/test-goldens/init/ts-named/package.json
+++ b/packages/labs/cli/test-goldens/init/ts-named/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@web/dev-server": "^0.1.32",
-    "typescript": "~5.3.3"
+    "typescript": "~5.8.0"
   },
   "exports": {
     "./lib/el-element.js": {

--- a/packages/labs/compiler/package.json
+++ b/packages/labs/compiler/package.json
@@ -107,7 +107,7 @@
     "@parse5/tools": "^0.3.0",
     "lit-html": "^3.2.0",
     "parse5": "^7.1.2",
-    "typescript": "~5.5.0"
+    "typescript": "~5.8.0"
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "11.1.6",

--- a/packages/labs/compiler/package.json
+++ b/packages/labs/compiler/package.json
@@ -107,7 +107,7 @@
     "@parse5/tools": "^0.3.0",
     "lit-html": "^3.2.0",
     "parse5": "^7.1.2",
-    "typescript": "~5.8.0"
+    "typescript": "~5.9.0"
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "11.1.6",

--- a/packages/labs/compiler/test_files/comment_binding.golden.js
+++ b/packages/labs/compiler/test_files/comment_binding.golden.js
@@ -2,5 +2,7 @@ import { html } from 'lit-html';
 const text = 'text';
 const node = document.createElement('span');
 const b_1 = i => i;
-const lit_template_1 = { h: b_1 `<?>\n  <!-- Comment binding '' -->\n  <?><!--?-->`, parts: [{ type: 2, index: 0 }, { type: 7, index: 1 }, { type: 2, index: 2 }] };
+const lit_template_1 = { h: b_1 `<?>
+  <!-- Comment binding '' -->
+  <?><!--?-->`, parts: [{ type: 2, index: 0 }, { type: 7, index: 1 }, { type: 2, index: 2 }] };
 export const one = { ["_$litType$"]: lit_template_1, values: [text, text, node] };

--- a/packages/labs/compiler/test_files/dev_mode_template_textarea_expression.golden.js
+++ b/packages/labs/compiler/test_files/dev_mode_template_textarea_expression.golden.js
@@ -49,7 +49,9 @@ html `<textarea>
 import * as litHtmlPrivate_1 from "lit-html/private-ssr-support.js";
 const { AttributePart: A_1 } = litHtmlPrivate_1._$LH;
 const b_1 = i => i;
-const lit_template_1 = { h: b_1 `<template><template>\n    <div>Valid. Static content can be compiled.</div>\n  </template></template>`, parts: [{ type: 1, index: 0, name: "id", strings: ["", ""], ctor: A_1 }] };
+const lit_template_1 = { h: b_1 `<template><template>
+    <div>Valid. Static content can be compiled.</div>
+  </template></template>`, parts: [{ type: 1, index: 0, name: "id", strings: ["", ""], ctor: A_1 }] };
 // Valid, because attribute on outer template element is ok:
 ({ ["_$litType$"]: lit_template_1, values: ['test'] });
 const lit_template_2 = { h: b_1 `<textarea>Valid, can be compiled.</textarea>`, parts: [{ type: 1, index: 0, name: "id", strings: ["", ""], ctor: A_1 }] };

--- a/packages/labs/compiler/test_files/parts_kitchen_sink.golden.js
+++ b/packages/labs/compiler/test_files/parts_kitchen_sink.golden.js
@@ -3,5 +3,7 @@ import { ref } from 'lit/directives/ref.js';
 import * as litHtmlPrivate_1 from "lit-html/private-ssr-support.js";
 const { AttributePart: A_1, PropertyPart: P_1, BooleanAttributePart: B_1, EventPart: E_1 } = litHtmlPrivate_1._$LH;
 const b_1 = i => i;
-const lit_template_1 = { h: b_1 ` <div>\n  <?>\n</div>`, parts: [{ type: 1, index: 0, name: "attribute-part", strings: ["", ""], ctor: A_1 }, { type: 1, index: 0, name: "boolean-attribute-part", strings: ["", ""], ctor: B_1 }, { type: 1, index: 0, name: "propertyPart", strings: ["", ""], ctor: P_1 }, { type: 1, index: 0, name: "click", strings: ["", ""], ctor: E_1 }, { type: 6, index: 0 }, { type: 2, index: 1 }] };
+const lit_template_1 = { h: b_1 ` <div>
+  <?>
+</div>`, parts: [{ type: 1, index: 0, name: "attribute-part", strings: ["", ""], ctor: A_1 }, { type: 1, index: 0, name: "boolean-attribute-part", strings: ["", ""], ctor: B_1 }, { type: 1, index: 0, name: "propertyPart", strings: ["", ""], ctor: P_1 }, { type: 1, index: 0, name: "click", strings: ["", ""], ctor: E_1 }, { type: 6, index: 0 }, { type: 2, index: 1 }] };
 ({ ["_$litType$"]: lit_template_1, values: ['attributeValue', true, 'propertyValue', () => console.log('EventPart'), ref(console.log), 'childPart'] });

--- a/packages/labs/compiler/test_files/raw_text_element.golden.js
+++ b/packages/labs/compiler/test_files/raw_text_element.golden.js
@@ -1,12 +1,16 @@
 import { html } from 'lit-html';
 const b_1 = i => i;
-const lit_template_1 = { h: b_1 `<script>\n  potato;\n</script>`, parts: [] };
+const lit_template_1 = { h: b_1 `<script>
+  potato;
+</script>`, parts: [] };
 // TODO: In the future we can figure out a way to correctly compile raw text
 // elements. The complexity is that they depend on creating adjacent Text nodes
 // which cannot be represented in the prepared HTML. Thus a binding in a raw
 // text node results in the template not being optimized.
 const scriptTemplateNoBinding = { ["_$litType$"]: lit_template_1, values: [] };
-const lit_template_2 = { h: b_1 `<style>\n  carrot\n</style>`, parts: [] };
+const lit_template_2 = { h: b_1 `<style>
+  carrot
+</style>`, parts: [] };
 const styleTemplateNoBinding = { ["_$litType$"]: lit_template_2, values: [] };
 const lit_template_3 = { h: b_1 `<textarea>tomato</textarea>`, parts: [] };
 const textareaTemplateNoBinding = { ["_$litType$"]: lit_template_3, values: [] };

--- a/packages/labs/compiler/test_files/raw_text_element_edgecase.golden.js
+++ b/packages/labs/compiler/test_files/raw_text_element_edgecase.golden.js
@@ -2,5 +2,13 @@
 // miscompiled into `<?>`.
 import { html, render } from 'lit';
 const b_1 = i => i;
-const lit_template_1 = { h: b_1 `<style>\n  div::before {\n    content: '<!---->';\n  }\n  div::after {\n    content: '<!--?-->';\n  }\n</style>\n<div>Hello world</div>`, parts: [] };
+const lit_template_1 = { h: b_1 `<style>
+  div::before {
+    content: '<!---->';
+  }
+  div::after {
+    content: '<!--?-->';
+  }
+</style>
+<div>Hello world</div>`, parts: [] };
 render({ ["_$litType$"]: lit_template_1, values: [] }, document.body);

--- a/packages/labs/eslint-plugin/package.json
+++ b/packages/labs/eslint-plugin/package.json
@@ -66,6 +66,6 @@
   "dependencies": {
     "@lit-labs/analyzer": "^0.13.0",
     "@typescript-eslint/utils": "^6.19.0",
-    "typescript": "~5.5.0"
+    "typescript": "~5.8.0"
   }
 }

--- a/packages/labs/eslint-plugin/package.json
+++ b/packages/labs/eslint-plugin/package.json
@@ -58,7 +58,7 @@
     ".": "./index.js"
   },
   "devDependencies": {
-    "@types/node": "^20.11.5",
+    "@types/node": "^22.17.0",
     "@typescript-eslint/parser": "^6.19.0",
     "@typescript-eslint/rule-tester": "^6.19.0",
     "eslint": "^8.56.0"
@@ -66,6 +66,6 @@
   "dependencies": {
     "@lit-labs/analyzer": "^0.13.0",
     "@typescript-eslint/utils": "^6.19.0",
-    "typescript": "~5.8.0"
+    "typescript": "~5.9.0"
   }
 }

--- a/packages/labs/gen-manifest/package.json
+++ b/packages/labs/gen-manifest/package.json
@@ -58,7 +58,7 @@
   },
   "devDependencies": {
     "@lit-internal/tests": "^0.0.1",
-    "@types/node": "^17.0.31",
+    "@types/node": "^22.17.0",
     "lit": "^3.2.0",
     "uvu": "^0.5.3"
   },

--- a/packages/labs/gen-utils/package.json
+++ b/packages/labs/gen-utils/package.json
@@ -54,7 +54,7 @@
   },
   "devDependencies": {
     "@lit-internal/tests": "^0.0.1",
-    "@types/node": "^20.14.8"
+    "@types/node": "^22.17.0"
   },
   "engines": {
     "node": ">=14.8.0"

--- a/packages/labs/gen-wrapper-angular/goldens/test-element-a/package.json
+++ b/packages/labs/gen-wrapper-angular/goldens/test-element-a/package.json
@@ -14,7 +14,7 @@
     "@angular/core": "^13.3.0"
   },
   "devDependencies": {
-    "typescript": "~5.8.0"
+    "typescript": "~5.9.0"
   },
   "files": [
     "element-a.js",

--- a/packages/labs/gen-wrapper-angular/goldens/test-element-a/package.json
+++ b/packages/labs/gen-wrapper-angular/goldens/test-element-a/package.json
@@ -14,7 +14,7 @@
     "@angular/core": "^13.3.0"
   },
   "devDependencies": {
-    "typescript": "~5.5.0"
+    "typescript": "~5.8.0"
   },
   "files": [
     "element-a.js",

--- a/packages/labs/gen-wrapper-react/goldens/test-element-a/package.json
+++ b/packages/labs/gen-wrapper-react/goldens/test-element-a/package.json
@@ -15,7 +15,7 @@
     "@types/react": "^17 || ^18 || ^19"
   },
   "devDependencies": {
-    "typescript": "~5.8.0"
+    "typescript": "~5.9.0"
   },
   "files": [
     "element-a.{js,js.map,d.ts,d.ts.map}",

--- a/packages/labs/gen-wrapper-react/goldens/test-element-a/package.json
+++ b/packages/labs/gen-wrapper-react/goldens/test-element-a/package.json
@@ -15,7 +15,7 @@
     "@types/react": "^17 || ^18 || ^19"
   },
   "devDependencies": {
-    "typescript": "~5.5.0"
+    "typescript": "~5.8.0"
   },
   "files": [
     "element-a.{js,js.map,d.ts,d.ts.map}",

--- a/packages/labs/gen-wrapper-vue/goldens/test-element-a/package.json
+++ b/packages/labs/gen-wrapper-vue/goldens/test-element-a/package.json
@@ -15,7 +15,7 @@
     "@lit-labs/vue-utils": "^0.1.0"
   },
   "devDependencies": {
-    "typescript": "~5.5.0",
+    "typescript": "~5.8.0",
     "@vitejs/plugin-vue": "^5.0.5",
     "@rollup/plugin-typescript": "^11.1.6",
     "vite": "^5.3.1",

--- a/packages/labs/gen-wrapper-vue/goldens/test-element-a/package.json
+++ b/packages/labs/gen-wrapper-vue/goldens/test-element-a/package.json
@@ -15,7 +15,7 @@
     "@lit-labs/vue-utils": "^0.1.0"
   },
   "devDependencies": {
-    "typescript": "~5.8.0",
+    "typescript": "~5.9.0",
     "@vitejs/plugin-vue": "^5.0.5",
     "@rollup/plugin-typescript": "^11.1.6",
     "vite": "^5.3.1",

--- a/packages/labs/gen-wrapper-vue/test-output/package.json
+++ b/packages/labs/gen-wrapper-vue/test-output/package.json
@@ -14,9 +14,9 @@
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^2.3.1",
-    "typescript": "~5.3.3",
+    "typescript": "~5.8.0",
     "vite": "^2.9.2",
-    "vue-tsc": "^1.8.8"
+    "vue-tsc": "^2.0.22"
   },
   "scripts": {
     "installSelf": "wireit",

--- a/packages/labs/gen-wrapper-vue/test-output/package.json
+++ b/packages/labs/gen-wrapper-vue/test-output/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^2.3.1",
-    "typescript": "~5.8.0",
+    "typescript": "~5.9.0",
     "vite": "^2.9.2",
     "vue-tsc": "^2.0.22"
   },

--- a/packages/labs/rollup-plugin-minify-html-literals/package.json
+++ b/packages/labs/rollup-plugin-minify-html-literals/package.json
@@ -74,7 +74,7 @@
   "devDependencies": {
     "@types/clean-css": "^4.2.0",
     "@types/html-minifier": "^4.0.5",
-    "@types/node": "^22.4.1",
+    "@types/node": "^22.17.0",
     "@types/sinon": "^5.0.1",
     "c8": "^10.1.2",
     "husky": "^0.14.3",

--- a/packages/labs/ssr-dom-shim/src/lib/element-internals.ts
+++ b/packages/labs/ssr-dom-shim/src/lib/element-internals.ts
@@ -4,8 +4,12 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+type StringKeys<T extends object> = {
+  [K in keyof T]: T[K] extends string | null ? K : never;
+}[keyof T];
+
 type ARIAAttributeMap = {
-  [K in keyof ARIAMixin]: string;
+  [K in StringKeys<ARIAMixin>]: string;
 };
 
 /**
@@ -66,6 +70,7 @@ type ElementInternalsInterface = ElementInternals;
 export const ElementInternalsShim = class ElementInternals
   implements ElementInternalsInterface
 {
+  ariaActiveDescendantElement = null;
   ariaAtomic = '';
   ariaAutoComplete = '';
   ariaBrailleLabel = '';
@@ -76,21 +81,28 @@ export const ElementInternalsShim = class ElementInternals
   ariaColIndex = '';
   ariaColIndexText = '';
   ariaColSpan = '';
+  ariaControlsElements = null;
   ariaCurrent = '';
+  ariaDescribedByElements = null;
   ariaDescription = '';
+  ariaDetailsElements = null;
   ariaDisabled = '';
+  ariaErrorMessageElements = null;
   ariaExpanded = '';
+  ariaFlowToElements = null;
   ariaHasPopup = '';
   ariaHidden = '';
   ariaInvalid = '';
   ariaKeyShortcuts = '';
   ariaLabel = '';
+  ariaLabelledByElements = null;
   ariaLevel = '';
   ariaLive = '';
   ariaModal = '';
   ariaMultiLine = '';
   ariaMultiSelectable = '';
   ariaOrientation = '';
+  ariaOwnsElements = null;
   ariaPlaceholder = '';
   ariaPosInSet = '';
   ariaPressed = '';

--- a/packages/labs/ssr-dom-shim/src/lib/element-internals.ts
+++ b/packages/labs/ssr-dom-shim/src/lib/element-internals.ts
@@ -8,6 +8,9 @@ type StringKeys<T extends object> = {
   [K in keyof T]: T[K] extends string | null ? K : never;
 }[keyof T];
 
+// Since TypeScript 5.9, ARIAMixin has properties with the type Element | null
+// or Element[] | null. However, we can only support string attributes,
+// which is why we filter for string properties.
 type ARIAAttributeMap = {
   [K in StringKeys<ARIAMixin>]: string;
 };

--- a/packages/labs/ssr-dom-shim/src/lib/element-internals.ts
+++ b/packages/labs/ssr-dom-shim/src/lib/element-internals.ts
@@ -20,6 +20,7 @@ export const ariaMixinAttributes: ARIAAttributeMap = {
   ariaChecked: 'aria-checked',
   ariaColCount: 'aria-colcount',
   ariaColIndex: 'aria-colindex',
+  ariaColIndexText: 'aria-colindextext',
   ariaColSpan: 'aria-colspan',
   ariaCurrent: 'aria-current',
   ariaDescription: 'aria-description',
@@ -40,10 +41,12 @@ export const ariaMixinAttributes: ARIAAttributeMap = {
   ariaPosInSet: 'aria-posinset',
   ariaPressed: 'aria-pressed',
   ariaReadOnly: 'aria-readonly',
+  ariaRelevant: 'aria-relevant',
   ariaRequired: 'aria-required',
   ariaRoleDescription: 'aria-roledescription',
   ariaRowCount: 'aria-rowcount',
   ariaRowIndex: 'aria-rowindex',
+  ariaRowIndexText: 'aria-rowindextext',
   ariaRowSpan: 'aria-rowspan',
   ariaSelected: 'aria-selected',
   ariaSetSize: 'aria-setsize',
@@ -71,6 +74,7 @@ export const ElementInternalsShim = class ElementInternals
   ariaChecked = '';
   ariaColCount = '';
   ariaColIndex = '';
+  ariaColIndexText = '';
   ariaColSpan = '';
   ariaCurrent = '';
   ariaDescription = '';
@@ -91,10 +95,12 @@ export const ElementInternalsShim = class ElementInternals
   ariaPosInSet = '';
   ariaPressed = '';
   ariaReadOnly = '';
+  ariaRelevant = '';
   ariaRequired = '';
   ariaRoleDescription = '';
   ariaRowCount = '';
   ariaRowIndex = '';
+  ariaRowIndexText = '';
   ariaRowSpan = '';
   ariaSelected = '';
   ariaSetSize = '';

--- a/packages/labs/ssr-react/package.json
+++ b/packages/labs/ssr-react/package.json
@@ -100,7 +100,7 @@
   },
   "devDependencies": {
     "@lit/react": "1.0.8",
-    "@types/node": "^20.11.25",
+    "@types/node": "^22.17.0",
     "@types/react": "^18.0.27",
     "@types/react-dom": "^18.0.10",
     "lit": "^3.1.2",

--- a/packages/labs/ssr/src/lib/lit-element-renderer.ts
+++ b/packages/labs/ssr/src/lib/lit-element-renderer.ts
@@ -62,7 +62,7 @@ export class LitElementRenderer extends ElementRenderer {
       for (const [ariaProp, ariaAttribute] of Object.entries(
         ariaMixinAttributes
       )) {
-        const value = internals[ariaProp as keyof ARIAMixin];
+        const value = internals[ariaProp as keyof typeof ariaMixinAttributes];
         if (value && !this.element.hasAttribute(ariaAttribute)) {
           this.element.setAttribute(ariaAttribute, value);
           this.element.setAttribute(

--- a/packages/labs/test-projects/test-element-a/package.json
+++ b/packages/labs/test-projects/test-element-a/package.json
@@ -21,7 +21,7 @@
     "lit": "file:../../../lit"
   },
   "devDependencies": {
-    "typescript": "~5.5.0"
+    "typescript": "~5.8.0"
   },
   "wireit": {
     "build": {

--- a/packages/labs/test-projects/test-element-a/package.json
+++ b/packages/labs/test-projects/test-element-a/package.json
@@ -21,7 +21,7 @@
     "lit": "file:../../../lit"
   },
   "devDependencies": {
-    "typescript": "~5.8.0"
+    "typescript": "~5.9.0"
   },
   "wireit": {
     "build": {

--- a/packages/labs/tsserver-plugin/example/package.json
+++ b/packages/labs/tsserver-plugin/example/package.json
@@ -4,6 +4,6 @@
   "type": "module",
   "devDependencies": {
     "@lit-labs/tsserver-plugin": "file:..",
-    "typescript": "~5.5.0"
+    "typescript": "~5.8.0"
   }
 }

--- a/packages/labs/tsserver-plugin/example/package.json
+++ b/packages/labs/tsserver-plugin/example/package.json
@@ -4,6 +4,6 @@
   "type": "module",
   "devDependencies": {
     "@lit-labs/tsserver-plugin": "file:..",
-    "typescript": "~5.8.0"
+    "typescript": "~5.9.0"
   }
 }

--- a/packages/labs/tsserver-plugin/package.json
+++ b/packages/labs/tsserver-plugin/package.json
@@ -49,6 +49,6 @@
     ".": "./index.js"
   },
   "devDependencies": {
-    "typescript": "~5.5.0"
+    "typescript": "~5.8.0"
   }
 }

--- a/packages/labs/tsserver-plugin/package.json
+++ b/packages/labs/tsserver-plugin/package.json
@@ -49,6 +49,6 @@
     ".": "./index.js"
   },
   "devDependencies": {
-    "typescript": "~5.8.0"
+    "typescript": "~5.9.0"
   }
 }

--- a/packages/lit-starter-ts/package.json
+++ b/packages/lit-starter-ts/package.json
@@ -64,7 +64,7 @@
     "rimraf": "^3.0.2",
     "rollup": "^4.18.0",
     "rollup-plugin-summary": "^2.0.1",
-    "typescript": "~5.8.0"
+    "typescript": "~5.9.0"
   },
   "customElements": "custom-elements.json"
 }

--- a/packages/lit-starter-ts/package.json
+++ b/packages/lit-starter-ts/package.json
@@ -64,7 +64,7 @@
     "rimraf": "^3.0.2",
     "rollup": "^4.18.0",
     "rollup-plugin-summary": "^2.0.1",
-    "typescript": "~5.5.0"
+    "typescript": "~5.8.0"
   },
   "customElements": "custom-elements.json"
 }

--- a/packages/localize-tools/package.json
+++ b/packages/localize-tools/package.json
@@ -140,7 +140,7 @@
     "minimist": "^1.2.5",
     "parse5": "^7.1.1",
     "source-map-support": "^0.5.19",
-    "typescript": "~5.5.0"
+    "typescript": "~5.8.0"
   },
   "devDependencies": {
     "@lit-internal/tests": "0.0.1",

--- a/packages/localize-tools/package.json
+++ b/packages/localize-tools/package.json
@@ -140,7 +140,7 @@
     "minimist": "^1.2.5",
     "parse5": "^7.1.1",
     "source-map-support": "^0.5.19",
-    "typescript": "~5.8.0"
+    "typescript": "~5.9.0"
   },
   "devDependencies": {
     "@lit-internal/tests": "0.0.1",

--- a/packages/localize-tools/src/messages.ts
+++ b/packages/localize-tools/src/messages.ts
@@ -99,7 +99,7 @@ export function sortProgramMessages(
   messages: ProgramMessage[]
 ): ProgramMessage[] {
   return messages.sort((a, b) => {
-    if (a.desc ?? '' !== b.desc ?? '') {
+    if ((a.desc ?? '') !== (b.desc ?? '')) {
       return (a.desc ?? '').localeCompare(b.desc ?? '');
     }
     return a.file.fileName.localeCompare(b.file.fileName);

--- a/packages/localize/examples/transform-js/package.json
+++ b/packages/localize/examples/transform-js/package.json
@@ -60,6 +60,6 @@
     "@web/dev-server": "^0.1.22",
     "rollup": "^4.18.0",
     "rollup-plugin-summary": "^2.0.1",
-    "typescript": "~5.5.0"
+    "typescript": "~5.8.0"
   }
 }

--- a/packages/localize/examples/transform-js/package.json
+++ b/packages/localize/examples/transform-js/package.json
@@ -60,6 +60,6 @@
     "@web/dev-server": "^0.1.22",
     "rollup": "^4.18.0",
     "rollup-plugin-summary": "^2.0.1",
-    "typescript": "~5.8.0"
+    "typescript": "~5.9.0"
   }
 }

--- a/packages/localize/examples/transform-ts/package.json
+++ b/packages/localize/examples/transform-ts/package.json
@@ -63,6 +63,6 @@
     "@web/dev-server": "^0.1.22",
     "rollup": "^4.18.0",
     "rollup-plugin-summary": "^2.0.1",
-    "typescript": "~5.5.0"
+    "typescript": "~5.8.0"
   }
 }

--- a/packages/localize/examples/transform-ts/package.json
+++ b/packages/localize/examples/transform-ts/package.json
@@ -63,6 +63,6 @@
     "@web/dev-server": "^0.1.22",
     "rollup": "^4.18.0",
     "rollup-plugin-summary": "^2.0.1",
-    "typescript": "~5.8.0"
+    "typescript": "~5.9.0"
   }
 }

--- a/packages/tests-typescript/package.json
+++ b/packages/tests-typescript/package.json
@@ -5,20 +5,27 @@
   "type": "module",
   "dependencies": {
     "typescript": "5.8.2",
+    "typescript5_5": "npm:typescript@~5.5.0",
+    "typescript5_6": "npm:typescript@~5.6.0",
+    "typescript5_7": "npm:typescript@~5.7.0",
     "lit": "*"
   },
   "scripts": {
     "test": "wireit",
     "test:node": "wireit",
     "test:nodenext": "wireit",
-    "test:bundler": "wireit"
+    "test:bundler": "wireit",
+    "test:ts5_5": "wireit"
   },
   "wireit": {
     "test": {
       "dependencies": [
         "test:node",
         "test:nodenext",
-        "test:bundler"
+        "test:bundler",
+        "test:ts5_5",
+        "test:ts5_6",
+        "test:ts5_7"
       ]
     },
     "test:node": {
@@ -35,6 +42,24 @@
     },
     "test:bundler": {
       "command": "npx tsc --module es2020 --moduleResolution bundler --lib DOM --noEmit src/test-entry.ts",
+      "dependencies": [
+        "../lit:build"
+      ]
+    },
+    "test:ts5_5": {
+      "command": "node ../../node_modules/typescript5_5/bin/tsc --module es2020 --moduleResolution node --lib DOM --noEmit src/test-entry.ts",
+      "dependencies": [
+        "../lit:build"
+      ]
+    },
+    "test:ts5_6": {
+      "command": "node ../../node_modules/typescript5_6/bin/tsc --module es2020 --moduleResolution node --lib DOM --noEmit src/test-entry.ts",
+      "dependencies": [
+        "../lit:build"
+      ]
+    },
+    "test:ts5_7": {
+      "command": "node ../../node_modules/typescript5_7/bin/tsc --module es2020 --moduleResolution node --lib DOM --noEmit src/test-entry.ts",
       "dependencies": [
         "../lit:build"
       ]

--- a/packages/tests-typescript/package.json
+++ b/packages/tests-typescript/package.json
@@ -4,10 +4,11 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "typescript": "5.8.2",
+    "typescript": "5.9.2",
     "typescript5_5": "npm:typescript@~5.5.0",
     "typescript5_6": "npm:typescript@~5.6.0",
     "typescript5_7": "npm:typescript@~5.7.0",
+    "typescript5_8": "npm:typescript@~5.8.0",
     "lit": "*"
   },
   "scripts": {
@@ -25,7 +26,8 @@
         "test:bundler",
         "test:ts5_5",
         "test:ts5_6",
-        "test:ts5_7"
+        "test:ts5_7",
+        "test:ts5_8"
       ]
     },
     "test:node": {
@@ -60,6 +62,12 @@
     },
     "test:ts5_7": {
       "command": "node ../../node_modules/typescript5_7/bin/tsc --module es2020 --moduleResolution node --lib DOM --noEmit src/test-entry.ts",
+      "dependencies": [
+        "../lit:build"
+      ]
+    },
+    "test:ts5_8": {
+      "command": "node ../../node_modules/typescript5_8/bin/tsc --module es2020 --moduleResolution node --lib DOM --noEmit src/test-entry.ts",
       "dependencies": [
         "../lit:build"
       ]

--- a/playground/package.json
+++ b/playground/package.json
@@ -9,7 +9,7 @@
     "new": "node ./scripts/new.js"
   },
   "devDependencies": {
-    "typescript": "~5.8.0",
+    "typescript": "~5.9.0",
     "vite": "^5.3.4"
   }
 }

--- a/playground/package.json
+++ b/playground/package.json
@@ -9,7 +9,7 @@
     "new": "node ./scripts/new.js"
   },
   "devDependencies": {
-    "typescript": "~5.5.0",
+    "typescript": "~5.8.0",
     "vite": "^5.3.4"
   }
 }


### PR DESCRIPTION
This PR updates all TypeScript dependencies to version 5.9, adds .d.ts compilation checks for older TypeScript versions (see `packages/tests-typescript/package.json`) and adds newly added ARIAMixin properties (ariaColIndexText, ariaRelevant and ariaRowIndexText) to the ElementInternals SSR shim.