### PR TITLE
[lit-html] Include SVGElement in render root union type

### DIFF
--- a/.changeset/sour-heads-study.md
+++ b/.changeset/sour-heads-study.md
@@ -1,0 +1,5 @@
+---
+'lit-html': patch
+---
+
+Add type SVGElement to render root union type. Change resolves type error when passing an SVGElement as the container argument to render(...), allowing SVG elements to be used as valid render roots.

--- a/.changeset/sour-heads-study.md
+++ b/.changeset/sour-heads-study.md
@@ -2,4 +2,4 @@
 'lit-html': patch
 ---
 
-Add type SVGElement to render root union type. Change resolves type error when passing an SVGElement as the container argument to render(...), allowing SVG elements to be used as valid render roots.
+Add `SVGElement` to the `render()` container type, allowing SVG elements to be used as render roots without type errors.

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -55,7 +55,7 @@ export namespace LitUnstable {
       kind: 'begin render';
       id: number;
       value: unknown;
-      container: HTMLElement | DocumentFragment;
+      container: RenderRootNode;
       options: RenderOptions | undefined;
       part: ChildPart | undefined;
     }
@@ -63,7 +63,7 @@ export namespace LitUnstable {
       kind: 'end render';
       id: number;
       value: unknown;
-      container: HTMLElement | DocumentFragment;
+      container: RenderRootNode;
       options: RenderOptions | undefined;
       part: ChildPart;
     }
@@ -721,6 +721,11 @@ export interface RenderOptions {
    */
   isConnected?: boolean;
 }
+
+/**
+ * The root DOM node for rendering.
+ */
+export type RenderRootNode = HTMLElement | SVGElement | DocumentFragment;
 
 const walker = d.createTreeWalker(
   d,
@@ -2240,7 +2245,7 @@ if (DEV_MODE && global.litHtmlVersions.length > 1) {
  */
 export const render = (
   value: unknown,
-  container: HTMLElement | DocumentFragment,
+  container: RenderRootNode,
   options?: RenderOptions
 ): RootPart => {
   if (DEV_MODE && container == null) {


### PR DESCRIPTION
## Changes
- Create exportable union type `RenderRootNode` to replace `HTMLElement | DocumentFragment` for reusability
- Add type `SVGElement` to render root element union type 
  - This resolves type error when passing an `SVGElement` as the `container` argument to `render(...)`, allowing SVG elements to be used as valid render roots
  
## Linked Issues Being Addressed
- #2282

  