### PR TITLE
[localize] Fix "&", "<" and ">" getting replaced with html escape sequences.

### DIFF
--- a/.changeset/cold-banks-tie.md
+++ b/.changeset/cold-banks-tie.md
@@ -1,0 +1,5 @@
+---
+'@lit/localize-tools': minor
+---
+
+Keep Escape Sequences in html Translations as they where written

--- a/packages/localize-tools/src/program-analysis.ts
+++ b/packages/localize-tools/src/program-analysis.ts
@@ -517,6 +517,8 @@ function replaceHtmlWithPlaceholders(
 
   const traverse = (node: ChildNode): void => {
     if (node.nodeName === '#text') {
+      // Copy source range to preserve escape sequences from the source text intact.
+      // parse5 does not preserve escape sequences, so node.value has html like escape sequences removed.
       const location = node.sourceCodeLocation!;
       const text = html.substring(location.startOffset, location.endOffset);
       components.push(text);

--- a/packages/localize-tools/src/program-analysis.ts
+++ b/packages/localize-tools/src/program-analysis.ts
@@ -6,7 +6,7 @@
 
 import ts from 'typescript';
 import * as parse5 from 'parse5';
-import {ChildNode, ParentNode, TextNode, CommentNode} from '@parse5/tools';
+import {ChildNode, ParentNode, CommentNode} from '@parse5/tools';
 import {ProgramMessage, Placeholder} from './messages.js';
 import {createDiagnostic} from './typescript.js';
 import {

--- a/packages/localize-tools/src/program-analysis.ts
+++ b/packages/localize-tools/src/program-analysis.ts
@@ -517,7 +517,8 @@ function replaceHtmlWithPlaceholders(
 
   const traverse = (node: ChildNode): void => {
     if (node.nodeName === '#text') {
-      const text = (node as TextNode).value;
+      const location = node.sourceCodeLocation!;
+      const text = html.substring(location.startOffset, location.endOffset);
       components.push(text);
     } else if (node.nodeName === '#comment') {
       components.push({
@@ -535,7 +536,7 @@ function replaceHtmlWithPlaceholders(
     }
   };
 
-  const frag = parse5.parseFragment(html);
+  const frag = parse5.parseFragment(html, {sourceCodeLocationInfo: true});
   for (const child of frag.childNodes) {
     traverse(child);
   }

--- a/packages/localize-tools/src/tests/transform.unit.test.mts
+++ b/packages/localize-tools/src/tests/transform.unit.test.mts
@@ -347,7 +347,7 @@ test('msg(string(msg(string))) translated', async () => {
 test('msg(string(<b>msg(string)</b>)) translated', async () => {
   await checkTransform(
     'msg(str`Hello <b>${msg("World", {id: "bar"})}</b>!`, {id: "foo"});',
-    '`Hola &lt;b&gt;Mundo&lt;/b&gt;!`;',
+    '`Hola <b>Mundo</b>!`;',
     {
       messages: [
         {

--- a/packages/localize-tools/src/tests/transform.unit.test.ts
+++ b/packages/localize-tools/src/tests/transform.unit.test.ts
@@ -124,6 +124,26 @@ test('msg(string) translated', async () => {
   });
 });
 
+test('msg(string) with symbols', async () => {
+  // "\" in code needs to be double escaped (string inside a string).
+  await checkTransform(
+    'msg("Hello World \\\\ ${} ` < > &", {id: "foo"});',
+    '"Hello World \\\\ ${} ` < > &";'
+  );
+});
+
+test('msg(string) translated with symbols', async () => {
+  // "\" in code needs to be double escaped (string inside a string).
+  // "$", "`" only needs to be escaped in template literal string
+  await checkTransform(
+    'msg("Hello World \\\\ ${} ` < > &", {id: "foo"});',
+    '`Hola Mundo \\\\ \\${} \\` < > &`;',
+    {
+      messages: [{name: 'foo', contents: ['Hola Mundo \\ ${} ` < > &']}],
+    }
+  );
+});
+
 test('html(msg(string))', async () => {
   await checkTransform(
     'html`<b>${msg("Hello World", {id: "foo"})}</b>`;',
@@ -136,6 +156,27 @@ test('html(msg(string)) translated', async () => {
     'html`<b>${msg("Hello World", {id: "foo"})}</b>`;',
     'html`<b>Hola Mundo</b>`;',
     {messages: [{name: 'foo', contents: ['Hola Mundo']}]}
+  );
+});
+
+// Fix: "<", ">", "&" need to be escaped in html literal
+test('html(msg(string)) with symbols', async () => {
+  // "\" in code needs to be double escaped (string inside a string).
+  // "$", "`" only needs to be escaped in template literal string
+  await checkTransform(
+    'html`<b>${msg("Hello World \\\\ ${} ` < > &", {id: "foo"})}</b>`;',
+    'html`<b>Hello World \\\\ \\${} \\` < > &</b>`;' // should be: 'html`<b>Hello World \\\\ \\${} \\` &lt; &gt; &amp;</b>`;'
+  );
+});
+
+// Fix: "<", ">", "&" need to be escaped in html literal
+test('html(msg(string)) translated with symbols', async () => {
+  // "\" in code needs to be double escaped (string inside a string).
+  // "$", "`" only needs to be escaped in template literal string
+  await checkTransform(
+    'html`<b>${msg("Hello World \\\\ ${} ` < > &", {id: "foo"})}</b>`;',
+    'html`<b>Hola Mundo \\\\ \\${} \\` < > &</b>`;', // should be: 'html`<b>Hola Mundo \\\\ \\${} \\` &lt; &gt; &amp;</b>`;'
+    {messages: [{name: 'foo', contents: ['Hola Mundo \\ ${} ` < > &']}]}
   );
 });
 
@@ -159,6 +200,38 @@ test('html(msg(html)) translated', async () => {
             {untranslatable: '<i>', index: 0},
             'Mundo',
             {untranslatable: '</i>', index: 1},
+          ],
+        },
+      ],
+    }
+  );
+});
+
+test('html(msg(html)) with symbols', async () => {
+  // "\" in code needs to be double escaped (string inside a string).
+  // "$", "`" only needs to be escaped in template literal string
+  await checkTransform(
+    'html`<b>${msg(html`Hello <i>World</i> \\\\ \\${} \\` &lt; &gt; &amp;`, {id: "foo"})}</b>`;',
+    'html`<b>Hello <i>World</i> \\\\ \\${} \\` &lt; &gt; &amp;</b>`;'
+  );
+});
+
+test('html(msg(html)) translated with symbols', async () => {
+  // "\" in code needs to be double escaped (string inside a string).
+  // "$", "`" only needs to be escaped in template literal string
+  await checkTransform(
+    'html`<b>${msg(html`Hello <i>World</i> \\\\ \\$ \\` &lt; &gt; &amp;`, {id: "foo"})}</b>`;',
+    'html`<b>Hola <i>Mundo</i> \\\\ \\$ \\` &lt; &gt; &amp;</b>`;',
+    {
+      messages: [
+        {
+          name: 'foo',
+          contents: [
+            'Hola ',
+            {untranslatable: '<i>', index: 0},
+            'Mundo',
+            {untranslatable: '</i>', index: 1},
+            ' \\ $ ` &lt; &gt; &amp;',
           ],
         },
       ],
@@ -338,6 +411,40 @@ test('msg(string(msg(string))) translated', async () => {
         {
           name: 'bar',
           contents: ['Mundo'],
+        },
+      ],
+    }
+  );
+});
+
+test('msg(string(msg(html)))', async () => {
+  await checkTransform(
+    'msg(str`Hello ${msg(html`<b>World</b>`, {id: "bar"})}!`, {id: "foo"});',
+    '`Hello ${html`<b>World</b>`}!`;'
+  );
+});
+
+test('msg(string(msg(html))) translated', async () => {
+  await checkTransform(
+    'msg(str`Hello ${msg(html`<b>World</b>`, {id: "bar"})}!`, {id: "foo"});',
+    '`Hola ${html`<b>Mundo</b>`}!`;',
+    {
+      messages: [
+        {
+          name: 'foo',
+          contents: [
+            'Hola ',
+            {untranslatable: '${msg("World", {id: "bar"})}', index: 0},
+            '!',
+          ],
+        },
+        {
+          name: 'bar',
+          contents: [
+            {untranslatable: '<b>', index: 0},
+            'Mundo',
+            {untranslatable: '</b>', index: 1},
+          ],
         },
       ],
     }

--- a/packages/localize-tools/src/typescript.ts
+++ b/packages/localize-tools/src/typescript.ts
@@ -89,10 +89,7 @@ export function escapeTextContentToEmbedInTemplateLiteral(
   return unescaped
     .replace(/\\/g, `\\\\`)
     .replace(/`/g, '\\`')
-    .replace(/\$/g, '\\$')
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
+    .replace(/\$/g, '\\$');
 }
 
 /**

--- a/packages/localize-tools/testdata/build-runtime-xliff-ph/goldens/xliff/es-419.xlf
+++ b/packages/localize-tools/testdata/build-runtime-xliff-ph/goldens/xliff/es-419.xlf
@@ -56,8 +56,8 @@
   <target>described 0</target>
 </trans-unit>
 <trans-unit id="h02c268d9b1fcb031">
-  <source>&lt;Hello<ph id="0">&lt;b></ph>&lt;World &amp; Friends><ph id="1">&lt;/b></ph>!></source>
-  <target>&lt;Hola<ph id="0">&lt;b></ph>&lt;Mundo &amp; Amigos><ph id="1">&lt;/b></ph>!></target>
+  <source>&amp;lt;Hello<ph id="0">&lt;b></ph>&amp;lt;World &amp;amp; Friends&amp;gt;<ph id="1">&lt;/b></ph>!&amp;gt;</source>
+  <target>&amp;lt;Hola<ph id="0">&lt;b></ph>&amp;lt;Mundo &amp;amp; Amigos&amp;gt;<ph id="1">&lt;/b></ph>!&amp;gt;</target>
 </trans-unit>
 <trans-unit id="s372f95c2b25986c8">
   <source>Different <ph id="0">${user}</ph></source>

--- a/packages/localize-tools/testdata/build-runtime-xliff-ph/input/xliff/es-419.xlf
+++ b/packages/localize-tools/testdata/build-runtime-xliff-ph/input/xliff/es-419.xlf
@@ -56,8 +56,8 @@
   <target>described 0</target>
 </trans-unit>
 <trans-unit id="h02c268d9b1fcb031">
-  <source>&lt;Hello<ph id="0">&lt;b></ph>&lt;World &amp; Friends><ph id="1">&lt;/b></ph>!></source>
-  <target>&lt;Hola<ph id="0">&lt;b></ph>&lt;Mundo &amp; Amigos><ph id="1">&lt;/b></ph>!></target>
+  <source>&amp;lt;Hello<ph id="0">&lt;b></ph>&amp;lt;World &amp;amp; Friends&amp;gt;<ph id="1">&lt;/b></ph>!&amp;gt;</source>
+  <target>&amp;lt;Hola<ph id="0">&lt;b></ph>&amp;lt;Mundo &amp;amp; Amigos&amp;gt;<ph id="1">&lt;/b></ph>!&amp;gt;</target>
 </trans-unit>
 <trans-unit id="s372f95c2b25986c8">
   <source>Different <ph id="0">${user}</ph></source>

--- a/packages/localize-tools/testdata/build-runtime-xliff/goldens/xliff/es-419.xlf
+++ b/packages/localize-tools/testdata/build-runtime-xliff/goldens/xliff/es-419.xlf
@@ -51,8 +51,8 @@
   <target><x id="0" equiv-text="&lt;b>"/>Hola<x id="1" equiv-text="&lt;/b>"/>! Clic <x id="2" equiv-text="&lt;a href=&quot;${urlBase}/${urlPath}&quot;>"/>aquí<x id="3" equiv-text="&lt;/a>"/>!</target>
 </trans-unit>
 <trans-unit id="h02c268d9b1fcb031">
-  <source>&lt;Hello<x id="0" equiv-text="&lt;b>"/>&lt;World &amp; Friends><x id="1" equiv-text="&lt;/b>"/>!></source>
-  <target>&lt;Hola<x id="0" equiv-text="&lt;b>"/>&lt;Mundo &amp; Amigos><x id="1" equiv-text="&lt;/b>"/>!></target>
+  <source>&amp;lt;Hello<x id="0" equiv-text="&lt;b>"/>&amp;lt;World &amp;amp; Friends&amp;gt;<x id="1" equiv-text="&lt;/b>"/>!&amp;gt;</source>
+  <target>&amp;lt;Hola<x id="0" equiv-text="&lt;b>"/>&amp;lt;Mundo &amp;amp; Amigos&amp;gt;<x id="1" equiv-text="&lt;/b>"/>!&amp;gt;</target>
 </trans-unit>
 <trans-unit id="s03c68d79ad36e8d4">
   <note>Description of 0</note>

--- a/packages/localize-tools/testdata/build-runtime-xliff/input/xliff/es-419.xlf
+++ b/packages/localize-tools/testdata/build-runtime-xliff/input/xliff/es-419.xlf
@@ -51,8 +51,8 @@
   <target><x id="0" equiv-text="&lt;b>"/>Hola<x id="1" equiv-text="&lt;/b>"/>! Clic <x id="2" equiv-text="&lt;a href=&quot;${urlBase}/${urlPath}&quot;>"/>aquí<x id="3" equiv-text="&lt;/a>"/>!</target>
 </trans-unit>
 <trans-unit id="h02c268d9b1fcb031">
-  <source>&lt;Hello<x id="0" equiv-text="&lt;b>"/>&lt;World &amp; Friends><x id="1" equiv-text="&lt;/b>"/>!></source>
-  <target>&lt;Hola<x id="0" equiv-text="&lt;b>"/>&lt;Mundo &amp; Amigos><x id="1" equiv-text="&lt;/b>"/>!></target>
+  <source>&amp;lt;Hello<x id="0" equiv-text="&lt;b>"/>&amp;lt;World &amp;amp; Friends&amp;gt;<x id="1" equiv-text="&lt;/b>"/>!&amp;gt;</source>
+  <target>&amp;lt;Hola<x id="0" equiv-text="&lt;b>"/>&amp;lt;Mundo &amp;amp; Amigos&amp;gt;<x id="1" equiv-text="&lt;/b>"/>!&amp;gt;</target>
 </trans-unit>
 <trans-unit id="s03c68d79ad36e8d4">
   <note>Description of 0</note>

--- a/packages/localize-tools/testdata/build-transform-xliff-std/goldens/xliff/es-419.xlf
+++ b/packages/localize-tools/testdata/build-transform-xliff-std/goldens/xliff/es-419.xlf
@@ -43,8 +43,8 @@
   <target>Hola Mundo</target>
 </trans-unit>
 <trans-unit id="h02c268d9b1fcb031">
-  <source>&lt;Hello<ph id="0">&lt;b></ph>&lt;World &amp; Friends><ph id="1">&lt;/b></ph>!></source>
-  <target>&lt;Hola<ph id="0">&lt;b></ph>&lt;Mundo &amp; Amigos><ph id="1">&lt;/b></ph>!></target>
+  <source>&amp;lt;Hello<ph id="0">&lt;b></ph>&amp;lt;World &amp;amp; Friends&amp;gt;<ph id="1">&lt;/b></ph>!&amp;gt;</source>
+  <target>&amp;lt;Hola<ph id="0">&lt;b></ph>&amp;lt;Mundo &amp;amp; Amigos&amp;gt;<ph id="1">&lt;/b></ph>!&amp;gt;</target>
 </trans-unit>
 </body>
 </file>

--- a/packages/localize-tools/testdata/build-transform-xliff-std/input/xliff/es-419.xlf
+++ b/packages/localize-tools/testdata/build-transform-xliff-std/input/xliff/es-419.xlf
@@ -43,8 +43,8 @@
   <target>Hola Mundo</target>
 </trans-unit>
 <trans-unit id="h02c268d9b1fcb031">
-  <source>&lt;Hello<ph id="0">&lt;b></ph>&lt;World &amp; Friends><ph id="1">&lt;/b></ph>!></source>
-  <target>&lt;Hola<ph id="0">&lt;b></ph>&lt;Mundo &amp; Amigos><ph id="1">&lt;/b></ph>!></target>
+  <source>&amp;lt;Hello<ph id="0">&lt;b></ph>&amp;lt;World &amp;amp; Friends&amp;gt;<ph id="1">&lt;/b></ph>!&amp;gt;</source>
+  <target>&amp;lt;Hola<ph id="0">&lt;b></ph>&amp;lt;Mundo &amp;amp; Amigos&amp;gt;<ph id="1">&lt;/b></ph>!&amp;gt;</target>
 </trans-unit>
 </body>
 </file>

--- a/packages/localize-tools/testdata/build-transform-xliff/goldens/xliff/es-419.xlf
+++ b/packages/localize-tools/testdata/build-transform-xliff/goldens/xliff/es-419.xlf
@@ -43,8 +43,8 @@
   <target>Hola Mundo</target>
 </trans-unit>
 <trans-unit id="h02c268d9b1fcb031">
-  <source>&lt;Hello<ph id="0">&lt;b></ph>&lt;World &amp; Friends><ph id="1">&lt;/b></ph>!></source>
-  <target>&lt;Hola<ph id="0">&lt;b></ph>&lt;Mundo &amp; Amigos><ph id="1">&lt;/b></ph>!></target>
+  <source>&amp;lt;Hello<ph id="0">&lt;b></ph>&amp;lt;World &amp;amp; Friends&amp;gt;<ph id="1">&lt;/b></ph>!&amp;gt;</source>
+  <target>&amp;lt;Hola<ph id="0">&lt;b></ph>&amp;lt;Mundo &amp;amp; Amigos&amp;gt;<ph id="1">&lt;/b></ph>!&amp;gt;</target>
 </trans-unit>
 <trans-unit id="s63f0bfacf2c00f6b">
   <source>Hello</source>

--- a/packages/localize-tools/testdata/build-transform-xliff/input/xliff/es-419.xlf
+++ b/packages/localize-tools/testdata/build-transform-xliff/input/xliff/es-419.xlf
@@ -43,8 +43,8 @@
   <target>Hola Mundo</target>
 </trans-unit>
 <trans-unit id="h02c268d9b1fcb031">
-  <source>&lt;Hello<ph id="0">&lt;b></ph>&lt;World &amp; Friends><ph id="1">&lt;/b></ph>!></source>
-  <target>&lt;Hola<ph id="0">&lt;b></ph>&lt;Mundo &amp; Amigos><ph id="1">&lt;/b></ph>!></target>
+  <source>&amp;lt;Hello<ph id="0">&lt;b></ph>&amp;lt;World &amp;amp; Friends&amp;gt;<ph id="1">&lt;/b></ph>!&amp;gt;</source>
+  <target>&amp;lt;Hola<ph id="0">&lt;b></ph>&amp;lt;Mundo &amp;amp; Amigos&amp;gt;<ph id="1">&lt;/b></ph>!&amp;gt;</target>
 </trans-unit>
 <trans-unit id="s63f0bfacf2c00f6b">
   <source>Hello</source>

--- a/packages/localize-tools/testdata/extract-xliff-fresh-ph/goldens/data/xliff/es-419.xlf
+++ b/packages/localize-tools/testdata/extract-xliff-fresh-ph/goldens/data/xliff/es-419.xlf
@@ -3,7 +3,7 @@
 <file target-language="es-419" source-language="en" original="lit-localize-inputs" datatype="plaintext">
 <body>
 <trans-unit id="h02c268d9b1fcb031">
-  <source>&lt;Hello<ph id="0">&lt;b&gt;</ph>&lt;World &amp; Friends&gt;<ph id="1">&lt;/b&gt;</ph>!&gt;</source>
+  <source>&amp;lt;Hello<ph id="0">&lt;b&gt;</ph>&amp;lt;World &amp;amp; Friends&amp;gt;<ph id="1">&lt;/b&gt;</ph>!&amp;gt;</source>
 </trans-unit>
 <trans-unit id="he7b474847636149b">
   <source>Hello <ph id="0">&lt;b&gt;${name}</ph>!<ph id="1">&lt;/b&gt;</ph></source>

--- a/packages/localize-tools/testdata/extract-xliff-fresh-ph/goldens/data/xliff/zh_CN.xlf
+++ b/packages/localize-tools/testdata/extract-xliff-fresh-ph/goldens/data/xliff/zh_CN.xlf
@@ -3,7 +3,7 @@
 <file target-language="zh_CN" source-language="en" original="lit-localize-inputs" datatype="plaintext">
 <body>
 <trans-unit id="h02c268d9b1fcb031">
-  <source>&lt;Hello<ph id="0">&lt;b&gt;</ph>&lt;World &amp; Friends&gt;<ph id="1">&lt;/b&gt;</ph>!&gt;</source>
+  <source>&amp;lt;Hello<ph id="0">&lt;b&gt;</ph>&amp;lt;World &amp;amp; Friends&amp;gt;<ph id="1">&lt;/b&gt;</ph>!&amp;gt;</source>
 </trans-unit>
 <trans-unit id="he7b474847636149b">
   <source>Hello <ph id="0">&lt;b&gt;${name}</ph>!<ph id="1">&lt;/b&gt;</ph></source>

--- a/packages/localize-tools/testdata/extract-xliff-fresh/goldens/data/xliff/es-419.xlf
+++ b/packages/localize-tools/testdata/extract-xliff-fresh/goldens/data/xliff/es-419.xlf
@@ -3,7 +3,7 @@
 <file target-language="es-419" source-language="en" original="lit-localize-inputs" datatype="plaintext">
 <body>
 <trans-unit id="h02c268d9b1fcb031">
-  <source>&lt;Hello<x id="0" equiv-text="&lt;b&gt;"/>&lt;World &amp; Friends&gt;<x id="1" equiv-text="&lt;/b&gt;"/>!&gt;</source>
+  <source>&amp;lt;Hello<x id="0" equiv-text="&lt;b&gt;"/>&amp;lt;World &amp;amp; Friends&amp;gt;<x id="1" equiv-text="&lt;/b&gt;"/>!&amp;gt;</source>
 </trans-unit>
 <trans-unit id="h82ccc38d4d46eaa9">
   <source>Hello <x id="0" equiv-text="&lt;b&gt;${html `&lt;i&gt;World&lt;/i&gt;`}&lt;/b&gt;"/>!</source>

--- a/packages/localize-tools/testdata/extract-xliff-fresh/goldens/data/xliff/zh_CN.xlf
+++ b/packages/localize-tools/testdata/extract-xliff-fresh/goldens/data/xliff/zh_CN.xlf
@@ -3,7 +3,7 @@
 <file target-language="zh_CN" source-language="en" original="lit-localize-inputs" datatype="plaintext">
 <body>
 <trans-unit id="h02c268d9b1fcb031">
-  <source>&lt;Hello<x id="0" equiv-text="&lt;b&gt;"/>&lt;World &amp; Friends&gt;<x id="1" equiv-text="&lt;/b&gt;"/>!&gt;</source>
+  <source>&amp;lt;Hello<x id="0" equiv-text="&lt;b&gt;"/>&amp;lt;World &amp;amp; Friends&amp;gt;<x id="1" equiv-text="&lt;/b&gt;"/>!&amp;gt;</source>
 </trans-unit>
 <trans-unit id="h82ccc38d4d46eaa9">
   <source>Hello <x id="0" equiv-text="&lt;b&gt;${html `&lt;i&gt;World&lt;/i&gt;`}&lt;/b&gt;"/>!</source>


### PR DESCRIPTION
Fixes #5012

"&", "<" and ">" do not need to be escaped in Template Literal Strings.
This causes invalid translations when these symbols are used in non HTML Context.
I think it is the code author/translator responsibility to properly escape special characters depending on the context.
lit/localize can not know in which context the strings are used.