### PR TITLE
Ignore a /.envrc file for managing working environment.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -14,6 +14,9 @@ node_modules/
 /playground/p/**/package-lock.json
 /playground/p/scratch/*/
 !/playground/p/scratch/*.*
+/.direnv/
+/.envrc
+/.actrc
 
 packages/benchmarks/generated/
 packages/benchmarks/generator/build/

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ node_modules/
 /playground/p/**/package-lock.json
 /playground/p/scratch/*/
 !/playground/p/scratch/*.*
+/.direnv/
+/.envrc
+/.actrc

--- a/.prettierignore
+++ b/.prettierignore
@@ -14,6 +14,9 @@ node_modules/
 /playground/p/**/package-lock.json
 /playground/p/scratch/*/
 !/playground/p/scratch/*.*
+/.direnv/
+/.envrc
+/.actrc
 
 packages/benchmarks/generated/
 packages/benchmarks/generator/build/


### PR DESCRIPTION
I thought about checking in my nix based working dev environment setup but unless we used that as the basis for CI then it would get out of date, and getting a good github actions environemnt running locally so I can iterate on that turned into too much of a rathole, so for now let devs do what they like with a .envrc file. The /.direnv/ directory should always be git ignored, it just stores a versioned cache of dev environments.

Also ignore .actrc which is a user's local config for the act tool for running github actions locally. It usually has very setup-specific options, and should not be checked in.