### PR TITLE
Implement the full CustomElementRegistry type for the ssr shim.

### DIFF
--- a/.changeset/rare-dryers-jump.md
+++ b/.changeset/rare-dryers-jump.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/ssr-dom-shim': minor
+---
+
+Implement the full CustomElementRegistry type for the ssr shim. Improves fidelity and compilability.

--- a/packages/labs/ssr-dom-shim/src/index.ts
+++ b/packages/labs/ssr-dom-shim/src/index.ts
@@ -249,7 +249,7 @@ class CustomElementRegistry implements RealCustomElementRegistry {
     return null;
   }
 
-  upgrade(element: HTMLElement) {
+  upgrade(_element: HTMLElement) {
     // In SSR this doesn't make a lot of sense, so we do nothing.
   }
 


### PR DESCRIPTION
This improves fidelity, and by making the class a declaration rather than an expression, and explicitly implementing the real interface we're able to better cooperate with JSCompiler's renaming.