### PR TITLE
fix(lit-html,lit,lit-element): adjust ssr directive patch condition

### DIFF
--- a/.changeset/five-deers-own.md
+++ b/.changeset/five-deers-own.md
@@ -1,7 +1,7 @@
 ---
-'lit-html': minor
-'lit': minor
-'lit-element': minor
+'lit-html': patch
+'lit': patch
+'lit-element': patch
 ---
 
 Adjusted the comparison to use the name property of the \_$resolve function and the resolveOverrideFn in private ssr support to prevent duplicated patching of the directive class.

--- a/.changeset/five-deers-own.md
+++ b/.changeset/five-deers-own.md
@@ -1,0 +1,7 @@
+---
+'lit-html': minor
+'lit': minor
+'lit-element': minor
+---
+
+Adjusted the comparison to use the name property of the \_$resolve function and the resolveOverrideFn in private ssr support to prevent duplicated patching of the directive class.

--- a/packages/lit-html/src/private-ssr-support.ts
+++ b/packages/lit-html/src/private-ssr-support.ts
@@ -68,7 +68,7 @@ export const _$LH = {
       values: unknown[]
     ) => unknown
   ) => {
-    if (directiveClass.prototype._$resolve !== resolveOverrideFn) {
+    if (directiveClass.prototype._$resolve.name !== resolveOverrideFn.name) {
       resolveMethodName ??= directiveClass.prototype._$resolve
         .name as NonNullable<typeof resolveMethodName>;
       for (


### PR DESCRIPTION
### Description
Adjusted the comparison to use the Function.name property of the `_$resolve` function and the `resolveOverrideFn` in private ssr support to prevent attempted duplicative patching of a directive class.

It appears that after the first patching the directive, like `classMap`, that the conditional check remains `false`. The member/method on the class is still `_$resolve`, but its name is `ssrResolve`. Further processing of checking the Prototype of the directive with `proto.hasOwnProperty(resolveMethodName)` since `ssrResolve` doesn't exist. That path leads to an error being thrown and breaks SSR for that render.

Hopefully addresses Issue #4527 