### PR TITLE
fix(@lit-labs/ssr-react,@lit-labs/nextjs): Enable ssr create element patch

### DIFF
--- a/.changeset/metal-bobcats-cross.md
+++ b/.changeset/metal-bobcats-cross.md
@@ -1,0 +1,6 @@
+---
+'@lit-labs/ssr-react': patch
+'@lit-labs/nextjs': patch
+---
+
+Prevent duplicative patching of React.createElement.

--- a/packages/labs/ssr-react/src/node/enable-lit-ssr.ts
+++ b/packages/labs/ssr-react/src/node/enable-lit-ssr.ts
@@ -20,9 +20,12 @@ import {wrapJsx, wrapJsxDev, wrapJsxs} from '../lib/node/wrap-jsx.js';
 /* eslint-disable @typescript-eslint/no-explicit-any */
 // The `.default ??` is used to get around inconsistent behavior with how
 // tools like webpack seem to do es module interop.
-Object.assign((React as any).default ?? React, {
-  createElement: wrapCreateElement(React.createElement),
-});
+if (React.createElement.name !== 'litPatchedCreateElement') {
+  Object.assign((React as any).default ?? React, {
+    createElement: wrapCreateElement(React.createElement),
+  });
+}
+
 if (process.env.NODE_ENV === 'production') {
   Object.assign((ReactJSXRuntime as any).default ?? ReactJSXRuntime, {
     jsx: wrapJsx(ReactJSXRuntime.jsx, ReactJSXRuntime.jsxs),


### PR DESCRIPTION
### Description
Added a guard to check if `React.createElement` was already patched with `litPatchedCreateElement` to prevent adding to the stack multiple calls to `litPatchedCreateElement`. 

Addresses issue #4986 