### PR TITLE
[labs/ssr] Fix import.meta.url in VM modules

### DIFF
--- a/.changeset/tough-bars-stop.md
+++ b/.changeset/tough-bars-stop.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/ssr': patch
+---
+
+Fix bug where import.meta.url had a VM context ID appended to it.

--- a/packages/labs/ssr/src/lib/module-loader.ts
+++ b/packages/labs/ssr/src/lib/module-loader.ts
@@ -409,7 +409,9 @@ export const resolveSpecifier = async (
  * Web-like import.meta initializer that sets up import.meta.url
  */
 const initializeImportMeta = (meta: {url: string}, module: vm.Module) => {
-  meta.url = module.identifier;
+  // Module identifiers end in a `:n` where `n` is the vm context ID,
+  // which we don't want in the URL.
+  meta.url = module.identifier.replace(/:\d+$/, '');
 };
 
 const resolve = async (

--- a/packages/labs/ssr/src/test/lib/module-loader_test.ts
+++ b/packages/labs/ssr/src/test/lib/module-loader_test.ts
@@ -25,6 +25,15 @@ test('loads a single module', async () => {
   assert.is(moduleRecord?.imports.length, 0);
 });
 
+test('supports import.meta.url', async () => {
+  const loader = new ModuleLoader();
+  const result = await loader.importModule('./import-meta-url.js', testIndex);
+  const {module} = result;
+
+  const expectedUrl = path.resolve(testIndex, '../import-meta-url.js');
+  assert.equal(module.namespace.importMetaUrl, expectedUrl);
+});
+
 test('loads a module with an import', async () => {
   const loader = new ModuleLoader();
   const result = await loader.importModule('./index.js', testIndex);

--- a/packages/labs/ssr/src/test/test-files/module-loader/import-meta-url.js
+++ b/packages/labs/ssr/src/test/test-files/module-loader/import-meta-url.js
@@ -1,0 +1,1 @@
+export const importMetaUrl = import.meta.url;


### PR DESCRIPTION
`import.meta.url` in the ModuleLoader had a `:n` appended to it with the context ID (or something similar).