### PR TITLE
[labs/ssr] Remove and reduce internal generator usage

### DIFF
--- a/packages/labs/ssr/src/lib/element-renderer.ts
+++ b/packages/labs/ssr/src/lib/element-renderer.ts
@@ -185,7 +185,8 @@ export abstract class ElementRenderer {
    * The default implementation serializes all attributes on the element
    * instance.
    */
-  *renderAttributes(): RenderResult {
+  renderAttributes(): RenderResult {
+    const renderResult = [];
     if (this.element !== undefined) {
       const {attributes} = this.element;
       for (
@@ -194,12 +195,13 @@ export abstract class ElementRenderer {
         i++
       ) {
         if (value === '' || value === undefined || value === null) {
-          yield ` ${name}`;
+          renderResult.push(` ${name}`);
         } else {
-          yield ` ${name}="${escapeHtml(value)}"`;
+          renderResult.push(` ${name}="${escapeHtml(value)}"`);
         }
       }
     }
+    return renderResult;
   }
 }
 
@@ -215,13 +217,15 @@ export class FallbackRenderer extends ElementRenderer {
     this._attributes[name.toLowerCase()] = value;
   }
 
-  override *renderAttributes(): RenderResult {
+  override renderAttributes(): RenderResult {
+    const renderResult = [];
     for (const [name, value] of Object.entries(this._attributes)) {
       if (value === '' || value === undefined || value === null) {
-        yield ` ${name}`;
+        renderResult.push(` ${name}`);
       } else {
-        yield ` ${name}="${escapeHtml(value)}"`;
+        renderResult.push(` ${name}="${escapeHtml(value)}"`);
       }
     }
+    return renderResult;
   }
 }

--- a/packages/labs/ssr/src/lib/lit-element-renderer.ts
+++ b/packages/labs/ssr/src/lib/lit-element-renderer.ts
@@ -121,29 +121,35 @@ export class LitElementRenderer extends ElementRenderer {
     attributeToProperty(this.element as LitElement, name, value);
   }
 
-  override *renderShadow(renderInfo: RenderInfo): RenderResult {
+  override renderShadow(renderInfo: RenderInfo): RenderResult {
+    const renderResult = [];
     // Render styles.
     const styles = (this.element.constructor as typeof LitElement)
       .elementStyles;
     if (styles !== undefined && styles.length > 0) {
-      yield '<style>';
+      renderResult.push('<style>');
       for (const style of styles) {
-        yield (style as CSSResult).cssText;
+        renderResult.push((style as CSSResult).cssText);
       }
-      yield '</style>';
+      renderResult.push('</style>');
     }
     // Render template
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    yield* renderValue((this.element as any).render(), renderInfo);
+    renderResult.push(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ...renderValue((this.element as any).render(), renderInfo)
+    );
+    return renderResult;
   }
 
-  override *renderLight(renderInfo: RenderInfo): RenderResult {
+  override renderLight(renderInfo: RenderInfo): RenderResult {
+    const renderResult = [];
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const value = (this.element as any)?.renderLight();
     if (value) {
-      yield* renderValue(value, renderInfo);
+      renderResult.push(...renderValue(value, renderInfo));
     } else {
-      yield '';
+      renderResult.push('');
     }
+    return renderResult;
   }
 }


### PR DESCRIPTION
This PR removes generator usage from most of the internal implementation of SSR's `render`. It then optimizes generator overhead by concatenating string parts together before yielding them out from `render` itself. Based on performance improvements we saw from reducing generator usage in our internal rendering engine, we believe this will help Lit SSR as well.