### PR TITLE
[ci] fix two broken CI issues

### DIFF
--- a/.changeset/lovely-mangos-deny.md
+++ b/.changeset/lovely-mangos-deny.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/vue-utils': patch
+---
+
+Fixed an issue where assignSlotNodes would throw an error due to it processing an internal Vue implementation slotname

--- a/.changeset/witty-masks-begin.md
+++ b/.changeset/witty-masks-begin.md
@@ -1,0 +1,5 @@
+---
+'@lit-internal/scripts': patch
+---
+
+Fix CI issue regarding release image

--- a/packages/internal-scripts/src/release-image.ts
+++ b/packages/internal-scripts/src/release-image.ts
@@ -153,7 +153,10 @@ async function generateReleaseImage(contents: string) {
        </body>
      </html>
    `;
-  const browser = await puppeteer.launch({headless: true});
+  const browser = await puppeteer.launch({
+    headless: true,
+    args: ['--no-sandbox'],
+  });
   const page = await browser.newPage();
   await page.setViewport({width: 800, height: 800, deviceScaleFactor: 2});
   await page.setContent(html);

--- a/packages/labs/vue-utils/src/wrapper-utils.ts
+++ b/packages/labs/vue-utils/src/wrapper-utils.ts
@@ -45,12 +45,18 @@ const assignWrappedNode = (v: VNode, name: string) =>
 // Converts Vue slot data to native slot-able nodes by directly manipulating
 // vNodes.
 export const assignSlotNodes = (slots: Slots) =>
-  Object.keys(slots).map((name) =>
-    slots[name]().map((v: VNode) =>
-      name === 'default'
-        ? v
-        : isElementNode(v)
-          ? assignNode(v, name)
-          : assignWrappedNode(v, name)
-    )
-  );
+  Object.keys(slots)
+    // Vue seems to have introduced a `__` slot name that holds metadata
+    // in the form of number[] rather than vNodes.
+    .filter((name) => name !== '__')
+    .map((name) => {
+      const slotValue = slots[name];
+      const nodes = Array.isArray(slotValue) ? slotValue : slotValue();
+      return nodes.map((v: VNode) =>
+        name === 'default'
+          ? v
+          : isElementNode(v)
+            ? assignNode(v, name)
+            : assignWrappedNode(v, name)
+      );
+    });


### PR DESCRIPTION
CI is broken based on the kernel used by GH Actions. We are using unbuntu-latest. [See this CI error](https://github.com/lit/lit/actions/runs/15080547701/job/42397010351?pr=4970). Pretty sure we can trust the content we are running so we should be able to just turn the sandbox off since this just generates an image.

It was also broken because it seems that Vue introduced a new hidden slot with the slotname `__` which seems to hold metadata we were not expecting. [Related CI failure](https://github.com/lit/lit/actions/runs/15080964528/job/42397632767?pr=4991)
<!-- bbranch-comment-start -->

| Parent | Children |
| -- | -- |
| (main) | [#4970](https://github.com/lit/lit/pull/4970) |

<!-- bbranch-comment-end -->