### PR TITLE
docs: update link to internal-scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ lit-html 1.x source is available on the [`lit-html-1.x`](https://github.com/lit/
 - Internal packages (not published to npm)
   - [`tests`](./packages/tests) - Test infrastructure for the monorepo.
   - [`benchmarks`](./packages/benchmarks) - Benchmarks for testing various libraries in the monorepo.
-  - [`@lit-internal/scripts`](./packages/@lit-internal/scripts) - Utility scripts used within the monorepo.
+  - [`@lit-internal/scripts`](./packages/internal-scripts) - Utility scripts used within the monorepo.
 
 ## Contributing to Lit
 


### PR DESCRIPTION
Correcting an invalid directory reference for @lit-internal/scripts