### PR TITLE
[labs/analyzer] Adjust attribute source locations in template parser

### DIFF
--- a/.changeset/cuddly-boats-slide.md
+++ b/.changeset/cuddly-boats-slide.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/analyzer': patch
+---
+
+Adjust attribute source locations in template parser

--- a/packages/labs/analyzer/src/lib/lit/template.ts
+++ b/packages/labs/analyzer/src/lib/lit/template.ts
@@ -419,7 +419,14 @@ export const parseLitTemplate = (
 
         if (node.attrs.length > 0) {
           for (const attr of node.attrs) {
-            // TODO (justinfagnani): adjust attribute locations
+            const attrSourceLocation =
+              node.sourceCodeLocation?.attrs?.[attr.name];
+
+            if (attrSourceLocation !== undefined) {
+              attrSourceLocation.startLine += lineAdjust;
+              attrSourceLocation.startCol += colAdjust;
+              attrSourceLocation.startOffset += offsetAdjust;
+            }
 
             if (attr.name.startsWith(marker)) {
               // An element binding, like <div ${}>
@@ -514,6 +521,12 @@ export const parseLitTemplate = (
                 } as AttributePartInfo)
               );
               spanIndex += strings.length - 1;
+            }
+
+            if (attrSourceLocation !== undefined) {
+              attrSourceLocation.endLine += lineAdjust;
+              attrSourceLocation.endCol += colAdjust;
+              attrSourceLocation.endOffset += offsetAdjust;
             }
           }
         }

--- a/packages/labs/analyzer/src/test/server/lit/template_test.ts
+++ b/packages/labs/analyzer/src/test/server/lit/template_test.ts
@@ -193,6 +193,27 @@ const assertTemplateNodeText = (
   assert.equal(elementTextFromLinesAndCols, expected);
 };
 
+const assertAttributeText = (
+  node: Element,
+  attrName: string,
+  templateExpression: ts.TaggedTemplateExpression,
+  expected: string
+) => {
+  // Trim off the leading and trailing backticks
+  const templateText = templateExpression.template.getFullText().slice(1, -1);
+  assert.ok(node.sourceCodeLocation?.attrs);
+  const sourceLocation = node.sourceCodeLocation?.attrs?.[attrName];
+  assert.ok(
+    sourceLocation,
+    `source location for attribute not found: ${attrName}`
+  );
+  const {startOffset, endOffset} = sourceLocation;
+
+  // Check that the offsets are correct:
+  const textFromOffsets = templateText.substring(startOffset, endOffset);
+  assert.equal(textFromOffsets, expected);
+};
+
 suite('parseLitTemplate', () => {
   const testFilePath = path.resolve(testFilesDir, 'hello.ts');
   const {sourceFile, checker} = getTestSourceFile(testFilePath);
@@ -323,6 +344,13 @@ suite('parseLitTemplate', () => {
         div as Element,
         templateExpression,
         `<div class="\${'a'}"><span>Hello, world!</span></div>`
+      );
+
+      assertAttributeText(
+        div as Element,
+        'class$lit$',
+        templateExpression,
+        `class="\${'a'}"`
       );
 
       const span = (div as Element).childNodes[0];


### PR DESCRIPTION
This is the same as https://github.com/lit/lit/pull/5054, just based on `main`.