### PR TITLE
[labs/ssr] Convert generators to a trampoline pattern

### DIFF
--- a/.changeset/metal-otters-laugh.md
+++ b/.changeset/metal-otters-laugh.md
@@ -1,0 +1,6 @@
+---
+'@lit-labs/ssr': minor
+'@lit-labs/ssr-react': patch
+---
+
+Convert all generator usage to a thunk/trampoline pattern to increase performance.

--- a/.changeset/metal-otters-laugh.md
+++ b/.changeset/metal-otters-laugh.md
@@ -1,6 +1,8 @@
 ---
-'@lit-labs/ssr': minor
+'@lit-labs/ssr': major
 '@lit-labs/ssr-react': patch
 ---
 
 Convert all generator usage to a thunk/trampoline pattern to increase performance.
+
+This is a breaking change to the ElementRenderer interface.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "cSpell.words": ["renderable", "Thunked"]
+}

--- a/packages/labs/ssr-react/src/lib/node/wrap-jsx.ts
+++ b/packages/labs/ssr-react/src/lib/node/wrap-jsx.ts
@@ -74,7 +74,7 @@ export function wrapJsxs(originalJsxs: typeof jsxs) {
         const templateShadowRoot = createElement('template', {
           ...templateAttributes,
           dangerouslySetInnerHTML: {
-            __html: [...shadowContents].join(''),
+            __html: collectResultSync(shadowContents),
           },
         });
 

--- a/packages/labs/ssr/README.md
+++ b/packages/labs/ssr/README.md
@@ -268,7 +268,7 @@ has lower overhead compared to the `RenderResult` returned by `render()`.
 You should prefer `renderThunked()` over `render()`, which exists for backwards
 compatibility.
 
-In the future we may introduce APIs like `renderToStream()` and
+In the future we may introduce APIs like `renderToString()` and
 `renderToStream()` that eliminate the need to expose the underlying
 representation.
 

--- a/packages/labs/ssr/README.md
+++ b/packages/labs/ssr/README.md
@@ -36,7 +36,7 @@ including defining `customElements` on the global object.
 
 Web servers should prefer rendering to a stream, as they have a lower memory
 footprint and allow sending data in chunks as they are being processed. For this
-case use `ThunkedRenderResultReadable`, which is a Node `Readable` stream
+case use `RenderResultReadable`, which is a Node `Readable` stream
 implementation that provides values from `RenderResult`. This can be piped
 into a `Writable` stream, or passed to web server frameworks like [Koa](https://koajs.com/).
 
@@ -44,14 +44,14 @@ into a `Writable` stream, or passed to web server frameworks like [Koa](https://
 // Example: server.js:
 
 import {renderThunked} from '@lit-labs/ssr';
-import {ThunkedRenderResultReadable} from '@lit-labs/ssr/lib/render-result-readable.js';
+import {RenderResultReadable} from '@lit-labs/ssr/lib/render-result-readable.js';
 import {myTemplate} from './my-template.js';
 
 //...
 
 const ssrResult = renderThunked(myTemplate(data));
 // Assume `context` is a Koa.Context.
-context.body = new ThunkedRenderResultReadable(ssrResult);
+context.body = new RenderResultReadable(ssrResult);
 ```
 
 #### Rendering to a string
@@ -101,7 +101,7 @@ export const renderTemplate = (someData) => {
 ```js
 // Example: server.js:
 
-import {ThunkedRenderResultReadable} from '@lit-labs/ssr/lib/render-result-readable.js';
+import {RenderResultReadable} from '@lit-labs/ssr/lib/render-result-readable.js';
 import {renderModule} from '@lit-labs/ssr/lib/render-module.js';
 
 // Execute the above `renderTemplate` in a separate VM context with a minimal DOM shim
@@ -115,7 +115,7 @@ const ssrResult = await (renderModule(
 // ...
 
 // Assume `context` is a Koa.Context, or other API that accepts a Readable.
-context.body = new ThunkedRenderResultReadable(ssrResult);
+context.body = new RenderResultReadable(ssrResult);
 ```
 
 ## Client usage
@@ -203,7 +203,7 @@ Here's an example that shows how to use a server-only template to render a full 
 
 ```js
 import {renderThunked, html} from '@lit-labs/ssr';
-import {ThunkedRenderResultReadable} from '@lit-labs/ssr/lib/render-result-readable.js';
+import {RenderResultReadable} from '@lit-labs/ssr/lib/render-result-readable.js';
 import './app-shell.js';
 import {getContent} from './content-template.js';
 
@@ -253,7 +253,7 @@ const ssrResult = renderThunked(html`
 
 // ...
 
-context.body = new ThunkedRenderResultReadable(ssrResult);
+context.body = new RenderResultReadable(ssrResult);
 ```
 
 ## Thunked vs non-Thunked Rendering

--- a/packages/labs/ssr/package.json
+++ b/packages/labs/ssr/package.json
@@ -76,7 +76,7 @@
       ]
     },
     "test:unit": {
-      "command": "NODE_OPTIONS=--experimental-vm-modules uvu test \"lib/.*_test\\.js$\"",
+      "command": "NODE_OPTIONS=\"--experimental-vm-modules --enable-source-maps\" uvu test \"lib/.*_test\\.js$\"",
       "#comment": [
         "These unit tests use the default export condition, so they require a",
         "full build of all dependencies."

--- a/packages/labs/ssr/src/demo/global/app-server.ts
+++ b/packages/labs/ssr/src/demo/global/app-server.ts
@@ -8,8 +8,8 @@
  * This is a server-only module that renders the HTML file shell.
  */
 
-import {render} from '../../lib/render.js';
-import {RenderResult} from '../../lib/render-result.js';
+import {renderThunked} from '../../lib/render.js';
+import {ThunkedRenderResult} from '../../lib/render-result.js';
 import {template, initialData} from './module.js';
 
 export function renderAppWithInitialData() {
@@ -21,7 +21,7 @@ export function renderAppWithInitialData() {
 // shell in unbalanced fragments. By yielding the HTML preamble immediately
 // with no lit-html template preparation or rendering needed, we minimize TTFB,
 // And can get the browser to start prefetch as soon as possible.
-export function renderApp(data: typeof initialData): RenderResult {
+export function renderApp(data: typeof initialData): ThunkedRenderResult {
   return [
     `
     <!doctype html>
@@ -44,7 +44,7 @@ export function renderApp(data: typeof initialData): RenderResult {
         <div>`,
 
     // Call the SSR render() function to render a client/server shared template.
-    () => render(template(data)),
+    () => renderThunked(template(data)),
 
     `
         </div>

--- a/packages/labs/ssr/src/demo/global/app-server.ts
+++ b/packages/labs/ssr/src/demo/global/app-server.ts
@@ -9,6 +9,7 @@
  */
 
 import {render} from '../../lib/render.js';
+import {RenderResult} from '../../lib/render-result.js';
 import {template, initialData} from './module.js';
 
 export function renderAppWithInitialData() {
@@ -20,8 +21,9 @@ export function renderAppWithInitialData() {
 // shell in unbalanced fragments. By yielding the HTML preamble immediately
 // with no lit-html template preparation or rendering needed, we minimize TTFB,
 // And can get the browser to start prefetch as soon as possible.
-export function* renderApp(data: typeof initialData) {
-  yield `
+export function renderApp(data: typeof initialData): RenderResult {
+  return [
+    `
     <!doctype html>
     <html>
       <head>
@@ -34,19 +36,20 @@ export function* renderApp(data: typeof initialData) {
           });
         </script>
         <script src="./node_modules/@webcomponents/template-shadowroot/template-shadowroot.min.js"></script>
-        `;
-  yield `
+        `,
+    `
       </head>
       <body>
         <button>Hydrate</button>
-        <div>`;
+        <div>`,
 
-  // Call the SSR render() function to render a client/server shared template.
-  yield* render(template(data));
+    // Call the SSR render() function to render a client/server shared template.
+    () => render(template(data)),
 
-  yield `
+    `
         </div>
         <script>TemplateShadowRoot.hydrateShadowRoots(document.body);</script>
       </body>
-</html>`;
+    </html>`,
+  ];
 }

--- a/packages/labs/ssr/src/demo/global/server.ts
+++ b/packages/labs/ssr/src/demo/global/server.ts
@@ -5,13 +5,13 @@
  */
 
 import Koa from 'koa';
-import staticFiles from 'koa-static';
-import koaNodeResolve from 'koa-node-resolve';
-import {URL} from 'url';
-import * as path from 'path';
-import {renderAppWithInitialData} from './app-server.js';
-import {RenderResultReadable} from '../../lib/render-result-readable.js';
 import mount from 'koa-mount';
+import koaNodeResolve from 'koa-node-resolve';
+import staticFiles from 'koa-static';
+import * as path from 'path';
+import {URL} from 'url';
+import {ThunkedRenderResultReadable} from '../../lib/render-result-readable.js';
+import {renderAppWithInitialData} from './app-server.js';
 const {nodeResolve} = koaNodeResolve;
 
 const moduleUrl = new URL(import.meta.url);
@@ -32,7 +32,7 @@ app.use(async (ctx: Koa.Context, next: Function) => {
 
   const ssrResult = renderAppWithInitialData();
   ctx.type = 'text/html';
-  ctx.body = new RenderResultReadable(ssrResult);
+  ctx.body = new ThunkedRenderResultReadable(ssrResult);
 });
 app.use(nodeResolve({root: monorepoRoot}));
 app.use(

--- a/packages/labs/ssr/src/demo/global/server.ts
+++ b/packages/labs/ssr/src/demo/global/server.ts
@@ -10,7 +10,7 @@ import koaNodeResolve from 'koa-node-resolve';
 import staticFiles from 'koa-static';
 import * as path from 'path';
 import {URL} from 'url';
-import {ThunkedRenderResultReadable} from '../../lib/render-result-readable.js';
+import {RenderResultReadable} from '../../lib/render-result-readable.js';
 import {renderAppWithInitialData} from './app-server.js';
 const {nodeResolve} = koaNodeResolve;
 
@@ -32,7 +32,7 @@ app.use(async (ctx: Koa.Context, next: Function) => {
 
   const ssrResult = renderAppWithInitialData();
   ctx.type = 'text/html';
-  ctx.body = new ThunkedRenderResultReadable(ssrResult);
+  ctx.body = new RenderResultReadable(ssrResult);
 });
 app.use(nodeResolve({root: monorepoRoot}));
 app.use(

--- a/packages/labs/ssr/src/demo/vm-modules/app-server.ts
+++ b/packages/labs/ssr/src/demo/vm-modules/app-server.ts
@@ -8,8 +8,8 @@
  * This is a server-only module that renders the HTML file shell.
  */
 
-import {render} from '../../lib/render.js';
-import {RenderResult} from '../../lib/render-result.js';
+import {renderThunked} from '../../lib/render.js';
+import {ThunkedRenderResult} from '../../lib/render-result.js';
 import {template, initialData} from './module.js';
 
 export function renderAppWithInitialData() {
@@ -21,7 +21,7 @@ export function renderAppWithInitialData() {
 // shell in unbalanced fragments. By yielding the HTML preamble immediately
 // with no lit-html template preparation or rendering needed, we minimize TTFB,
 // And can get the browser to start prefetch as soon as possible.
-export function renderApp(data: typeof initialData): RenderResult {
+export function renderApp(data: typeof initialData): ThunkedRenderResult {
   return [
     `
     <!doctype html>
@@ -44,7 +44,7 @@ export function renderApp(data: typeof initialData): RenderResult {
         <div>`,
 
     // Call the SSR render() function to render a client/server shared template.
-    () => render(template(data)),
+    () => renderThunked(template(data)),
 
     `
         </div>

--- a/packages/labs/ssr/src/demo/vm-modules/app-server.ts
+++ b/packages/labs/ssr/src/demo/vm-modules/app-server.ts
@@ -9,6 +9,7 @@
  */
 
 import {render} from '../../lib/render.js';
+import {RenderResult} from '../../lib/render-result.js';
 import {template, initialData} from './module.js';
 
 export function renderAppWithInitialData() {
@@ -20,8 +21,9 @@ export function renderAppWithInitialData() {
 // shell in unbalanced fragments. By yielding the HTML preamble immediately
 // with no lit-html template preparation or rendering needed, we minimize TTFB,
 // And can get the browser to start prefetch as soon as possible.
-export function* renderApp(data: typeof initialData) {
-  yield `
+export function renderApp(data: typeof initialData): RenderResult {
+  return [
+    `
     <!doctype html>
     <html>
       <head>
@@ -34,19 +36,20 @@ export function* renderApp(data: typeof initialData) {
           });
         </script>
         <script src="./node_modules/@webcomponents/template-shadowroot/template-shadowroot.min.js"></script>
-        `;
-  yield `
+        `,
+    `
       </head>
       <body>
         <button>Hydrate</button>
-        <div>`;
+        <div>`,
 
-  // Call the SSR render() function to render a client/server shared template.
-  yield* render(template(data));
+    // Call the SSR render() function to render a client/server shared template.
+    () => render(template(data)),
 
-  yield `
+    `
         </div>
         <script>TemplateShadowRoot.hydrateShadowRoots(document.body);</script>
       </body>
-</html>`;
+    </html>`,
+  ];
 }

--- a/packages/labs/ssr/src/lib/element-renderer.ts
+++ b/packages/labs/ssr/src/lib/element-renderer.ts
@@ -185,7 +185,8 @@ export abstract class ElementRenderer {
    * The default implementation serializes all attributes on the element
    * instance.
    */
-  *renderAttributes(): RenderResult {
+  renderAttributes(): RenderResult {
+    const result: RenderResult = [];
     if (this.element !== undefined) {
       const {attributes} = this.element;
       for (
@@ -194,12 +195,13 @@ export abstract class ElementRenderer {
         i++
       ) {
         if (value === '' || value === undefined || value === null) {
-          yield ` ${name}`;
+          result.push(` ${name}`);
         } else {
-          yield ` ${name}="${escapeHtml(value)}"`;
+          result.push(` ${name}="${escapeHtml(value)}"`);
         }
       }
     }
+    return result;
   }
 }
 
@@ -215,13 +217,15 @@ export class FallbackRenderer extends ElementRenderer {
     this._attributes[name.toLowerCase()] = value;
   }
 
-  override *renderAttributes(): RenderResult {
+  override renderAttributes(): RenderResult {
+    const result: RenderResult = [];
     for (const [name, value] of Object.entries(this._attributes)) {
       if (value === '' || value === undefined || value === null) {
-        yield ` ${name}`;
+        result.push(` ${name}`);
       } else {
-        yield ` ${name}="${escapeHtml(value)}"`;
+        result.push(` ${name}="${escapeHtml(value)}"`);
       }
     }
+    return result;
   }
 }

--- a/packages/labs/ssr/src/lib/element-renderer.ts
+++ b/packages/labs/ssr/src/lib/element-renderer.ts
@@ -8,7 +8,7 @@
 
 import {escapeHtml} from './util/escape-html.js';
 import type {RenderInfo} from './render-value.js';
-import type {RenderResult} from './render-result.js';
+import type {ThunkedRenderResult} from './render-result.js';
 
 type Interface<T> = {
   [P in keyof T]: T[P];
@@ -168,14 +168,14 @@ export abstract class ElementRenderer {
    * If `renderShadow()` returns undefined, no declarative shadow root is
    * emitted.
    */
-  renderShadow(_renderInfo: RenderInfo): RenderResult | undefined {
+  renderShadow(_renderInfo: RenderInfo): ThunkedRenderResult | undefined {
     return undefined;
   }
 
   /**
    * Render the element's light DOM children.
    */
-  renderLight(_renderInfo: RenderInfo): RenderResult | undefined {
+  renderLight(_renderInfo: RenderInfo): ThunkedRenderResult | undefined {
     return undefined;
   }
 
@@ -185,8 +185,8 @@ export abstract class ElementRenderer {
    * The default implementation serializes all attributes on the element
    * instance.
    */
-  renderAttributes(): RenderResult {
-    const result: RenderResult = [];
+  renderAttributes(): ThunkedRenderResult {
+    const result: ThunkedRenderResult = [];
     if (this.element !== undefined) {
       const {attributes} = this.element;
       for (
@@ -217,8 +217,8 @@ export class FallbackRenderer extends ElementRenderer {
     this._attributes[name.toLowerCase()] = value;
   }
 
-  override renderAttributes(): RenderResult {
-    const result: RenderResult = [];
+  override renderAttributes(): ThunkedRenderResult {
+    const result: ThunkedRenderResult = [];
     for (const [name, value] of Object.entries(this._attributes)) {
       if (value === '' || value === undefined || value === null) {
         result.push(` ${name}`);

--- a/packages/labs/ssr/src/lib/element-renderer.ts
+++ b/packages/labs/ssr/src/lib/element-renderer.ts
@@ -52,6 +52,16 @@ export type ShadowRootOptions = ShadowRootInit;
 
 /**
  * An object that renders elements of a certain type.
+ *
+ * The `render*()` methods return a ThunkedRenderResult, which is an array of
+ * strings and/or thunks that return strings or Promises for strings. This allows
+ * the renderer to emit content in chunks, and to perform async work (e.g.
+ * fetching data) as part of rendering. Renderers can assume that their
+ * thunks will be invoked in order, and that any Promises will be awaited before
+ * subsequent thunks are invoked.
+ *
+ * If a renderer does not need to emit content in chunks or perform async work,
+ * it can simply return an array of strings.
  */
 export abstract class ElementRenderer {
   // TODO (justinfagnani): We shouldn't assume that ElementRenderer subclasses

--- a/packages/labs/ssr/src/lib/lit-element-renderer.ts
+++ b/packages/labs/ssr/src/lib/lit-element-renderer.ts
@@ -13,7 +13,7 @@ import {
 } from '@lit-labs/ssr-dom-shim';
 import {renderValue} from './render-value.js';
 import type {RenderInfo} from './render-value.js';
-import type {RenderResult} from './render-result.js';
+import type {ThunkedRenderResult} from './render-result.js';
 
 export type Constructor<T> = {new (): T};
 
@@ -121,8 +121,8 @@ export class LitElementRenderer extends ElementRenderer {
     attributeToProperty(this.element as LitElement, name, value);
   }
 
-  override renderShadow(renderInfo: RenderInfo): RenderResult {
-    const result: RenderResult = [];
+  override renderShadow(renderInfo: RenderInfo): ThunkedRenderResult {
+    const result: ThunkedRenderResult = [];
     // Render styles.
     const styles = (this.element.constructor as typeof LitElement)
       .elementStyles;
@@ -139,7 +139,7 @@ export class LitElementRenderer extends ElementRenderer {
     return result;
   }
 
-  override renderLight(renderInfo: RenderInfo): RenderResult {
+  override renderLight(renderInfo: RenderInfo): ThunkedRenderResult {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const value = (this.element as any)?.renderLight();
     if (value) {

--- a/packages/labs/ssr/src/lib/lit-element-renderer.ts
+++ b/packages/labs/ssr/src/lib/lit-element-renderer.ts
@@ -121,29 +121,31 @@ export class LitElementRenderer extends ElementRenderer {
     attributeToProperty(this.element as LitElement, name, value);
   }
 
-  override *renderShadow(renderInfo: RenderInfo): RenderResult {
+  override renderShadow(renderInfo: RenderInfo): RenderResult {
+    const result: RenderResult = [];
     // Render styles.
     const styles = (this.element.constructor as typeof LitElement)
       .elementStyles;
     if (styles !== undefined && styles.length > 0) {
-      yield '<style>';
+      result.push('<style>');
       for (const style of styles) {
-        yield (style as CSSResult).cssText;
+        result.push((style as CSSResult).cssText);
       }
-      yield '</style>';
+      result.push('</style>');
     }
     // Render template
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    yield* renderValue((this.element as any).render(), renderInfo);
+    result.push(() => renderValue((this.element as any).render(), renderInfo));
+    return result;
   }
 
-  override *renderLight(renderInfo: RenderInfo): RenderResult {
+  override renderLight(renderInfo: RenderInfo): RenderResult {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const value = (this.element as any)?.renderLight();
     if (value) {
-      yield* renderValue(value, renderInfo);
+      return [() => renderValue(value, renderInfo)];
     } else {
-      yield '';
+      return [''];
     }
   }
 }

--- a/packages/labs/ssr/src/lib/render-lit-html.ts
+++ b/packages/labs/ssr/src/lib/render-lit-html.ts
@@ -6,7 +6,7 @@
 
 import {render as _render} from './render.js';
 import type {RenderInfo as _RenderInfo} from './render-value.js';
-import type {RenderResult as _RenderResult} from './render-result.js';
+import type {ThunkedRenderResult as _RenderResult} from './render-result.js';
 
 /**
  * @deprecated Ability to import from `@lit-labs/ssr/lib/render-lit-html.js`

--- a/packages/labs/ssr/src/lib/render-result-readable.ts
+++ b/packages/labs/ssr/src/lib/render-result-readable.ts
@@ -185,7 +185,10 @@ export class ThunkedRenderResultReadable extends Readable {
         this._waiting = true;
         const thunkResult = await value();
         let newIterator: ThunkedRenderResultIterator;
-        if (typeof thunkResult === 'string') {
+        if (thunkResult === undefined) {
+          // If the thunk returned undefined, create an empty iterator
+          newIterator = [][Symbol.iterator]() as ThunkedRenderResultIterator;
+        } else if (typeof thunkResult === 'string') {
           // If the thunk returned a string, create a single-item iterator
           newIterator = [thunkResult][
             Symbol.iterator

--- a/packages/labs/ssr/src/lib/render-result-readable.ts
+++ b/packages/labs/ssr/src/lib/render-result-readable.ts
@@ -8,14 +8,12 @@ import {Readable} from 'stream';
 import {RenderResult} from './render-result.js';
 import {ThunkedRenderResult, Thunk} from './render-result.js';
 
-type RenderResultIterator = Iterator<string | Promise<RenderResult>>;
+type RenderResultIterator = Iterator<string | Thunk | Promise<RenderResult>>;
 
 /**
  * A Readable that reads from a RenderResult.
  */
 export class RenderResultReadable extends Readable {
-  private _result: RenderResult;
-
   /**
    * A stack of open iterators.
    *
@@ -25,6 +23,7 @@ export class RenderResultReadable extends Readable {
    */
   private _iterators: Array<RenderResultIterator>;
   private _currentIterator?: RenderResultIterator;
+
   /**
    * `_waiting` flag is used to prevent multiple concurrent reads.
    *
@@ -35,10 +34,9 @@ export class RenderResultReadable extends Readable {
    */
   private _waiting = false;
 
-  constructor(result: RenderResult) {
+  constructor(result: RenderResult | ThunkedRenderResult) {
     super();
-    this._result = result;
-    this._iterators = [this._result[Symbol.iterator]()];
+    this._iterators = [result[Symbol.iterator]()];
   }
 
   override async _read(_size: number) {
@@ -78,129 +76,58 @@ export class RenderResultReadable extends Readable {
         continue;
       }
 
-      const value = next.value;
+      let value:
+        | string
+        | Thunk
+        | Promise<string | RenderResult | ThunkedRenderResult>
+        | RenderResult
+        | ReturnType<Thunk> = next.value;
 
-      if (typeof value === 'string') {
-        if (this.push(value) === false) {
-          // The consumer doesn't want any more values. Return for now and
-          // we may get a new call to _read()
-          return;
+      // This inner loop lets us repeatedly resolve thunks and Promises
+      // until we get to a string, array, or iterator.
+      while (value !== undefined) {
+        // Trampoline in case of nested thunks
+        while (typeof value === 'function') {
+          value = value();
         }
-      } else {
-        // Must be a Promise
-        this._iterators.push(this._currentIterator);
-        this._waiting = true;
-        this._currentIterator = (await value)[
-          Symbol.iterator
-        ]() as RenderResultIterator;
-        this._waiting = false;
-      }
-    }
-    // Pushing `null` ends the stream
-    this.push(null);
-  }
-}
 
-type ThunkedRenderResultIterator = Iterator<string | Thunk>;
-
-/**
- * A Readable that reads from a ThunkedRenderResult.
- */
-export class ThunkedRenderResultReadable extends Readable {
-  private _result: ThunkedRenderResult;
-
-  /**
-   * A stack of open iterators.
-   *
-   * We need to keep this as instance state because we can pause and resume
-   * reading values at any time and can't guarantee to run iterators to
-   * completion in any one loop.
-   */
-  private _iterators: Array<ThunkedRenderResultIterator>;
-  private _currentIterator?: ThunkedRenderResultIterator;
-  /**
-   * `_waiting` flag is used to prevent multiple concurrent reads.
-   *
-   * ThunkedRenderResultReadable handles async ThunkedRenderResult's, and must await them.
-   * While awaiting a result, it's possible for `_read` to be called again.
-   * Without this flag, a new read is initiated and the order of the data in the
-   * stream becomes inconsistent.
-   */
-  private _waiting = false;
-
-  constructor(result: ThunkedRenderResult) {
-    super();
-    this._result = result;
-    this._iterators = [this._result[Symbol.iterator]()];
-  }
-
-  override async _read(_size: number) {
-    if (this._waiting) {
-      return;
-    }
-    // This implementation reads values from the RenderResult and pushes them
-    // into the base class's Readable implementation. It tries to be as
-    // efficient as possible, which means:
-    //   1. Avoid microtasks and Promise allocations. Read and write values
-    //      synchronously when possible.
-    //   2. Write as many values to the Readable per call to _read() as
-    //      possible.
-    //
-    // To do this correctly we must adhere to the Readable contract for
-    // _read(), which states that:
-    //
-    // - The size parameter can be safely ignored
-    // - _read() should call `this.push()` as many times as it can until
-    //   `this.push()` returns false, which means the underlying Readable
-    //   does not want any more values.
-    // - `this.push(null)` ends the stream
-    //
-    // This means that we cannot use for/of loops to iterate on the render
-    // result, because we must be able to return in the middle of the loop
-    // and resume on the next call to _read().
-
-    // Get the current iterator, only if we don't already have one from the
-    // previous call to _read()
-    this._currentIterator ??= this._iterators.pop();
-
-    while (this._currentIterator !== undefined) {
-      const next = this._currentIterator.next();
-      if (next.done === true) {
-        // Restore the outer iterator
-        this._currentIterator = this._iterators.pop();
-        continue;
-      }
-
-      const value = next.value;
-
-      if (typeof value === 'string') {
-        if (this.push(value) === false) {
-          // The consumer doesn't want any more values. Return for now and
-          // we may get a new call to _read()
-          return;
+        if (value === undefined) {
+          // Just continue to the next value from the iterator
+          break;
         }
-      } else {
-        // Must be a thunk
-        this._iterators.push(this._currentIterator);
-        this._waiting = true;
-        const thunkResult = await value();
-        let newIterator: ThunkedRenderResultIterator;
-        if (thunkResult === undefined) {
-          // If the thunk returned undefined, create an empty iterator
-          newIterator = [][Symbol.iterator]() as ThunkedRenderResultIterator;
-        } else if (typeof thunkResult === 'string') {
-          // If the thunk returned a string, create a single-item iterator
-          newIterator = [thunkResult][
-            Symbol.iterator
-          ]() as ThunkedRenderResultIterator;
+
+        if (typeof value === 'string') {
+          if (this.push(value) === false) {
+            // Backpressure: The consumer doesn't want any more values. Return
+            // for now and we may get a new call to _read()
+            return;
+          }
+          break;
+        }
+
+        if (
+          Array.isArray(value) ||
+          typeof (value as unknown as RenderResult)[Symbol.iterator] ===
+            'function'
+        ) {
+          // If it's an array or iterable, iterate over it by pushing the
+          // current iterator on the stack and making the new one current. The
+          // next loop of the outer while() will call next() on it.
+          this._iterators.push(this._currentIterator);
+          this._currentIterator = (value as RenderResult)[Symbol.iterator]();
+          break;
         } else {
-          // If the thunk returned an array, iterate over it
-          newIterator = thunkResult[
-            Symbol.iterator
-          ]() as ThunkedRenderResultIterator;
+          // Must be a Promise. Await it can continue the inner loop to handle
+          // whatever it resolves to.
+          if (typeof (value as Promise<unknown>).then !== 'function') {
+            throw new Error(
+              `Unexpected value in RenderResult: ${value} (${typeof value})`
+            );
+          }
+          this._waiting = true;
+          value = await value;
+          this._waiting = false;
         }
-        this._currentIterator = newIterator;
-        this._waiting = false;
       }
     }
     // Pushing `null` ends the stream

--- a/packages/labs/ssr/src/lib/render-result-readable.ts
+++ b/packages/labs/ssr/src/lib/render-result-readable.ts
@@ -5,9 +5,10 @@
  */
 
 import {Readable} from 'stream';
-import {RenderResult, Thunk} from './render-result.js';
+import {RenderResult} from './render-result.js';
+import {ThunkedRenderResult, Thunk} from './render-result.js';
 
-type RenderResultIterator = Iterator<string | Thunk>;
+type RenderResultIterator = Iterator<string | Promise<RenderResult>>;
 
 /**
  * A Readable that reads from a RenderResult.
@@ -86,19 +87,114 @@ export class RenderResultReadable extends Readable {
           return;
         }
       } else {
+        // Must be a Promise
+        this._iterators.push(this._currentIterator);
+        this._waiting = true;
+        this._currentIterator = (await value)[
+          Symbol.iterator
+        ]() as RenderResultIterator;
+        this._waiting = false;
+      }
+    }
+    // Pushing `null` ends the stream
+    this.push(null);
+  }
+}
+
+type ThunkedRenderResultIterator = Iterator<string | Thunk>;
+
+/**
+ * A Readable that reads from a ThunkedRenderResult.
+ */
+export class ThunkedRenderResultReadable extends Readable {
+  private _result: ThunkedRenderResult;
+
+  /**
+   * A stack of open iterators.
+   *
+   * We need to keep this as instance state because we can pause and resume
+   * reading values at any time and can't guarantee to run iterators to
+   * completion in any one loop.
+   */
+  private _iterators: Array<ThunkedRenderResultIterator>;
+  private _currentIterator?: ThunkedRenderResultIterator;
+  /**
+   * `_waiting` flag is used to prevent multiple concurrent reads.
+   *
+   * ThunkedRenderResultReadable handles async ThunkedRenderResult's, and must await them.
+   * While awaiting a result, it's possible for `_read` to be called again.
+   * Without this flag, a new read is initiated and the order of the data in the
+   * stream becomes inconsistent.
+   */
+  private _waiting = false;
+
+  constructor(result: ThunkedRenderResult) {
+    super();
+    this._result = result;
+    this._iterators = [this._result[Symbol.iterator]()];
+  }
+
+  override async _read(_size: number) {
+    if (this._waiting) {
+      return;
+    }
+    // This implementation reads values from the RenderResult and pushes them
+    // into the base class's Readable implementation. It tries to be as
+    // efficient as possible, which means:
+    //   1. Avoid microtasks and Promise allocations. Read and write values
+    //      synchronously when possible.
+    //   2. Write as many values to the Readable per call to _read() as
+    //      possible.
+    //
+    // To do this correctly we must adhere to the Readable contract for
+    // _read(), which states that:
+    //
+    // - The size parameter can be safely ignored
+    // - _read() should call `this.push()` as many times as it can until
+    //   `this.push()` returns false, which means the underlying Readable
+    //   does not want any more values.
+    // - `this.push(null)` ends the stream
+    //
+    // This means that we cannot use for/of loops to iterate on the render
+    // result, because we must be able to return in the middle of the loop
+    // and resume on the next call to _read().
+
+    // Get the current iterator, only if we don't already have one from the
+    // previous call to _read()
+    this._currentIterator ??= this._iterators.pop();
+
+    while (this._currentIterator !== undefined) {
+      const next = this._currentIterator.next();
+      if (next.done === true) {
+        // Restore the outer iterator
+        this._currentIterator = this._iterators.pop();
+        continue;
+      }
+
+      const value = next.value;
+
+      if (typeof value === 'string') {
+        if (this.push(value) === false) {
+          // The consumer doesn't want any more values. Return for now and
+          // we may get a new call to _read()
+          return;
+        }
+      } else {
         // Must be a thunk
         this._iterators.push(this._currentIterator);
         this._waiting = true;
         const thunkResult = await value();
-        let newIterator: RenderResultIterator;
+        let newIterator: ThunkedRenderResultIterator;
         if (typeof thunkResult === 'string') {
           // If the thunk returned a string, create a single-item iterator
           newIterator = [thunkResult][
             Symbol.iterator
-          ]() as RenderResultIterator;
+          ]() as ThunkedRenderResultIterator;
         } else {
           // If the thunk returned an array, iterate over it
-          newIterator = thunkResult[Symbol.iterator]() as RenderResultIterator;
+          newIterator = thunkResult[
+            Symbol.iterator
+          ]() as ThunkedRenderResultIterator;
         }
         this._currentIterator = newIterator;
         this._waiting = false;

--- a/packages/labs/ssr/src/lib/render-result.ts
+++ b/packages/labs/ssr/src/lib/render-result.ts
@@ -5,6 +5,21 @@
  */
 
 /**
+ * A rendered value as an iterable of strings or Promises of a RenderResult.
+ *
+ * This type is a synchronous Iterable so that consumers do not have to await
+ * every value according to the JS asynchronous iterator protocol, which would
+ * cause additional overhead compared to a sync iterator.
+ *
+ * Consumers should check the type of each value emitted by the iterator, and
+ * if it is a Promise await it if possible, or throw an error.
+ *
+ * The utility functions {@link collectRenderResult} and
+ * {@link collectRenderResultSync} do this for you.
+ */
+export type RenderResult = Iterable<string | Promise<RenderResult>>;
+
+/**
  * A thunk is a function that when called returns either:
  * - A string
  * - An array of strings and/or thunks
@@ -12,8 +27,8 @@
  */
 export type Thunk = () =>
   | string
-  | RenderResult
-  | Promise<string | RenderResult>;
+  | ThunkedRenderResult
+  | Promise<string | ThunkedRenderResult>;
 
 /**
  * A rendered value as an array of strings or thunks.
@@ -25,12 +40,14 @@ export type Thunk = () =>
  * The utility functions {@link collectResult} and {@link collectResultSync}
  * handle the iteration and thunk calling for you.
  */
-export type RenderResult = Array<string | Thunk>;
+export type ThunkedRenderResult = Array<string | Thunk>;
 
 /**
  * Joins a RenderResult into a string
  */
-export const collectResult = async (result: RenderResult): Promise<string> => {
+export const collectResult = async (
+  result: ThunkedRenderResult
+): Promise<string> => {
   let value = '';
   for (const chunk of result) {
     if (typeof chunk === 'string') {
@@ -52,7 +69,7 @@ export const collectResult = async (result: RenderResult): Promise<string> => {
  *
  * This function throws if a thunk returns a Promise.
  */
-export const collectResultSync = (result: RenderResult): string => {
+export const collectResultSync = (result: ThunkedRenderResult): string => {
   let value = '';
   for (const chunk of result) {
     if (typeof chunk === 'string') {

--- a/packages/labs/ssr/src/lib/render-result.ts
+++ b/packages/labs/ssr/src/lib/render-result.ts
@@ -26,6 +26,7 @@ export type RenderResult = Iterable<string | Promise<RenderResult>>;
  * - A Promise of the above
  */
 export type Thunk = () =>
+  | void
   | string
   | ThunkedRenderResult
   | Promise<string | ThunkedRenderResult>;
@@ -52,6 +53,7 @@ export const collectResult = async (
   let str = '';
   for (const chunk of result) {
     let value:
+      | void
       | string
       | Promise<RenderResult | ThunkedRenderResult>
       | Thunk
@@ -65,7 +67,7 @@ export const collectResult = async (
       str += value;
     } else if (Array.isArray(value)) {
       str += await collectResult(value);
-    } else {
+    } else if (value !== undefined) {
       str += await collectResult(await value);
     }
   }
@@ -84,6 +86,7 @@ export const collectResultSync = (
   let str = '';
   for (const chunk of result) {
     let value:
+      | void
       | string
       | Promise<RenderResult | ThunkedRenderResult>
       | Thunk
@@ -97,7 +100,7 @@ export const collectResultSync = (
       str += value;
     } else if (Array.isArray(value)) {
       str += collectResultSync(value);
-    } else {
+    } else if (value !== undefined) {
       throw new Error(
         'Promises not supported in collectResultSync. ' +
           'Please use collectResult.'

--- a/packages/labs/ssr/src/lib/render-value.ts
+++ b/packages/labs/ssr/src/lib/render-value.ts
@@ -397,7 +397,7 @@ const getTemplateOpcodes = (result: TemplateResult) => {
    * previous opcode was not `text)
    */
   const flush = (value: string) => {
-    const op = getLast(ops);
+    const op = ops.at(-1);
     if (op !== undefined && op.type === 'text') {
       op.value += value;
     } else {
@@ -750,7 +750,7 @@ export function renderValue(
   if (isRenderLightDirective(value)) {
     // If a value was produced with renderLight(), we want to call and render
     // the renderLight() method.
-    const instance = getLast(renderInfo.customElementInstanceStack);
+    const instance = renderInfo.customElementInstanceStack.at(-1);
     if (instance !== undefined) {
       const renderLightResult = instance.renderLight(renderInfo);
       if (renderLightResult !== undefined) {
@@ -892,7 +892,7 @@ And the inner template was:
           // `nothing`
           if (committedValue !== noChange) {
             const instance = op.useCustomElementInstance
-              ? getLast(renderInfo.customElementInstanceStack)
+              ? renderInfo.customElementInstanceStack.at(-1)
               : undefined;
             if (part.type === PartType.PROPERTY) {
               attributeResult = renderPropertyPart(
@@ -949,15 +949,14 @@ And the inner template was:
             // Note that the event target parent is either the unnamed/named slot
             // in the parent event target if it exists or the parent event target
             // if no matching slot exists.
-            const eventTarget = getLast(
-              renderInfo.eventTargetStack
+            const eventTarget = renderInfo.eventTargetStack.at(
+              -1
             ) as HTMLElementWithEventMeta;
-            const slotName = getLast(renderInfo.slotStack);
+            const slotName = renderInfo.slotStack.at(-1);
             (instance.element as HTMLElementWithEventMeta).__eventTargetParent =
               elementSlotMap.get(eventTarget)?.get(slotName) ?? eventTarget;
-            (instance.element as HTMLElementWithEventMeta).__host = getLast(
-              renderInfo.customElementHostStack
-            )?.element;
+            (instance.element as HTMLElementWithEventMeta).__host =
+              renderInfo.customElementHostStack.at(-1)?.element;
             renderInfo.eventTargetStack.push(instance.element);
           }
           // Set static attributes to the element renderer
@@ -971,7 +970,7 @@ And the inner template was:
       }
       case 'custom-element-attributes': {
         renderResult.push(() => {
-          const instance = getLast(renderInfo.customElementInstanceStack);
+          const instance = renderInfo.customElementInstanceStack.at(-1);
           if (instance === undefined) {
             throw new Error(
               `Internal error: ${op.type} outside of custom element context`
@@ -1017,7 +1016,7 @@ And the inner template was:
       }
       case 'custom-element-shadow': {
         renderResult.push(() => {
-          const instance = getLast(renderInfo.customElementInstanceStack);
+          const instance = renderInfo.customElementInstanceStack.at(-1);
           if (instance === undefined) {
             throw new Error(
               `Internal error: ${op.type} outside of custom element context`
@@ -1058,7 +1057,7 @@ And the inner template was:
         break;
       case 'slot-element-open': {
         renderResult.push(() => {
-          const host = getLast(renderInfo.customElementHostStack);
+          const host = renderInfo.customElementHostStack.at(-1);
           if (host === undefined) {
             throw new Error(
               `Internal error: ${op.type} outside of custom element context`
@@ -1078,15 +1077,14 @@ And the inner template was:
               const element = new HTMLSlotElement() as HTMLSlotElement &
                 HTMLElementWithEventMeta;
               element.name = op.name ?? '';
-              const eventTarget = getLast(
-                renderInfo.eventTargetStack
+              const eventTarget = renderInfo.eventTargetStack.at(
+                -1
               ) as HTMLElementWithEventMeta;
-              const slotName = getLast(renderInfo.slotStack);
+              const slotName = renderInfo.slotStack.at(-1);
               element.__eventTargetParent =
                 elementSlotMap.get(eventTarget)?.get(slotName) ?? eventTarget;
-              element.__host = getLast(
-                renderInfo.customElementHostStack
-              )?.element;
+              element.__host =
+                renderInfo.customElementHostStack.at(-1)?.element;
               slots.set(op.name, element);
               renderInfo.eventTargetStack.push(element);
             }
@@ -1206,8 +1204,6 @@ function displayTemplateResult(
   }
   return result.strings.join('${...}');
 }
-
-const getLast = <T>(a: Array<T>) => a[a.length - 1];
 
 /**
  * Returns true if the given node is a <script> node that the browser will

--- a/packages/labs/ssr/src/lib/render-value.ts
+++ b/packages/labs/ssr/src/lib/render-value.ts
@@ -61,7 +61,7 @@ import {
 import {isRenderLightDirective} from '@lit-labs/ssr-client/directives/render-light.js';
 import {reflectedAttributeName} from './reflected-attributes.js';
 
-import type {RenderResult} from './render-result.js';
+import type {ThunkedRenderResult} from './render-result.js';
 import {isHydratable} from './server-template.js';
 import type {Part} from 'lit-html';
 
@@ -727,7 +727,7 @@ export function renderValue(
   value: unknown,
   renderInfo: RenderInfo,
   hydratable = true
-): RenderResult {
+): ThunkedRenderResult {
   if (renderInfo.customElementHostStack.length === 0) {
     // If the SSR root event target is not at the start of the event target
     // stack, we add it to the beginning of the array.
@@ -765,7 +765,7 @@ export function renderValue(
     );
   }
 
-  const result: RenderResult = [];
+  const result: ThunkedRenderResult = [];
 
   if (value != null && isTemplateResult(value)) {
     if (hydratable) {
@@ -809,7 +809,7 @@ export function renderValue(
 function renderTemplateResult(
   result: TemplateResult,
   renderInfo: RenderInfo
-): RenderResult {
+): ThunkedRenderResult {
   // In order to render a TemplateResult we have to handle and stream out
   // different parts of the result separately:
   //   - Literal sections of the template
@@ -830,7 +830,7 @@ function renderTemplateResult(
 
   /* The next value in result.values to render */
   let partIndex = 0;
-  const renderResult: RenderResult = [];
+  const renderResult: ThunkedRenderResult = [];
 
   for (const op of ops) {
     switch (op.type) {
@@ -885,7 +885,7 @@ And the inner template was:
               partIndex
             );
           }
-          let attributeResult: RenderResult = [];
+          let attributeResult: ThunkedRenderResult = [];
           // We don't emit anything on the server when value is `noChange` or
           // `nothing`
           if (committedValue !== noChange) {
@@ -1028,7 +1028,7 @@ And the inner template was:
           const shadowContents = instance.renderShadow(renderInfo);
           // Only emit a DSR if renderShadow() emitted something (returning
           // undefined allows effectively no-op rendering the element)
-          const shadowResult: RenderResult = [];
+          const shadowResult: ThunkedRenderResult = [];
           if (shadowContents !== undefined) {
             const {mode = 'open', delegatesFocus} =
               instance.shadowRootOptions ?? {};
@@ -1154,7 +1154,7 @@ function renderPropertyPart(
   instance: ElementRenderer | undefined,
   op: AttributePartOp,
   value: unknown
-): RenderResult {
+): ThunkedRenderResult {
   value = value === nothing ? undefined : value;
   // Property should be reflected to attribute
   const reflectedName = reflectedAttributeName(op.tagName, op.name);
@@ -1171,7 +1171,7 @@ function renderBooleanAttributePart(
   instance: ElementRenderer | undefined,
   op: AttributePartOp,
   value: unknown
-): RenderResult {
+): ThunkedRenderResult {
   if (value && value !== nothing) {
     if (instance !== undefined) {
       instance.setAttribute(op.name, '');
@@ -1186,7 +1186,7 @@ function renderAttributePart(
   instance: ElementRenderer | undefined,
   op: AttributePartOp,
   value: unknown
-): RenderResult {
+): ThunkedRenderResult {
   if (value !== nothing) {
     if (instance !== undefined) {
       instance.setAttribute(op.name, String(value ?? ''));

--- a/packages/labs/ssr/src/lib/render-value.ts
+++ b/packages/labs/ssr/src/lib/render-value.ts
@@ -885,7 +885,7 @@ And the inner template was:
               partIndex
             );
           }
-          let attributeResult: ThunkedRenderResult = [];
+          let attributeResult: string | undefined = undefined;
           // We don't emit anything on the server when value is `noChange` or
           // `nothing`
           if (committedValue !== noChange) {
@@ -1144,47 +1144,46 @@ function renderPropertyPart(
   instance: ElementRenderer | undefined,
   op: AttributePartOp,
   value: unknown
-): ThunkedRenderResult {
+): string | undefined {
   value = value === nothing ? undefined : value;
   // Property should be reflected to attribute
   const reflectedName = reflectedAttributeName(op.tagName, op.name);
   if (instance !== undefined) {
     instance.setProperty(op.name, value);
   }
-  if (reflectedName !== undefined) {
-    return [`${reflectedName}="${escapeHtml(String(value))}"`];
-  }
-  return [];
+  return reflectedName !== undefined
+    ? `${reflectedName}="${escapeHtml(String(value))}"`
+    : undefined;
 }
 
 function renderBooleanAttributePart(
   instance: ElementRenderer | undefined,
   op: AttributePartOp,
   value: unknown
-): ThunkedRenderResult {
+): string | undefined {
   if (value && value !== nothing) {
     if (instance !== undefined) {
       instance.setAttribute(op.name, '');
     } else {
-      return [`${op.name}`];
+      return op.name;
     }
   }
-  return [];
+  return undefined;
 }
 
 function renderAttributePart(
   instance: ElementRenderer | undefined,
   op: AttributePartOp,
   value: unknown
-): ThunkedRenderResult {
+): string | undefined {
   if (value !== nothing) {
     if (instance !== undefined) {
       instance.setAttribute(op.name, String(value ?? ''));
     } else {
-      return [`${op.name}="${escapeHtml(String(value ?? ''))}"`];
+      return `${op.name}="${escapeHtml(String(value ?? ''))}"`;
     }
   }
-  return [];
+  return undefined;
 }
 
 /**

--- a/packages/labs/ssr/src/lib/render-value.ts
+++ b/packages/labs/ssr/src/lib/render-value.ts
@@ -924,7 +924,6 @@ And the inner template was:
         // running them), but we still need to advance the part index
         renderResult.push(() => {
           partIndex++;
-          return '';
         });
         break;
       }
@@ -965,7 +964,6 @@ And the inner template was:
           }
           renderInfo.customElementInstanceStack.push(instance);
           renderInfo.customElementRendered?.(op.tagName);
-          return '';
         });
         break;
       }
@@ -1005,14 +1003,13 @@ And the inner template was:
           // since the hydration node walk will need to stop at this element
           // to hydrate it
           if (
-            op.boundAttributesCount > 0 ||
-            renderInfo.customElementHostStack.length > 0
+            (op.boundAttributesCount > 0 ||
+              renderInfo.customElementHostStack.length > 0) &&
+            hydratable
           ) {
-            if (hydratable) {
-              return `<!--lit-node ${op.nodeIndex}-->`;
-            }
+            return `<!--lit-node ${op.nodeIndex}-->`;
           }
-          return '';
+          return undefined;
         });
         break;
       }
@@ -1044,7 +1041,6 @@ And the inner template was:
             shadowResult.push('</template>');
             shadowResult.push(() => {
               renderInfo.customElementHostStack.pop();
-              return '';
             });
           }
           // renderInfo.customElementHostStack.pop();
@@ -1056,7 +1052,6 @@ And the inner template was:
         renderResult.push(() => {
           renderInfo.customElementInstanceStack.pop();
           renderInfo.eventTargetStack.pop();
-          return '';
         });
         break;
       case 'slot-element-open': {
@@ -1094,26 +1089,22 @@ And the inner template was:
               renderInfo.eventTargetStack.push(element);
             }
           }
-          return '';
         });
         break;
       }
       case 'slot-element-close':
         renderResult.push(() => {
           renderInfo.eventTargetStack.pop();
-          return '';
         });
         break;
       case 'slotted-element-open':
         renderResult.push(() => {
           renderInfo.slotStack.push(op.name);
-          return '';
         });
         break;
       case 'slotted-element-close':
         renderResult.push(() => {
           renderInfo.slotStack.pop();
-          return '';
         });
         break;
       default:
@@ -1125,7 +1116,6 @@ And the inner template was:
     if (partIndex !== result.values.length) {
       throwErrorForPartIndexMismatch(partIndex, result);
     }
-    return '';
   });
 
   return renderResult;

--- a/packages/labs/ssr/src/lib/render-value.ts
+++ b/packages/labs/ssr/src/lib/render-value.ts
@@ -796,7 +796,9 @@ export function renderValue(
         result.push(() => renderValue(item, renderInfo, hydratable));
       }
     } else {
-      result.push(escapeHtml(String(value)));
+      result.push(
+        escapeHtml(typeof value === 'string' ? value : String(value))
+      );
     }
     if (hydratable) {
       result.push(`<!--/lit-part-->`);
@@ -1152,7 +1154,7 @@ function renderPropertyPart(
     instance.setProperty(op.name, value);
   }
   return reflectedName !== undefined
-    ? `${reflectedName}="${escapeHtml(String(value))}"`
+    ? `${reflectedName}="${escapeHtml(typeof value === 'string' ? value : String(value))}"`
     : undefined;
 }
 
@@ -1177,10 +1179,16 @@ function renderAttributePart(
   value: unknown
 ): string | undefined {
   if (value !== nothing) {
+    value =
+      typeof value === 'string'
+        ? value
+        : value == null || value === noChange
+          ? ''
+          : String(value);
     if (instance !== undefined) {
-      instance.setAttribute(op.name, String(value ?? ''));
+      instance.setAttribute(op.name, value as string);
     } else {
-      return `${op.name}="${escapeHtml(String(value ?? ''))}"`;
+      return `${op.name}="${escapeHtml(value as string)}"`;
     }
   }
   return undefined;

--- a/packages/labs/ssr/src/lib/render-value.ts
+++ b/packages/labs/ssr/src/lib/render-value.ts
@@ -723,7 +723,7 @@ declare global {
   }
 }
 
-export function* renderValue(
+export function renderValue(
   value: unknown,
   renderInfo: RenderInfo,
   hydratable = true
@@ -754,7 +754,7 @@ export function* renderValue(
     if (instance !== undefined) {
       const renderLightResult = instance.renderLight(renderInfo);
       if (renderLightResult !== undefined) {
-        yield* renderLightResult;
+        return renderLightResult;
       }
     }
     value = null;
@@ -764,19 +764,24 @@ export function* renderValue(
       value
     );
   }
+
+  const result: RenderResult = [];
+
   if (value != null && isTemplateResult(value)) {
     if (hydratable) {
-      yield `<!--lit-part ${digestForTemplateResult(
-        value as TemplateResult
-      )}-->`;
+      result.push(
+        `<!--lit-part ${digestForTemplateResult(value as TemplateResult)}-->`
+      );
     }
-    yield* renderTemplateResult(value as TemplateResult, renderInfo);
+    result.push(() =>
+      renderTemplateResult(value as TemplateResult, renderInfo)
+    );
     if (hydratable) {
-      yield `<!--/lit-part-->`;
+      result.push(`<!--/lit-part-->`);
     }
   } else {
     if (hydratable) {
-      yield `<!--lit-part-->`;
+      result.push(`<!--lit-part-->`);
     }
     if (
       value === undefined ||
@@ -784,22 +789,24 @@ export function* renderValue(
       value === nothing ||
       value === noChange
     ) {
-      // yield nothing
+      // add nothing
     } else if (!isPrimitive(value) && isIterable(value)) {
       // Check that value is not a primitive, since strings are iterable
       for (const item of value) {
-        yield* renderValue(item, renderInfo, hydratable);
+        result.push(() => renderValue(item, renderInfo, hydratable));
       }
     } else {
-      yield escapeHtml(String(value));
+      result.push(escapeHtml(String(value)));
     }
     if (hydratable) {
-      yield `<!--/lit-part-->`;
+      result.push(`<!--/lit-part-->`);
     }
   }
+
+  return result;
 }
 
-function* renderTemplateResult(
+function renderTemplateResult(
   result: TemplateResult,
   renderInfo: RenderInfo
 ): RenderResult {
@@ -823,240 +830,305 @@ function* renderTemplateResult(
 
   /* The next value in result.values to render */
   let partIndex = 0;
+  const renderResult: RenderResult = [];
 
   for (const op of ops) {
     switch (op.type) {
       case 'text':
-        yield op.value;
+        renderResult.push(op.value);
         break;
       case 'child-part': {
-        const value = result.values[partIndex++];
-        let isValueHydratable = hydratable;
-        if (isTemplateResult(value)) {
-          isValueHydratable = isHydratable(value);
-          if (!isValueHydratable && hydratable) {
-            throw new Error(
-              `A server-only template can't be rendered inside an ordinary, hydratable template. A server-only template can only be rendered at the top level, or within other server-only templates. The outer template was:
+        renderResult.push(() => {
+          const value = result.values[partIndex++];
+          let isValueHydratable = hydratable;
+          if (isTemplateResult(value)) {
+            isValueHydratable = isHydratable(value);
+            if (!isValueHydratable && hydratable) {
+              throw new Error(
+                `A server-only template can't be rendered inside an ordinary, hydratable template. A server-only template can only be rendered at the top level, or within other server-only templates. The outer template was:
     ${displayTemplateResult(result)}
 
 And the inner template was:
     ${displayTemplateResult(value)}
               `
-            );
+              );
+            }
           }
-        }
-        yield* renderValue(value, renderInfo, isValueHydratable);
+          return renderValue(value, renderInfo, isValueHydratable);
+        });
         break;
       }
       case 'attribute-part': {
-        const statics = op.strings;
-        const part = new op.ctor(
-          // Passing only object with tagName for the element is fine since the
-          // directive only gets PartInfo without the node available in the
-          // constructor
-          {tagName: op.tagName} as HTMLElement,
-          op.name,
-          statics,
-          connectedDisconnectable(),
-          {}
-        );
-        const value =
-          part.strings === undefined ? result.values[partIndex] : result.values;
-        patchAnyDirectives(part, value, partIndex);
-        let committedValue: unknown = noChange;
-        // Values for EventParts are never emitted
-        if (!(part.type === PartType.EVENT)) {
-          committedValue = getAttributePartCommittedValue(
-            part,
-            value,
-            partIndex
+        renderResult.push(() => {
+          const statics = op.strings;
+          const part = new op.ctor(
+            // Passing only object with tagName for the element is fine since the
+            // directive only gets PartInfo without the node available in the
+            // constructor
+            {tagName: op.tagName} as HTMLElement,
+            op.name,
+            statics,
+            connectedDisconnectable(),
+            {}
           );
-        }
-        // We don't emit anything on the server when value is `noChange` or
-        // `nothing`
-        if (committedValue !== noChange) {
-          const instance = op.useCustomElementInstance
-            ? getLast(renderInfo.customElementInstanceStack)
-            : undefined;
-          if (part.type === PartType.PROPERTY) {
-            yield* renderPropertyPart(instance, op, committedValue);
-          } else if (part.type === PartType.BOOLEAN_ATTRIBUTE) {
-            // Boolean attribute binding
-            yield* renderBooleanAttributePart(instance, op, committedValue);
-          } else {
-            yield* renderAttributePart(instance, op, committedValue);
+          const value =
+            part.strings === undefined
+              ? result.values[partIndex]
+              : result.values;
+          patchAnyDirectives(part, value, partIndex);
+          let committedValue: unknown = noChange;
+          // Values for EventParts are never emitted
+          if (!(part.type === PartType.EVENT)) {
+            committedValue = getAttributePartCommittedValue(
+              part,
+              value,
+              partIndex
+            );
           }
-        }
-        partIndex += statics.length - 1;
+          let attributeResult: RenderResult = [];
+          // We don't emit anything on the server when value is `noChange` or
+          // `nothing`
+          if (committedValue !== noChange) {
+            const instance = op.useCustomElementInstance
+              ? getLast(renderInfo.customElementInstanceStack)
+              : undefined;
+            if (part.type === PartType.PROPERTY) {
+              attributeResult = renderPropertyPart(
+                instance,
+                op,
+                committedValue
+              );
+            } else if (part.type === PartType.BOOLEAN_ATTRIBUTE) {
+              // Boolean attribute binding
+              attributeResult = renderBooleanAttributePart(
+                instance,
+                op,
+                committedValue
+              );
+            } else {
+              attributeResult = renderAttributePart(
+                instance,
+                op,
+                committedValue
+              );
+            }
+          }
+          partIndex += statics.length - 1;
+          return attributeResult;
+        });
         break;
       }
       case 'element-part': {
         // We don't emit anything for element parts (since we only support
         // directives for now; since they can't render, we don't even bother
         // running them), but we still need to advance the part index
-        partIndex++;
+        renderResult.push(() => {
+          partIndex++;
+          return '';
+        });
         break;
       }
       case 'custom-element-open': {
-        // Instantiate the element and its renderer
-        const instance = getElementRenderer(
-          renderInfo,
-          op.tagName,
-          op.ctor,
-          op.staticAttributes
-        );
-        if (instance.element) {
-          // In the case the renderer has created an instance, we want to set
-          // the event target parent and the host of the element. Our
-          // EventTarget polyfill uses these values to calculate the
-          // composedPath of a dispatched event.
-          // Note that the event target parent is either the unnamed/named slot
-          // in the parent event target if it exists or the parent event target
-          // if no matching slot exists.
-          const eventTarget = getLast(
-            renderInfo.eventTargetStack
-          ) as HTMLElementWithEventMeta;
-          const slotName = getLast(renderInfo.slotStack);
-          (instance.element as HTMLElementWithEventMeta).__eventTargetParent =
-            elementSlotMap.get(eventTarget)?.get(slotName) ?? eventTarget;
-          (instance.element as HTMLElementWithEventMeta).__host = getLast(
-            renderInfo.customElementHostStack
-          )?.element;
-          renderInfo.eventTargetStack.push(instance.element);
-        }
-        // Set static attributes to the element renderer
-        for (const [name, value] of op.staticAttributes) {
-          instance.setAttribute(name, value);
-        }
-        renderInfo.customElementInstanceStack.push(instance);
-        renderInfo.customElementRendered?.(op.tagName);
-        break;
-      }
-      case 'custom-element-attributes': {
-        const instance = getLast(renderInfo.customElementInstanceStack);
-        if (instance === undefined) {
-          throw new Error(
-            `Internal error: ${op.type} outside of custom element context`
+        // Even though we don't emit anything for the custom element open, we
+        // need to return a thunk function so that we mutate the renderInfo
+        // state at the right time during the render.
+        renderResult.push(() => {
+          // Instantiate the element and its renderer
+          const instance = getElementRenderer(
+            renderInfo,
+            op.tagName,
+            op.ctor,
+            op.staticAttributes
           );
-        }
-        // Perform any connect-time work via the renderer (e.g. reflecting any
-        // properties to attributes, for example)
-        if (instance.connectedCallback) {
-          instance.connectedCallback();
-        }
-        // Render out any attributes on the instance (both static and those
-        // that may have been dynamically set by the renderer)
-        yield* instance.renderAttributes();
-        // If deferHydration flag is true or if this element is nested in
-        // another, add the `defer-hydration` attribute, so that it does not
-        // enable before the host element hydrates
-        if (
-          renderInfo.deferHydration ||
-          renderInfo.customElementHostStack.length > 0
-        ) {
-          yield ' defer-hydration';
-        }
-        break;
-      }
-      case 'possible-node-marker': {
-        // Add a node marker if this element had attribute bindings or if it
-        // was nested in another and we rendered the `defer-hydration` attribute
-        // since the hydration node walk will need to stop at this element
-        // to hydrate it
-        if (
-          op.boundAttributesCount > 0 ||
-          renderInfo.customElementHostStack.length > 0
-        ) {
-          if (hydratable) {
-            yield `<!--lit-node ${op.nodeIndex}-->`;
-          }
-        }
-        break;
-      }
-      case 'custom-element-shadow': {
-        const instance = getLast(renderInfo.customElementInstanceStack);
-        if (instance === undefined) {
-          throw new Error(
-            `Internal error: ${op.type} outside of custom element context`
-          );
-        }
-        renderInfo.customElementHostStack.push(instance);
-        const shadowContents = instance.renderShadow(renderInfo);
-        // Only emit a DSR if renderShadow() emitted something (returning
-        // undefined allows effectively no-op rendering the element)
-        if (shadowContents !== undefined) {
-          const {mode = 'open', delegatesFocus} =
-            instance.shadowRootOptions ?? {};
-          // `delegatesFocus` is intentionally allowed to coerce to boolean to
-          // match web platform behavior.
-          const delegatesfocusAttr = delegatesFocus
-            ? ' shadowrootdelegatesfocus'
-            : '';
-          yield `<template shadowroot="${mode}" shadowrootmode="${mode}"${delegatesfocusAttr}>`;
-          yield* shadowContents;
-          yield '</template>';
-        }
-        renderInfo.customElementHostStack.pop();
-        break;
-      }
-      case 'custom-element-close':
-        renderInfo.customElementInstanceStack.pop();
-        renderInfo.eventTargetStack.pop();
-        break;
-      case 'slot-element-open': {
-        const host = getLast(renderInfo.customElementHostStack);
-        if (host === undefined) {
-          throw new Error(
-            `Internal error: ${op.type} outside of custom element context`
-          );
-        } else if (host.element) {
-          // We need to track which element has which slots. This is necessary
-          // to calculate the correct event path by connecting children of the
-          // host element to the corresponding slot.
-          let slots = elementSlotMap.get(host.element);
-          if (slots === undefined) {
-            slots = new Map();
-            elementSlotMap.set(host.element, slots);
-          }
-          // op.name is either the slot name or undefined, which represents
-          // the unnamed slot case.
-          if (!slots.has(op.name)) {
-            const element = new HTMLSlotElement() as HTMLSlotElement &
-              HTMLElementWithEventMeta;
-            element.name = op.name ?? '';
+          if (instance.element) {
+            // In the case the renderer has created an instance, we want to set
+            // the event target parent and the host of the element. Our
+            // EventTarget polyfill uses these values to calculate the
+            // composedPath of a dispatched event.
+            // Note that the event target parent is either the unnamed/named slot
+            // in the parent event target if it exists or the parent event target
+            // if no matching slot exists.
             const eventTarget = getLast(
               renderInfo.eventTargetStack
             ) as HTMLElementWithEventMeta;
             const slotName = getLast(renderInfo.slotStack);
-            element.__eventTargetParent =
+            (instance.element as HTMLElementWithEventMeta).__eventTargetParent =
               elementSlotMap.get(eventTarget)?.get(slotName) ?? eventTarget;
-            element.__host = getLast(
+            (instance.element as HTMLElementWithEventMeta).__host = getLast(
               renderInfo.customElementHostStack
             )?.element;
-            slots.set(op.name, element);
-            renderInfo.eventTargetStack.push(element);
+            renderInfo.eventTargetStack.push(instance.element);
           }
-        }
-
+          // Set static attributes to the element renderer
+          for (const [name, value] of op.staticAttributes) {
+            instance.setAttribute(name, value);
+          }
+          renderInfo.customElementInstanceStack.push(instance);
+          renderInfo.customElementRendered?.(op.tagName);
+          return '';
+        });
+        break;
+      }
+      case 'custom-element-attributes': {
+        renderResult.push(() => {
+          const instance = getLast(renderInfo.customElementInstanceStack);
+          if (instance === undefined) {
+            throw new Error(
+              `Internal error: ${op.type} outside of custom element context`
+            );
+          }
+          // Perform any connect-time work via the renderer (e.g. reflecting any
+          // properties to attributes, for example)
+          if (instance.connectedCallback) {
+            instance.connectedCallback();
+          }
+          // Render out any attributes on the instance (both static and those
+          // that may have been dynamically set by the renderer)
+          const result = instance.renderAttributes();
+          // If deferHydration flag is true or if this element is nested in
+          // another, add the `defer-hydration` attribute, so that it does not
+          // enable before the host element hydrates
+          if (
+            renderInfo.deferHydration ||
+            renderInfo.customElementHostStack.length > 0
+          ) {
+            result.push(' defer-hydration');
+          }
+          return result;
+        });
+        break;
+      }
+      case 'possible-node-marker': {
+        renderResult.push(() => {
+          // Add a node marker if this element had attribute bindings or if it
+          // was nested in another and we rendered the `defer-hydration` attribute
+          // since the hydration node walk will need to stop at this element
+          // to hydrate it
+          if (
+            op.boundAttributesCount > 0 ||
+            renderInfo.customElementHostStack.length > 0
+          ) {
+            if (hydratable) {
+              return `<!--lit-node ${op.nodeIndex}-->`;
+            }
+          }
+          return '';
+        });
+        break;
+      }
+      case 'custom-element-shadow': {
+        renderResult.push(() => {
+          const instance = getLast(renderInfo.customElementInstanceStack);
+          if (instance === undefined) {
+            throw new Error(
+              `Internal error: ${op.type} outside of custom element context`
+            );
+          }
+          renderInfo.customElementHostStack.push(instance);
+          const shadowContents = instance.renderShadow(renderInfo);
+          // Only emit a DSR if renderShadow() emitted something (returning
+          // undefined allows effectively no-op rendering the element)
+          const shadowResult: RenderResult = [];
+          if (shadowContents !== undefined) {
+            const {mode = 'open', delegatesFocus} =
+              instance.shadowRootOptions ?? {};
+            // `delegatesFocus` is intentionally allowed to coerce to boolean to
+            // match web platform behavior.
+            const delegatesfocusAttr = delegatesFocus
+              ? ' shadowrootdelegatesfocus'
+              : '';
+            shadowResult.push(
+              `<template shadowroot="${mode}" shadowrootmode="${mode}"${delegatesfocusAttr}>`
+            );
+            shadowResult.push(() => shadowContents);
+            shadowResult.push('</template>');
+            shadowResult.push(() => {
+              renderInfo.customElementHostStack.pop();
+              return '';
+            });
+          }
+          // renderInfo.customElementHostStack.pop();
+          return shadowResult;
+        });
+        break;
+      }
+      case 'custom-element-close':
+        renderResult.push(() => {
+          renderInfo.customElementInstanceStack.pop();
+          renderInfo.eventTargetStack.pop();
+          return '';
+        });
+        break;
+      case 'slot-element-open': {
+        renderResult.push(() => {
+          const host = getLast(renderInfo.customElementHostStack);
+          if (host === undefined) {
+            throw new Error(
+              `Internal error: ${op.type} outside of custom element context`
+            );
+          } else if (host.element) {
+            // We need to track which element has which slots. This is necessary
+            // to calculate the correct event path by connecting children of the
+            // host element to the corresponding slot.
+            let slots = elementSlotMap.get(host.element);
+            if (slots === undefined) {
+              slots = new Map();
+              elementSlotMap.set(host.element, slots);
+            }
+            // op.name is either the slot name or undefined, which represents
+            // the unnamed slot case.
+            if (!slots.has(op.name)) {
+              const element = new HTMLSlotElement() as HTMLSlotElement &
+                HTMLElementWithEventMeta;
+              element.name = op.name ?? '';
+              const eventTarget = getLast(
+                renderInfo.eventTargetStack
+              ) as HTMLElementWithEventMeta;
+              const slotName = getLast(renderInfo.slotStack);
+              element.__eventTargetParent =
+                elementSlotMap.get(eventTarget)?.get(slotName) ?? eventTarget;
+              element.__host = getLast(
+                renderInfo.customElementHostStack
+              )?.element;
+              slots.set(op.name, element);
+              renderInfo.eventTargetStack.push(element);
+            }
+          }
+          return '';
+        });
         break;
       }
       case 'slot-element-close':
-        renderInfo.eventTargetStack.pop();
+        renderResult.push(() => {
+          renderInfo.eventTargetStack.pop();
+          return '';
+        });
         break;
       case 'slotted-element-open':
-        renderInfo.slotStack.push(op.name);
+        renderResult.push(() => {
+          renderInfo.slotStack.push(op.name);
+          return '';
+        });
         break;
       case 'slotted-element-close':
-        renderInfo.slotStack.pop();
+        renderResult.push(() => {
+          renderInfo.slotStack.pop();
+          return '';
+        });
         break;
       default:
         throw new Error('internal error');
     }
   }
 
-  if (partIndex !== result.values.length) {
-    throwErrorForPartIndexMismatch(partIndex, result);
-  }
+  renderResult.push(() => {
+    if (partIndex !== result.values.length) {
+      throwErrorForPartIndexMismatch(partIndex, result);
+    }
+    return '';
+  });
+
+  return renderResult;
 }
 
 function throwErrorForPartIndexMismatch(
@@ -1078,11 +1150,11 @@ function throwErrorForPartIndexMismatch(
   throw new Error(errorMsg);
 }
 
-function* renderPropertyPart(
+function renderPropertyPart(
   instance: ElementRenderer | undefined,
   op: AttributePartOp,
   value: unknown
-) {
+): RenderResult {
   value = value === nothing ? undefined : value;
   // Property should be reflected to attribute
   const reflectedName = reflectedAttributeName(op.tagName, op.name);
@@ -1090,36 +1162,39 @@ function* renderPropertyPart(
     instance.setProperty(op.name, value);
   }
   if (reflectedName !== undefined) {
-    yield `${reflectedName}="${escapeHtml(String(value))}"`;
+    return [`${reflectedName}="${escapeHtml(String(value))}"`];
   }
+  return [];
 }
 
-function* renderBooleanAttributePart(
+function renderBooleanAttributePart(
   instance: ElementRenderer | undefined,
   op: AttributePartOp,
   value: unknown
-) {
+): RenderResult {
   if (value && value !== nothing) {
     if (instance !== undefined) {
       instance.setAttribute(op.name, '');
     } else {
-      yield op.name;
+      return [`${op.name}`];
     }
   }
+  return [];
 }
 
-function* renderAttributePart(
+function renderAttributePart(
   instance: ElementRenderer | undefined,
   op: AttributePartOp,
   value: unknown
-) {
+): RenderResult {
   if (value !== nothing) {
     if (instance !== undefined) {
       instance.setAttribute(op.name, String(value ?? ''));
     } else {
-      yield `${op.name}="${escapeHtml(String(value ?? ''))}"`;
+      return [`${op.name}="${escapeHtml(String(value ?? ''))}"`];
     }
   }
+  return [];
 }
 
 /**

--- a/packages/labs/ssr/src/lib/render-value.ts
+++ b/packages/labs/ssr/src/lib/render-value.ts
@@ -888,8 +888,7 @@ And the inner template was:
             );
           }
           let attributeResult: string | undefined = undefined;
-          // We don't emit anything on the server when value is `noChange` or
-          // `nothing`
+          // We don't emit anything on the server when value is `noChange`
           if (committedValue !== noChange) {
             const instance = op.useCustomElementInstance
               ? renderInfo.customElementInstanceStack.at(-1)
@@ -978,12 +977,11 @@ And the inner template was:
           }
           // Perform any connect-time work via the renderer (e.g. reflecting any
           // properties to attributes, for example)
-          if (instance.connectedCallback) {
-            instance.connectedCallback();
-          }
+          instance?.connectedCallback();
+
           // Render out any attributes on the instance (both static and those
           // that may have been dynamically set by the renderer)
-          const result = instance.renderAttributes();
+          let result = instance.renderAttributes();
           // If deferHydration flag is true or if this element is nested in
           // another, add the `defer-hydration` attribute, so that it does not
           // enable before the host element hydrates
@@ -991,7 +989,7 @@ And the inner template was:
             renderInfo.deferHydration ||
             renderInfo.customElementHostStack.length > 0
           ) {
-            result.push(' defer-hydration');
+            result = result.concat(' defer-hydration');
           }
           return result;
         });
@@ -1044,7 +1042,6 @@ And the inner template was:
               renderInfo.customElementHostStack.pop();
             });
           }
-          // renderInfo.customElementHostStack.pop();
           return shadowResult;
         });
         break;

--- a/packages/labs/ssr/src/lib/render.ts
+++ b/packages/labs/ssr/src/lib/render.ts
@@ -21,6 +21,10 @@ export type {RenderInfo} from './render-value.js';
 /**
  * Renders a lit-html renderable, usually a template result, to an iterable.
  *
+ * When consuming the result, Promises *must* be awaited before retrieving
+ * subsequent values. If Promises are not awaited, or not awaited in the correct
+ * order, the output will be incorrect.
+ *
  * @param value Value to render
  * @param renderInfo Optional render context object that should be passed to any
  *   reentrant calls to `render`, e.g. from a `renderShadow` callback on an
@@ -39,6 +43,10 @@ export function render(
  * ElementRenderer is found.
  *
  * This method is suitable for streaming the contents of the element.
+ *
+ * When consuming the result, thunks *must* be called in order to obtain their
+ * values. If thunks are not called, or not called in the correct order, the
+ * output will be incorrect.
  *
  * @param value Value to render
  * @param renderInfo Optional render context object that should be passed to any
@@ -70,7 +78,9 @@ type InternalRenderResultIterator = Iterator<string | Thunk>;
 /**
  * Wraps a ThunkedRenderResult to implement a RenderResult.
  */
-class RenderResultIterator implements Iterator<string | Promise<RenderResult>> {
+export class RenderResultIterator
+  implements Iterator<string | Promise<RenderResult>>
+{
   /**
    * A stack of open iterators.
    *

--- a/packages/labs/ssr/src/lib/render.ts
+++ b/packages/labs/ssr/src/lib/render.ts
@@ -4,32 +4,51 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {LitElementRenderer} from './lit-element-renderer.js';
-import {renderValue} from './render-value.js';
-
-import type {RenderInfo} from './render-value.js';
-export type {RenderInfo} from './render-value.js';
-import type {RenderResult} from './render-result.js';
 import {isTemplateResult} from 'lit-html/directive-helpers.js';
+import {LitElementRenderer} from './lit-element-renderer.js';
+import type {
+  ThunkedRenderResult,
+  RenderResult,
+  Thunk,
+} from './render-result.js';
+import type {RenderInfo} from './render-value.js';
+import {renderValue} from './render-value.js';
 import {isHydratable} from './server-template.js';
+
 export type {RenderResult} from './render-result.js';
+export type {RenderInfo} from './render-value.js';
 
 /**
- * Renders a lit-html template (or any renderable lit-html value) to a thunk array.
- * Any custom elements encountered will be rendered if a matching
- * ElementRenderer is found.
- *
- * This method is suitable for streaming the contents of the element.
+ * Renders a lit-html renderable, usually a template result, to an iterable.
  *
  * @param value Value to render
- * @param renderInfo Optional render context object that should be passed
- *   to any reentrant calls to `render`, e.g. from a `renderShadow` callback
- *   on an ElementRenderer.
+ * @param renderInfo Optional render context object that should be passed to any
+ *   reentrant calls to `render`, e.g. from a `renderShadow` callback on an
+ *   ElementRenderer.
  */
 export function render(
   value: unknown,
   renderInfo?: Partial<RenderInfo>
 ): RenderResult {
+  return new RenderResultIterator(renderThunked(value, renderInfo));
+}
+
+/**
+ * Renders a lit-html template (or any renderable lit-html value) to a thunk
+ * array. Any custom elements encountered will be rendered if a matching
+ * ElementRenderer is found.
+ *
+ * This method is suitable for streaming the contents of the element.
+ *
+ * @param value Value to render
+ * @param renderInfo Optional render context object that should be passed to any
+ *   reentrant calls to `render`, e.g. from a `renderShadow` callback on an
+ *   ElementRenderer.
+ */
+export function renderThunked(
+  value: unknown,
+  renderInfo?: Partial<RenderInfo>
+): ThunkedRenderResult {
   const defaultRenderInfo = {
     elementRenderers: [LitElementRenderer],
     customElementInstanceStack: [],
@@ -44,4 +63,88 @@ export function render(
     hydratable = isHydratable(value);
   }
   return renderValue(value, renderInfo as RenderInfo, hydratable);
+}
+
+type InternalRenderResultIterator = Iterator<string | Thunk>;
+
+/**
+ * Wraps a ThunkedRenderResult to implement a RenderResult.
+ */
+class RenderResultIterator implements Iterator<string | Promise<RenderResult>> {
+  /**
+   * A stack of open iterators.
+   *
+   * As the ThunkedRenderResult thunks are called, they may yield new arrays of
+   * strings and/or thunks. We push the iterators for these arrays onto the
+   * stack and consume them depth-first.
+   */
+  private _iterators: Array<InternalRenderResultIterator>;
+  private _waiting = false;
+
+  constructor(result: ThunkedRenderResult) {
+    this._iterators = [result[Symbol.iterator]()];
+  }
+
+  next(): IteratorResult<string | Promise<RenderResult>, unknown> {
+    if (this._waiting) {
+      throw new Error(
+        'Cannot call next() while waiting for a Promise to resolve'
+      );
+    }
+    const iterator = this._iterators.at(-1);
+    if (iterator === undefined) {
+      return {done: true, value: undefined};
+    }
+
+    // Get the next value from the current iterator
+    const result = iterator.next();
+    if (result.done) {
+      this._iterators.pop();
+      return this.next();
+    }
+    let value: string | Thunk | ReturnType<Thunk> = result.value;
+
+    // If the value is a string, return the result as-is:
+    if (typeof value === 'string') {
+      return result as IteratorResult<string, unknown>;
+    }
+
+    // Otherwise, it's a thunk. Trampoline to fully evaluate thunks:
+    while (typeof value === 'function') {
+      value = value();
+    }
+
+    // If the value is a string, return a new iterator result:
+    if (typeof value === 'string') {
+      return {done: false, value};
+    }
+
+    // If the value is an array, push a new iterator for it onto the stack, and
+    // recurse to start consuming it:
+    if (Array.isArray(value)) {
+      this._iterators.push(value[Symbol.iterator]());
+      return this.next();
+    }
+
+    // The value is a Promise. Convert to a Promise<RenderResult>:
+    this._waiting = true;
+    return {
+      done: false,
+      value: value.then((r) => {
+        if (typeof r === 'string') {
+          return r;
+        }
+        // Instead of returning a new iterator, flatten the array into our
+        // iterator stack:
+        this._iterators.push(r[Symbol.iterator]());
+        this._waiting = false;
+        return this;
+      }),
+    };
+  }
+
+  // Make the iterator itself iterable
+  [Symbol.iterator](): Iterator<string | Promise<RenderResult>> {
+    return this;
+  }
 }

--- a/packages/labs/ssr/src/lib/render.ts
+++ b/packages/labs/ssr/src/lib/render.ts
@@ -124,6 +124,11 @@ export class RenderResultIterator
       value = value();
     }
 
+    // If the value is undefined, return the next value:
+    if (value === undefined) {
+      return this.next();
+    }
+
     // If the value is a string, return a new iterator result:
     if (typeof value === 'string') {
       return {done: false, value};

--- a/packages/labs/ssr/src/lib/render.ts
+++ b/packages/labs/ssr/src/lib/render.ts
@@ -15,8 +15,8 @@ import {isHydratable} from './server-template.js';
 export type {RenderResult} from './render-result.js';
 
 /**
- * Renders a lit-html template (or any renderable lit-html value) to a string
- * iterator. Any custom elements encountered will be rendered if a matching
+ * Renders a lit-html template (or any renderable lit-html value) to a thunk array.
+ * Any custom elements encountered will be rendered if a matching
  * ElementRenderer is found.
  *
  * This method is suitable for streaming the contents of the element.
@@ -26,7 +26,7 @@ export type {RenderResult} from './render-result.js';
  *   to any reentrant calls to `render`, e.g. from a `renderShadow` callback
  *   on an ElementRenderer.
  */
-export function* render(
+export function render(
   value: unknown,
   renderInfo?: Partial<RenderInfo>
 ): RenderResult {
@@ -43,5 +43,5 @@ export function* render(
   if (isTemplateResult(value)) {
     hydratable = isHydratable(value);
   }
-  yield* renderValue(value, renderInfo as RenderInfo, hydratable);
+  return renderValue(value, renderInfo as RenderInfo, hydratable);
 }

--- a/packages/labs/ssr/src/lib/util/escape-html.ts
+++ b/packages/labs/ssr/src/lib/util/escape-html.ts
@@ -14,12 +14,11 @@ const replacements = {
   "'": '&#39;',
 };
 
+const replacer = (char: string) =>
+  replacements[char as keyof typeof replacements];
+
 /**
  * Replaces characters which have special meaning in HTML (&<>"') with escaped
  * HTML entities ("&amp;", "&lt;", etc.).
  */
-export const escapeHtml = (str: string) =>
-  str.replace(
-    /[&<>"']/g,
-    (char) => replacements[char as keyof typeof replacements]
-  );
+export const escapeHtml = (str: string) => str.replace(/[&<>"']/g, replacer);

--- a/packages/labs/ssr/src/test/integration/server/server.ts
+++ b/packages/labs/ssr/src/test/integration/server/server.ts
@@ -6,11 +6,9 @@
 
 import Router from '@koa/router';
 import cors from 'koa-cors';
-
-import {ModuleLoader} from '../../../lib/module-loader.js';
 import {getWindow} from '../../../lib/dom-shim.js';
-import {Readable} from 'stream';
-
+import {ModuleLoader} from '../../../lib/module-loader.js';
+import {RenderResultReadable} from '../../../lib/render-result-readable.js';
 import * as testModule from '../tests/basic-ssr.js';
 import {SSRTest} from '../tests/ssr-test.js';
 
@@ -32,8 +30,8 @@ export const ssrMiddleware = () => {
   router.get('/render/:mode/:testFile/:testName', async (context) => {
     const {mode, testFile, testName} = context.params;
 
-    let module: typeof testModule,
-      render: typeof import('../../../lib/render-lit-html.js').render;
+    let module: typeof testModule;
+    let render: typeof import('../../../lib/render.js').render;
     switch (mode) {
       case 'vm': {
         const loader = new ModuleLoader();
@@ -61,7 +59,7 @@ export const ssrMiddleware = () => {
         break;
       }
       case 'global': {
-        render = (await import('../../../lib/render-lit-html.js')).render;
+        render = (await import('../../../lib/render.js')).render;
         module = await import(`../tests/${testFile}-ssr.js`);
         break;
       }
@@ -104,7 +102,7 @@ export const ssrMiddleware = () => {
       test.serverRenderOptions
     );
     context.type = 'text/html';
-    context.body = Readable.from(result);
+    context.body = new RenderResultReadable(result);
   });
   return [cors(), router.routes(), router.allowedMethods()];
 };

--- a/packages/labs/ssr/src/test/integration/tests/basic-ssr.ts
+++ b/packages/labs/ssr/src/test/integration/tests/basic-ssr.ts
@@ -14,5 +14,5 @@
  * instanceof for certain value types. We might be able to change render()
  * and/or how it's loaded to not need this module.
  */
-export {render} from '../../../lib/render-lit-html.js';
+export {render} from '../../../lib/render.js';
 export * from './basic.js';

--- a/packages/labs/ssr/src/test/lib/render-lit_test.ts
+++ b/packages/labs/ssr/src/test/lib/render-lit_test.ts
@@ -425,7 +425,6 @@ for (const global of [emptyVmGlobal, shimmedVmGlobal]) {
     );
   });
 
-  // eslint-disable-next-line no-only-tests/no-only-tests
   test('element with reflected properties', async () => {
     const {render, elementWithReflectedProperties} = await setup();
     const result = await render(elementWithReflectedProperties);

--- a/packages/labs/ssr/src/test/lib/render-lit_test.ts
+++ b/packages/labs/ssr/src/test/lib/render-lit_test.ts
@@ -425,6 +425,7 @@ for (const global of [emptyVmGlobal, shimmedVmGlobal]) {
     );
   });
 
+  // eslint-disable-next-line no-only-tests/no-only-tests
   test('element with reflected properties', async () => {
     const {render, elementWithReflectedProperties} = await setup();
     const result = await render(elementWithReflectedProperties);

--- a/packages/labs/ssr/src/test/lib/render-result-iterator_test.ts
+++ b/packages/labs/ssr/src/test/lib/render-result-iterator_test.ts
@@ -1,0 +1,385 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {test} from 'uvu';
+// eslint-disable-next-line import/extensions
+import * as assert from 'uvu/assert';
+import {RenderResultIterator} from '../../lib/render.js';
+import type {ThunkedRenderResult, Thunk} from '../../lib/render-result.js';
+
+//
+// RenderResultIterator basic functionality
+//
+
+test('RenderResultIterator iterates strings', () => {
+  const thunked: ThunkedRenderResult = ['a', 'b', 'c'];
+  const iterator = new RenderResultIterator(thunked);
+
+  const result1 = iterator.next();
+  assert.equal(result1.done, false);
+  assert.equal(result1.value, 'a');
+
+  const result2 = iterator.next();
+  assert.equal(result2.done, false);
+  assert.equal(result2.value, 'b');
+
+  const result3 = iterator.next();
+  assert.equal(result3.done, false);
+  assert.equal(result3.value, 'c');
+
+  const result4 = iterator.next();
+  assert.equal(result4.done, true);
+  assert.equal(result4.value, undefined);
+});
+
+test('RenderResultIterator handles empty array', () => {
+  const thunked: ThunkedRenderResult = [];
+  const iterator = new RenderResultIterator(thunked);
+
+  const result = iterator.next();
+  assert.equal(result.done, true);
+  assert.equal(result.value, undefined);
+});
+
+test('RenderResultIterator is iterable', () => {
+  const thunked: ThunkedRenderResult = ['a', 'b'];
+  const iterator = new RenderResultIterator(thunked);
+
+  // Should be able to use in for...of loop
+  const values: (string | Promise<any>)[] = [];
+  for (const value of iterator) {
+    values.push(value);
+  }
+
+  assert.equal(values, ['a', 'b']);
+});
+
+//
+// Thunk handling
+//
+
+test('RenderResultIterator evaluates thunks returning strings', () => {
+  const thunk: Thunk = () => 'thunk-value';
+  const thunked: ThunkedRenderResult = ['a', thunk, 'b'];
+  const iterator = new RenderResultIterator(thunked);
+
+  const result1 = iterator.next();
+  assert.equal(result1.done, false);
+  assert.equal(result1.value, 'a');
+
+  const result2 = iterator.next();
+  assert.equal(result2.done, false);
+  assert.equal(result2.value, 'thunk-value');
+
+  const result3 = iterator.next();
+  assert.equal(result3.done, false);
+  assert.equal(result3.value, 'b');
+
+  const result4 = iterator.next();
+  assert.equal(result4.done, true);
+});
+
+test('RenderResultIterator evaluates thunks returning arrays with nested thunks', () => {
+  const innerThunk: Thunk = () => 'inner-value';
+  const outerThunk: Thunk = () => [innerThunk];
+  const thunked: ThunkedRenderResult = ['a', outerThunk, 'b'];
+  const iterator = new RenderResultIterator(thunked);
+
+  const result1 = iterator.next();
+  assert.equal(result1.done, false);
+  assert.equal(result1.value, 'a');
+
+  const result2 = iterator.next();
+  assert.equal(result2.done, false);
+  assert.equal(result2.value, 'inner-value');
+
+  const result3 = iterator.next();
+  assert.equal(result3.done, false);
+  assert.equal(result3.value, 'b');
+});
+
+test('RenderResultIterator evaluates thunks returning arrays', () => {
+  const thunk: Thunk = () => ['x', 'y'];
+  const thunked: ThunkedRenderResult = ['a', thunk, 'b'];
+  const iterator = new RenderResultIterator(thunked);
+
+  const values: string[] = [];
+  let result = iterator.next();
+  while (!result.done) {
+    if (typeof result.value === 'string') {
+      values.push(result.value);
+    }
+    result = iterator.next();
+  }
+
+  assert.equal(values, ['a', 'x', 'y', 'b']);
+});
+
+test('RenderResultIterator evaluates thunks returning nested arrays', () => {
+  const innerThunk: Thunk = () => ['y', 'z'];
+  const outerThunk: Thunk = () => ['x', innerThunk];
+  const thunked: ThunkedRenderResult = ['a', outerThunk, 'b'];
+  const iterator = new RenderResultIterator(thunked);
+
+  const values: string[] = [];
+  let result = iterator.next();
+  while (!result.done) {
+    if (typeof result.value === 'string') {
+      values.push(result.value);
+    }
+    result = iterator.next();
+  }
+
+  assert.equal(values, ['a', 'x', 'y', 'z', 'b']);
+});
+
+//
+// Promise handling
+//
+
+test('RenderResultIterator converts Promise<string> to Promise<RenderResult>', async () => {
+  const thunk: Thunk = () => Promise.resolve('async-value');
+  const thunked: ThunkedRenderResult = ['a', thunk, 'b'];
+  const iterator = new RenderResultIterator(thunked);
+
+  const result1 = iterator.next();
+  assert.equal(result1.done, false);
+  assert.equal(result1.value, 'a');
+
+  const result2 = iterator.next();
+  assert.equal(result2.done, false);
+  assert.ok(result2.value instanceof Promise);
+
+  const resolvedValue = await result2.value;
+  assert.equal(resolvedValue, 'async-value');
+});
+
+test('RenderResultIterator converts Promise<array> to Promise<RenderResult>', async () => {
+  const thunk: Thunk = () => Promise.resolve(['x', 'y']);
+  const thunked: ThunkedRenderResult = ['a', thunk, 'b'];
+  const iterator = new RenderResultIterator(thunked);
+
+  const result1 = iterator.next();
+  assert.equal(result1.done, false);
+  assert.equal(result1.value, 'a');
+
+  const result2 = iterator.next();
+  assert.equal(result2.done, false);
+  assert.ok(result2.value instanceof Promise);
+
+  const resolvedIterator = await result2.value;
+  assert.equal(resolvedIterator, iterator); // Should return the same iterator
+
+  // Continue iterating to get the array values
+  const result3 = iterator.next();
+  assert.equal(result3.done, false);
+  assert.equal(result3.value, 'x');
+
+  const result4 = iterator.next();
+  assert.equal(result4.done, false);
+  assert.equal(result4.value, 'y');
+
+  const result5 = iterator.next();
+  assert.equal(result5.done, false);
+  assert.equal(result5.value, 'b');
+});
+
+test('RenderResultIterator demonstrates proper async usage pattern', async () => {
+  // This test shows that you cannot manually iterate through async results
+  // with next() - you must use the async iteration protocols properly
+  const thunk: Thunk = () => Promise.resolve('async-value');
+  const thunked: ThunkedRenderResult = ['sync', thunk];
+  const iterator = new RenderResultIterator(thunked);
+
+  // First iteration gets sync value
+  const result1 = iterator.next();
+  assert.equal(result1.done, false);
+  assert.equal(result1.value, 'sync');
+
+  // Second iteration gets a promise
+  const result2 = iterator.next();
+  assert.equal(result2.done, false);
+  assert.ok(result2.value instanceof Promise);
+
+  // The promise resolves to the async value
+  const resolved = await result2.value;
+  assert.equal(resolved, 'async-value');
+
+  // Note: We cannot call next() again here because the iterator
+  // is still in "waiting" state. This is by design - async iteration
+  // should use for-await-of or similar patterns, not manual next() calls.
+});
+
+//
+// Error handling
+//
+
+test('RenderResultIterator throws when calling next() while waiting', () => {
+  const thunk: Thunk = () => Promise.resolve('async-value');
+  const thunked: ThunkedRenderResult = ['a', thunk];
+  const iterator = new RenderResultIterator(thunked);
+
+  // Get first value
+  iterator.next();
+
+  // Get promise value (sets _waiting to true)
+  const result = iterator.next();
+  assert.ok(result.value instanceof Promise);
+
+  // Trying to call next() again should throw
+  assert.throws(
+    () => iterator.next(),
+    'Cannot call next() while waiting for a Promise to resolve'
+  );
+});
+
+test('RenderResultIterator handles rejected promises', async () => {
+  const thunk: Thunk = () => Promise.reject(new Error('async error'));
+  const thunked: ThunkedRenderResult = ['a', thunk, 'b'];
+  const iterator = new RenderResultIterator(thunked);
+
+  // Get first value
+  const result1 = iterator.next();
+  assert.equal(result1.value, 'a');
+
+  // Get promise value
+  const result2 = iterator.next();
+  assert.ok(result2.value instanceof Promise);
+
+  // Promise should reject
+  try {
+    await result2.value;
+    assert.unreachable('Promise should have rejected');
+  } catch (error: any) {
+    assert.equal(error.message, 'async error');
+  }
+});
+
+//
+// Complex scenarios
+//
+
+test('RenderResultIterator handles mixed sync/async complex nesting', async () => {
+  const asyncThunk: Thunk = () => Promise.resolve(['async-x', 'async-y']);
+  const nestedThunk: Thunk = () => ['nested', asyncThunk];
+  const thunked: ThunkedRenderResult = ['start', nestedThunk, 'end'];
+  const iterator = new RenderResultIterator(thunked);
+
+  // start
+  const result1 = iterator.next();
+  assert.equal(result1.value, 'start');
+
+  // nested
+  const result2 = iterator.next();
+  assert.equal(result2.value, 'nested');
+
+  // async promise
+  const result3 = iterator.next();
+  assert.ok(result3.value instanceof Promise);
+  const resolvedIterator = await result3.value;
+  assert.equal(resolvedIterator, iterator);
+
+  // async-x
+  const result4 = iterator.next();
+  assert.equal(result4.value, 'async-x');
+
+  // async-y
+  const result5 = iterator.next();
+  assert.equal(result5.value, 'async-y');
+
+  // end
+  const result6 = iterator.next();
+  assert.equal(result6.value, 'end');
+
+  // done
+  const result7 = iterator.next();
+  assert.equal(result7.done, true);
+});
+
+test('RenderResultIterator handles nested arrays with async thunks', async () => {
+  const innerThunk: Thunk = () => Promise.resolve(['inner-async']);
+  const middleArray: ThunkedRenderResult = [innerThunk];
+  const outerThunk: Thunk = () => middleArray;
+  const thunked: ThunkedRenderResult = ['before', outerThunk, 'after'];
+  const iterator = new RenderResultIterator(thunked);
+
+  // before
+  const result1 = iterator.next();
+  assert.equal(result1.value, 'before');
+
+  // Promise from nested thunk
+  const result2 = iterator.next();
+  assert.ok(result2.value instanceof Promise);
+  const resolvedIterator = await result2.value;
+  assert.equal(resolvedIterator, iterator);
+
+  // inner-async
+  const result3 = iterator.next();
+  assert.equal(result3.value, 'inner-async');
+
+  // after
+  const result4 = iterator.next();
+  assert.equal(result4.value, 'after');
+
+  // done
+  const result5 = iterator.next();
+  assert.equal(result5.done, true);
+});
+
+//
+// Additional edge cases
+//
+
+test('RenderResultIterator handles empty thunk results', () => {
+  const emptyThunk: Thunk = () => [];
+  const thunked: ThunkedRenderResult = ['a', emptyThunk, 'b'];
+  const iterator = new RenderResultIterator(thunked);
+
+  const values: string[] = [];
+  let result = iterator.next();
+  while (!result.done) {
+    if (typeof result.value === 'string') {
+      values.push(result.value);
+    }
+    result = iterator.next();
+  }
+
+  assert.equal(values, ['a', 'b']);
+});
+
+test('RenderResultIterator handles thunk that returns Promise of empty array', async () => {
+  const asyncEmptyThunk: Thunk = () => Promise.resolve([]);
+  const thunked: ThunkedRenderResult = ['before', asyncEmptyThunk, 'after'];
+  const iterator = new RenderResultIterator(thunked);
+
+  // Get 'before'
+  const result1 = iterator.next();
+  assert.equal(result1.value, 'before');
+
+  // Get promise that resolves to empty array
+  const result2 = iterator.next();
+  assert.ok(result2.value instanceof Promise);
+
+  const resolved = await result2.value;
+  assert.equal(resolved, iterator); // Promise resolves to the iterator itself
+
+  // Should be able to continue to 'after'
+  const result3 = iterator.next();
+  assert.equal(result3.value, 'after');
+
+  // Done
+  const result4 = iterator.next();
+  assert.equal(result4.done, true);
+});
+
+test('RenderResultIterator Symbol.iterator returns itself', () => {
+  const thunked: ThunkedRenderResult = ['a', 'b'];
+  const iterator = new RenderResultIterator(thunked);
+
+  assert.equal(iterator[Symbol.iterator](), iterator);
+});
+
+test.run();

--- a/packages/labs/ssr/src/test/lib/render-result-iterator_test.ts
+++ b/packages/labs/ssr/src/test/lib/render-result-iterator_test.ts
@@ -155,6 +155,10 @@ test('RenderResultIterator converts Promise<string> to Promise<RenderResult>', a
 
   const resolvedValue = await result2.value;
   assert.equal(resolvedValue, 'async-value');
+
+  const result3 = iterator.next();
+  assert.equal(result3.done, false);
+  assert.equal(result3.value, 'b');
 });
 
 test('RenderResultIterator converts Promise<array> to Promise<RenderResult>', async () => {
@@ -185,32 +189,6 @@ test('RenderResultIterator converts Promise<array> to Promise<RenderResult>', as
   const result5 = iterator.next();
   assert.equal(result5.done, false);
   assert.equal(result5.value, 'b');
-});
-
-test('RenderResultIterator demonstrates proper async usage pattern', async () => {
-  // This test shows that you cannot manually iterate through async results
-  // with next() - you must use the async iteration protocols properly
-  const thunk: Thunk = () => Promise.resolve('async-value');
-  const thunked: ThunkedRenderResult = ['sync', thunk];
-  const iterator = new RenderResultIterator(thunked);
-
-  // First iteration gets sync value
-  const result1 = iterator.next();
-  assert.equal(result1.done, false);
-  assert.equal(result1.value, 'sync');
-
-  // Second iteration gets a promise
-  const result2 = iterator.next();
-  assert.equal(result2.done, false);
-  assert.ok(result2.value instanceof Promise);
-
-  // The promise resolves to the async value
-  const resolved = await result2.value;
-  assert.equal(resolved, 'async-value');
-
-  // Note: We cannot call next() again here because the iterator
-  // is still in "waiting" state. This is by design - async iteration
-  // should use for-await-of or similar patterns, not manual next() calls.
 });
 
 //

--- a/packages/labs/ssr/src/test/lib/render-result-readable_test.ts
+++ b/packages/labs/ssr/src/test/lib/render-result-readable_test.ts
@@ -8,36 +8,38 @@ import {Readable} from 'stream';
 import {test} from 'uvu';
 // eslint-disable-next-line import/extensions
 import * as assert from 'uvu/assert';
-import {RenderResultReadable} from '../../lib/render-result-readable.js';
+import {ThunkedRenderResultReadable} from '../../lib/render-result-readable.js';
 
 test('RenderResultReadable collects strings', async () => {
-  const s = await collectReadable(new RenderResultReadable(['a', 'b', 'c']));
+  const s = await collectReadable(
+    new ThunkedRenderResultReadable(['a', 'b', 'c'])
+  );
   assert.equal(s, 'abc');
 });
 
 test('RenderResultReadable collects strings and thunks', async () => {
   const s = await collectReadable(
-    new RenderResultReadable(['a', () => ['b'], 'c'])
+    new ThunkedRenderResultReadable(['a', () => ['b'], 'c'])
   );
   assert.equal(s, 'abc');
 });
 
 test('RenderResultReadable collects strings and thunks returning arrays', async () => {
   const s = await collectReadable(
-    new RenderResultReadable(['a', () => ['b', 'c'], 'd'])
+    new ThunkedRenderResultReadable(['a', () => ['b', 'c'], 'd'])
   );
   assert.equal(s, 'abcd');
 });
 
 test('RenderResultReadable collects strings and nested thunks', async () => {
   const s = await collectReadable(
-    new RenderResultReadable(['a', () => [() => ['b', 'c']], 'd'])
+    new ThunkedRenderResultReadable(['a', () => [() => ['b', 'c']], 'd'])
   );
   assert.equal(s, 'abcd');
 });
 
 test('RenderResultReadable collects all iterables when stream is back pressured', async () => {
-  class TestRenderResultReadable extends RenderResultReadable {
+  class TestRenderResultReadable extends ThunkedRenderResultReadable {
     override push(value: any) {
       super.push(value);
 
@@ -58,7 +60,7 @@ test('RenderResultReadable collects all iterables when stream is back pressured'
 });
 
 test('RenderResultReadable yields for some time until thunk promises resolve', async () => {
-  const readable = new RenderResultReadable([
+  const readable = new ThunkedRenderResultReadable([
     'a',
     () => new Promise((res) => setTimeout(res, 50)).then((_) => ['b', 'c']),
     () => new Promise((res) => setTimeout(res, 50)).then((_) => ['d', 'e']),
@@ -69,7 +71,7 @@ test('RenderResultReadable yields for some time until thunk promises resolve', a
 });
 
 test('pulling synchronously from RenderResultReadable cannot skip async work', async () => {
-  const readable = new RenderResultReadable([
+  const readable = new ThunkedRenderResultReadable([
     'a',
     () => new Promise((res) => setTimeout(res, 50)).then((_) => ['b']),
     'c',

--- a/packages/labs/ssr/src/test/lib/render-result-readable_test.ts
+++ b/packages/labs/ssr/src/test/lib/render-result-readable_test.ts
@@ -8,38 +8,127 @@ import {Readable} from 'stream';
 import {test} from 'uvu';
 // eslint-disable-next-line import/extensions
 import * as assert from 'uvu/assert';
-import {ThunkedRenderResultReadable} from '../../lib/render-result-readable.js';
+import {RenderResultReadable} from '../../lib/render-result-readable.js';
+
+// RenderResult
 
 test('RenderResultReadable collects strings', async () => {
+  const s = await collectReadable(new RenderResultReadable(['a', 'b', 'c']));
+  assert.equal(s, 'abc');
+});
+
+test('RenderResultReadable collects strings and Promises', async () => {
   const s = await collectReadable(
-    new ThunkedRenderResultReadable(['a', 'b', 'c'])
+    new RenderResultReadable(['a', Promise.resolve(['b']), 'c'])
   );
+  assert.equal(s, 'abc');
+});
+
+test('RenderResultReadable collects strings and Promises of iterables', async () => {
+  const s = await collectReadable(
+    new RenderResultReadable(['a', Promise.resolve(['b', 'c']), 'd'])
+  );
+  assert.equal(s, 'abcd');
+});
+
+test('RenderResultReadable collects strings and nested Promises of iterables', async () => {
+  const s = await collectReadable(
+    new RenderResultReadable([
+      'a',
+      Promise.resolve([Promise.resolve(['b', 'c'])]),
+      'd',
+    ])
+  );
+  assert.equal(s, 'abcd');
+});
+
+test('RenderResultReadable collects all iterables when stream is back pressured', async () => {
+  class TestRenderResultReadable extends RenderResultReadable {
+    override push(value: any) {
+      super.push(value);
+
+      // for the value different from "__" we return true to indicate that we can accept more data
+      return value !== '__';
+    }
+  }
+
+  const readable = new TestRenderResultReadable([
+    'a',
+    Promise.resolve([Promise.resolve(['__', 'b'])]),
+    '__',
+    'c',
+  ]);
+
+  const s = await collectReadable(readable);
+  assert.equal(s, 'a__b__c');
+});
+
+test('RenderResultReadable yields for some time until promises resolve', async () => {
+  const readable = new RenderResultReadable([
+    'a',
+    new Promise((res) => setTimeout(res, 50)).then((_) => ['b', 'c']),
+    new Promise((res) => setTimeout(res, 50)).then((_) => ['d', 'e']),
+    'f',
+  ]);
+  const s = await collectReadable(readable);
+  assert.equal(s, 'abcdef');
+});
+
+test('pulling synchronously from RenderResultReadable cannot skip async work', async () => {
+  const readable = new RenderResultReadable([
+    'a',
+    new Promise((res) => setTimeout(res, 50)).then((_) => ['b']),
+    'c',
+  ]);
+  readable.setEncoding('utf8');
+  assert.equal(readable.read(), 'a');
+  // Regression test where it was possible to skip Promises by calling `.read`
+  // while a promise was still resolving.
+  assert.equal(readable.read(), null);
+});
+
+// ThunkedRenderResult
+
+test('RenderResultReadable collects strings', async () => {
+  const s = await collectReadable(new RenderResultReadable(['a', 'b', 'c']));
   assert.equal(s, 'abc');
 });
 
 test('RenderResultReadable collects strings and thunks', async () => {
   const s = await collectReadable(
-    new ThunkedRenderResultReadable(['a', () => ['b'], 'c'])
+    new RenderResultReadable(['a', () => ['b'], 'c', () => 'd'])
   );
-  assert.equal(s, 'abc');
+  assert.equal(s, 'abcd');
 });
 
 test('RenderResultReadable collects strings and thunks returning arrays', async () => {
   const s = await collectReadable(
-    new ThunkedRenderResultReadable(['a', () => ['b', 'c'], 'd'])
+    new RenderResultReadable(['a', () => ['b', 'c'], 'd'])
   );
   assert.equal(s, 'abcd');
 });
 
 test('RenderResultReadable collects strings and nested thunks', async () => {
   const s = await collectReadable(
-    new ThunkedRenderResultReadable(['a', () => [() => ['b', 'c']], 'd'])
+    new RenderResultReadable(['a', () => [() => ['b', 'c']], 'd'])
+  );
+  assert.equal(s, 'abcd');
+});
+
+test('RenderResultReadable handles thunks returning promises', async () => {
+  const s = await collectReadable(
+    new RenderResultReadable([
+      'a',
+      () => Promise.resolve(['b']),
+      'c',
+      () => Promise.resolve('d'),
+    ])
   );
   assert.equal(s, 'abcd');
 });
 
 test('RenderResultReadable collects all iterables when stream is back pressured', async () => {
-  class TestRenderResultReadable extends ThunkedRenderResultReadable {
+  class TestRenderResultReadable extends RenderResultReadable {
     override push(value: any) {
       super.push(value);
 
@@ -60,7 +149,7 @@ test('RenderResultReadable collects all iterables when stream is back pressured'
 });
 
 test('RenderResultReadable yields for some time until thunk promises resolve', async () => {
-  const readable = new ThunkedRenderResultReadable([
+  const readable = new RenderResultReadable([
     'a',
     () => new Promise((res) => setTimeout(res, 50)).then((_) => ['b', 'c']),
     () => new Promise((res) => setTimeout(res, 50)).then((_) => ['d', 'e']),
@@ -71,7 +160,7 @@ test('RenderResultReadable yields for some time until thunk promises resolve', a
 });
 
 test('pulling synchronously from RenderResultReadable cannot skip async work', async () => {
-  const readable = new ThunkedRenderResultReadable([
+  const readable = new RenderResultReadable([
     'a',
     () => new Promise((res) => setTimeout(res, 50)).then((_) => ['b']),
     'c',

--- a/packages/labs/ssr/src/test/lib/render-result_test.ts
+++ b/packages/labs/ssr/src/test/lib/render-result_test.ts
@@ -15,8 +15,8 @@ test('collectResultSync collects strings', () => {
 
 test('collectResultSync throws for a Promise', () => {
   assert.throws(
-    () => collectResultSync(['a', Promise.resolve(['b']), 'c']),
-    'abc'
+    () => collectResultSync(['a', () => Promise.resolve(['b']), 'c']),
+    'Promises not supported in collectResultSync'
   );
 });
 
@@ -24,26 +24,23 @@ test('collectResult collects strings', async () => {
   assert.equal(await collectResult(['a', 'b', 'c']), 'abc');
 });
 
-test('collectResult collects strings and Promises', async () => {
-  assert.equal(await collectResult(['a', Promise.resolve(['b']), 'c']), 'abc');
+test('collectResult collects strings and thunks', async () => {
+  assert.equal(await collectResult(['a', () => ['b'], 'c']), 'abc');
 });
 
-test('collectResult collects strings and Promises of iterables', async () => {
+test('collectResult collects strings and thunks returning arrays', async () => {
+  assert.equal(await collectResult(['a', () => ['b', 'c'], 'd']), 'abcd');
+});
+
+test('collectResult collects strings and thunks returning Promises', async () => {
   assert.equal(
-    await collectResult(['a', Promise.resolve(['b', 'c']), 'd']),
+    await collectResult(['a', () => Promise.resolve(['b', 'c']), 'd']),
     'abcd'
   );
 });
 
-test('collectResult collects strings and nested Promises of iterables', async () => {
-  assert.equal(
-    await collectResult([
-      'a',
-      Promise.resolve([Promise.resolve(['b', 'c'])]),
-      'd',
-    ]),
-    'abcd'
-  );
+test('collectResult collects nested thunks', async () => {
+  assert.equal(await collectResult(['a', () => [() => 'b', 'c'], 'd']), 'abcd');
 });
 
 test.run();

--- a/packages/labs/ssr/src/test/lib/render-result_test.ts
+++ b/packages/labs/ssr/src/test/lib/render-result_test.ts
@@ -59,8 +59,13 @@ test('collectResult collects strings and thunks returning arrays', async () => {
 
 test('collectResult collects strings and thunks returning Promises', async () => {
   assert.equal(
-    await collectResult(['a', () => Promise.resolve(['b', 'c']), 'd']),
-    'abcd'
+    await collectResult([
+      'a',
+      () => Promise.resolve(['b', 'c']),
+      'd',
+      () => Promise.resolve('e'),
+    ]),
+    'abcde'
   );
 });
 
@@ -72,6 +77,15 @@ test('collectResult collects nested thunks', async () => {
 
 test('collectResult collects strings and Promises', async () => {
   assert.equal(await collectResult(['a', Promise.resolve(['b']), 'c']), 'abc');
+});
+
+test('collectResult collects non-array iterables', async () => {
+  assert.equal(
+    await collectResult(
+      ['a', Promise.resolve(['b'][Symbol.iterator]()), 'c'][Symbol.iterator]()
+    ),
+    'abc'
+  );
 });
 
 test('collectResultSync throws for a Promise', () => {

--- a/packages/labs/ssr/src/test/lib/render-result_test.ts
+++ b/packages/labs/ssr/src/test/lib/render-result_test.ts
@@ -9,20 +9,45 @@ import {test} from 'uvu';
 import * as assert from 'uvu/assert';
 import {collectResult, collectResultSync} from '../../lib/render-result.js';
 
+//
+// collectResultSync
+//
+
+// Both RenderResult and ThunkedRenderResult
+
 test('collectResultSync collects strings', () => {
   assert.equal(collectResultSync(['a', 'b', 'c']), 'abc');
 });
 
-test('collectResultSync throws for a Promise', () => {
+// ThunkedRenderResult only
+
+test('collectResultSync throws for a thunk returning a Promise', () => {
   assert.throws(
     () => collectResultSync(['a', () => Promise.resolve(['b']), 'c']),
     'Promises not supported in collectResultSync'
   );
 });
 
+// RenderResult only
+
+test('collectResultSync throws for a Promise', () => {
+  assert.throws(
+    () => collectResultSync(['a', Promise.resolve(['b']), 'c']),
+    'abc'
+  );
+});
+
+//
+// collectResult
+//
+
+// Both RenderResult and ThunkedRenderResult
+
 test('collectResult collects strings', async () => {
   assert.equal(await collectResult(['a', 'b', 'c']), 'abc');
 });
+
+// ThunkedRenderResult only
 
 test('collectResult collects strings and thunks', async () => {
   assert.equal(await collectResult(['a', () => ['b'], 'c']), 'abc');
@@ -41,6 +66,37 @@ test('collectResult collects strings and thunks returning Promises', async () =>
 
 test('collectResult collects nested thunks', async () => {
   assert.equal(await collectResult(['a', () => [() => 'b', 'c'], 'd']), 'abcd');
+});
+
+// RenderResult only
+
+test('collectResult collects strings and Promises', async () => {
+  assert.equal(await collectResult(['a', Promise.resolve(['b']), 'c']), 'abc');
+});
+
+test('collectResultSync throws for a Promise', () => {
+  assert.throws(
+    () => collectResultSync(['a', Promise.resolve(['b']), 'c']),
+    'abc'
+  );
+});
+
+test('collectResult collects strings and Promises of iterables', async () => {
+  assert.equal(
+    await collectResult(['a', Promise.resolve(['b', 'c']), 'd']),
+    'abcd'
+  );
+});
+
+test('collectResult collects strings and nested Promises of iterables', async () => {
+  assert.equal(
+    await collectResult([
+      'a',
+      Promise.resolve([Promise.resolve(['b', 'c'])]),
+      'd',
+    ]),
+    'abcd'
+  );
 });
 
 test.run();

--- a/packages/labs/ssr/src/test/test-files/render-test-module.ts
+++ b/packages/labs/ssr/src/test/test-files/render-test-module.ts
@@ -14,7 +14,7 @@ import type {HTMLElementWithEventMeta} from '@lit-labs/ssr-dom-shim';
 import {html as serverhtml} from '../../lib/server-template.js';
 export {digestForTemplateResult} from '@lit-labs/ssr-client';
 
-export {render} from '../../lib/render-lit-html.js';
+export {renderThunked as render} from '../../lib/render.js';
 
 /* Real Tests */
 // prettier-ignore


### PR DESCRIPTION
This gets rid of generators completely from the SSR code in favor of a thunk/trampoline approach where render functions can return thunks that are called to continue rendering. This keeps our ability to render synchronously or asynchronously, while improving perf.

Benchmarks from https://github.com/lit/lit/pull/5103 are merged into a separate branch https://github.com/lit/lit/tree/ssr-thunks-benchmarks and show an **18x** improvement compared to `main`.

This approach works by mapping a template's opcodes array into an array of strings or thunks and performing all render state access and mutation in those thunks. Consumers must iterate the array and when they get a thunk, they have to call it and process the return value. The return value can be undefined, a string, another render result, or a promise.

The thunk representation converts recursion and generators into a kind of continuation, and this appears to eliminate a *huge* amount of overhead.

Like the generator approach, synchronous consumers can throw when they encounter Promises, so we can implement `renderToString()` and continue to render synchronously inside of `React.createElement` patches, etc.

Asynchronous consumers can pause evaluation simply by not calling the next thunk yet. They must await the promises return by thunks, and can pause when they receive backpressure signals, etc. from downstream consumers.

The change is *mostly* backwards compatible. `render()` continues to return ` RenderResult`, which is still an iterable of strings or promises. A new function called `renderThunked()` is added that returns a ThunkedRenderResult`, which is an array of strings of thunks. `render()` calls `renderThunked()` and wraps the result in an iterable that uses a trampoline to read through the result for a small overhead.

`collectResult()`, `collectResultSync()`, and `RenderResultReadable` have been updated to accept both `RenderResult`s and `ThunkedRenderResult`s. Users who are already using those to consumer renders can just change their render call from `render()` to `renderThunked()` to get the best performance. All existing users will get a signification improvement either way though.

Further optimizations are likely possible. One idea is to reduce the number of closures produced by making a Renderer class that keeps the current render state on a stack and produces new values when calling next. Because of this, the `ThunkedRenderResult` type might not be very stable going forward. We may see a few major versions go by as we settle this down - this is labs after all!

One breaking change here is to the return type of the ElementRenderer methods. They now directly return a `ThunkedRenderResult`. This may be a good stable API to settle on, since if they return iterables of strings, we have to chain iterables (which we did with `yield*` previously) or change the return type to support iterables of iterables and make nested iterables responsible for kicking off execution of their render when `next()` is called - essentially a manual generator.

Custom ElementRenderers are more rare than direct SSR `render()` users, so it may be worth some churn here to land the drastic performance improvements ASAP, then adjust APIs in future major versions if needed.