### PR TITLE
pin changeset action version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ jobs:
   release:
     # Don't run on forks. We can and should only release from the main repo.
     permissions:
-      contents: write  # for Git to git push
+      contents: write # for Git to git push
       pull-requests: write # to allow creating PR
       id-token: write # for npm provenance
 
@@ -54,7 +54,8 @@ jobs:
         # run, and its output will appear in the raw logs). Unknown why this is the case,
         # see https://github.com/changesets/action/issues/149 for discussion.
         id: cs
-        uses: changesets/action@v1
+        # Pinning to v1.5.1 as v1.5.2 introduced a bug with sub directories
+        uses: changesets/action@v1.5.1
         with:
           # The `working-directory` option is only available for steps that use
           # `run`. This `cwd` option is the same, but specific to this action.


### PR DESCRIPTION
There's a bug in changesets/action that causes an error when using sub directories: https://github.com/changesets/action/issues/475#issuecomment-2871206995

Example of failed release workflow: https://github.com/lit/lit/actions/runs/14846949543/job/41682877633

Pinning to a previous working version until it's fixed.