### PR TITLE
[labs/ssr] Remove support for deprecated `<template shadowroot>` attribute

### DIFF
--- a/.changeset/real-forks-wait.md
+++ b/.changeset/real-forks-wait.md
@@ -7,4 +7,4 @@
 '@lit-labs/testing': patch
 ---
 
-remove deprecated shadowroot attribute
+Remove support for the deprecated `<template shadowroot>` attribute.

--- a/.changeset/real-forks-wait.md
+++ b/.changeset/real-forks-wait.md
@@ -1,0 +1,9 @@
+---
+'@lit-labs/eleventy-plugin-lit': patch
+'@lit-labs/ssr-dom-shim': patch
+'@lit-labs/ssr-client': patch
+'@lit-labs/ssr-react': patch
+'@lit-labs/ssr': patch
+---
+
+remove deprecated shadowroot attribute

--- a/.changeset/real-forks-wait.md
+++ b/.changeset/real-forks-wait.md
@@ -4,6 +4,7 @@
 '@lit-labs/ssr-client': patch
 '@lit-labs/ssr-react': patch
 '@lit-labs/ssr': patch
+'@lit-labs/testing': patch
 ---
 
 remove deprecated shadowroot attribute

--- a/package-lock.json
+++ b/package-lock.json
@@ -8213,10 +8213,6 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
-    "node_modules/@webcomponents/template-shadowroot": {
-      "version": "0.1.0",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/@webcomponents/webcomponentsjs": {
       "version": "2.8.0",
       "dev": true,
@@ -27206,7 +27202,7 @@
     },
     "packages/labs/analyzer": {
       "name": "@lit-labs/analyzer",
-      "version": "0.13.2",
+      "version": "0.14.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@parse5/tools": "^0.7.0",
@@ -27290,10 +27286,10 @@
     },
     "packages/labs/cli": {
       "name": "@lit-labs/cli",
-      "version": "0.6.5",
+      "version": "0.6.6",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/analyzer": "^0.13.0",
+        "@lit-labs/analyzer": "^0.14.0",
         "@lit-labs/gen-utils": "^0.3.0",
         "@lit/localize-tools": "^0.8.0",
         "chalk": "^5.0.1",
@@ -27318,7 +27314,7 @@
     },
     "packages/labs/cli-localize": {
       "name": "@lit-labs/cli-localize",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit/localize-tools": "^0.8.0"
@@ -27440,10 +27436,10 @@
     },
     "packages/labs/compiler": {
       "name": "@lit-labs/compiler",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/analyzer": "^0.13.0",
+        "@lit-labs/analyzer": "^0.14.0",
         "@parse5/tools": "^0.3.0",
         "lit-html": "^3.2.0",
         "parse5": "^7.1.2",
@@ -27491,27 +27487,34 @@
     },
     "packages/labs/eleventy-plugin-lit": {
       "name": "@lit-labs/eleventy-plugin-lit",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/ssr": "^3.3.0",
+        "@lit-labs/ssr": "^4.0.0",
         "lit": "^2.7.0 || ^3.0.0"
       },
       "devDependencies": {
         "@11ty/eleventy": "^1.0.0",
-        "@webcomponents/template-shadowroot": "^0.1.0",
+        "@webcomponents/template-shadowroot": "^0.2.1",
         "rimraf": "^3.0.2"
       },
       "engines": {
         "node": ">=12.16.0"
       }
     },
+    "packages/labs/eleventy-plugin-lit/node_modules/@webcomponents/template-shadowroot": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@webcomponents/template-shadowroot/-/template-shadowroot-0.2.1.tgz",
+      "integrity": "sha512-fXL/vIUakyZL62hyvUh+EMwbVoTc0hksublmRz6ai6et8znHkJa6gtqMUZo1oc7dIz46exHSIImml9QTdknMHg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "packages/labs/eslint-plugin": {
       "name": "eslint-plugin-lit",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/analyzer": "^0.13.0",
+        "@lit-labs/analyzer": "^0.14.0",
         "@typescript-eslint/utils": "^6.19.0",
         "typescript": "~5.9.0"
       },
@@ -27524,7 +27527,7 @@
     },
     "packages/labs/forms": {
       "name": "@lit-labs/forms",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit/reactive-element": "^2.0.0"
@@ -27536,10 +27539,10 @@
     },
     "packages/labs/gen-manifest": {
       "name": "@lit-labs/gen-manifest",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/analyzer": "^0.13.0",
+        "@lit-labs/analyzer": "^0.14.0",
         "@lit-labs/gen-utils": "^0.3.0",
         "custom-elements-manifest": "^2.0.0"
       },
@@ -27559,10 +27562,10 @@
     },
     "packages/labs/gen-utils": {
       "name": "@lit-labs/gen-utils",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/analyzer": "^0.13.0"
+        "@lit-labs/analyzer": "^0.14.0"
       },
       "devDependencies": {
         "@lit-internal/tests": "^0.0.1",
@@ -27574,10 +27577,10 @@
     },
     "packages/labs/gen-wrapper-angular": {
       "name": "@lit-labs/gen-wrapper-angular",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/analyzer": "^0.13.0",
+        "@lit-labs/analyzer": "^0.14.0",
         "@lit-labs/gen-utils": "^0.3.0"
       },
       "devDependencies": {
@@ -27592,10 +27595,10 @@
     },
     "packages/labs/gen-wrapper-react": {
       "name": "@lit-labs/gen-wrapper-react",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/analyzer": "^0.13.0",
+        "@lit-labs/analyzer": "^0.14.0",
         "@lit-labs/gen-utils": "^0.3.0"
       },
       "devDependencies": {
@@ -27607,10 +27610,10 @@
     },
     "packages/labs/gen-wrapper-vue": {
       "name": "@lit-labs/gen-wrapper-vue",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/analyzer": "^0.13.0",
+        "@lit-labs/analyzer": "^0.14.0",
         "@lit-labs/gen-utils": "^0.3.0",
         "@lit-labs/vue-utils": "^0.1.1"
       },
@@ -27623,7 +27626,7 @@
     },
     "packages/labs/motion": {
       "name": "@lit-labs/motion",
-      "version": "1.0.9",
+      "version": "1.1.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "lit": "^3.1.2",
@@ -27653,7 +27656,7 @@
     },
     "packages/labs/observers": {
       "name": "@lit-labs/observers",
-      "version": "2.0.6",
+      "version": "2.1.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit/reactive-element": "^1.0.0 || ^2.0.0"
@@ -27845,7 +27848,7 @@
     },
     "packages/labs/rollup-plugin-minify-html-literals": {
       "name": "@lit-labs/rollup-plugin-minify-html-literals",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "clean-css": "^4.2.1",
@@ -27933,7 +27936,7 @@
     },
     "packages/labs/signals": {
       "name": "@lit-labs/signals",
-      "version": "0.1.3",
+      "version": "0.2.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "lit": "^2.0.0 || ^3.0.0",
@@ -27945,11 +27948,11 @@
     },
     "packages/labs/ssr": {
       "name": "@lit-labs/ssr",
-      "version": "3.3.1",
+      "version": "4.0.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit-labs/ssr-client": "^1.1.7",
-        "@lit-labs/ssr-dom-shim": "^1.3.0",
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
         "@lit/reactive-element": "^2.0.4",
         "@parse5/tools": "^0.3.0",
         "enhanced-resolve": "^5.10.0",
@@ -27971,7 +27974,7 @@
         "@types/koa-static": "^4.0.1",
         "@types/node": "^20.0.0",
         "@types/resolve": "^1.20.2",
-        "@webcomponents/template-shadowroot": "^0.1.0",
+        "@webcomponents/template-shadowroot": "^0.2.1",
         "command-line-args": "^5.1.1",
         "deepmerge": "^4.2.2",
         "koa": "^2.7.0",
@@ -27994,7 +27997,7 @@
     },
     "packages/labs/ssr-client": {
       "name": "@lit-labs/ssr-client",
-      "version": "1.1.7",
+      "version": "1.1.8",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit/reactive-element": "^2.0.4",
@@ -28007,15 +28010,15 @@
     },
     "packages/labs/ssr-dom-shim": {
       "name": "@lit-labs/ssr-dom-shim",
-      "version": "1.4.0",
+      "version": "1.5.1",
       "license": "BSD-3-Clause"
     },
     "packages/labs/ssr-react": {
       "name": "@lit-labs/ssr-react",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/ssr": "^3.3.0",
+        "@lit-labs/ssr": "^4.0.0",
         "@lit-labs/ssr-client": "^1.1.7"
       },
       "devDependencies": {
@@ -28043,6 +28046,13 @@
         "undici-types": "~6.21.0"
       }
     },
+    "packages/labs/ssr/node_modules/@webcomponents/template-shadowroot": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@webcomponents/template-shadowroot/-/template-shadowroot-0.2.1.tgz",
+      "integrity": "sha512-fXL/vIUakyZL62hyvUh+EMwbVoTc0hksublmRz6ai6et8znHkJa6gtqMUZo1oc7dIz46exHSIImml9QTdknMHg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "packages/labs/task": {
       "name": "@lit-labs/task",
       "version": "3.1.0",
@@ -28058,7 +28068,7 @@
     },
     "packages/labs/test-projects/test-element-a": {
       "name": "@lit-internal/test-element-a",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "dependencies": {
         "lit": "file:../../../lit"
       },
@@ -28068,9 +28078,9 @@
     },
     "packages/labs/test-projects/test-elements-react": {
       "name": "@lit-internal/test-elements-react",
-      "version": "1.0.9",
+      "version": "1.0.10",
       "dependencies": {
-        "@lit-internal/test-element-a": "1.0.1",
+        "@lit-internal/test-element-a": "1.0.2",
         "@lit/react": "1.0.8"
       },
       "peerDependencies": {
@@ -28084,13 +28094,13 @@
     },
     "packages/labs/testing": {
       "name": "@lit-labs/testing",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/ssr": "^3.3.0",
+        "@lit-labs/ssr": "^4.0.0",
         "@lit-labs/ssr-client": "^1.1.4",
         "@web/test-runner-commands": "^0.6.1",
-        "@webcomponents/template-shadowroot": "^0.1.0",
+        "@webcomponents/template-shadowroot": "^0.2.1",
         "lit": "^2.0.0 || ^3.0.0"
       },
       "devDependencies": {
@@ -28108,12 +28118,18 @@
         "node": ">=12.0.0"
       }
     },
+    "packages/labs/testing/node_modules/@webcomponents/template-shadowroot": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@webcomponents/template-shadowroot/-/template-shadowroot-0.2.1.tgz",
+      "integrity": "sha512-fXL/vIUakyZL62hyvUh+EMwbVoTc0hksublmRz6ai6et8znHkJa6gtqMUZo1oc7dIz46exHSIImml9QTdknMHg==",
+      "license": "BSD-3-Clause"
+    },
     "packages/labs/tsserver-plugin": {
       "name": "@lit-labs/tsserver-plugin",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/analyzer": "^0.13.1",
+        "@lit-labs/analyzer": "^0.14.0",
         "@parse5/tools": "^0.5.0",
         "typescript": "~5.9.0"
       },
@@ -28157,10 +28173,10 @@
     },
     "packages/labs/vscode-extension": {
       "name": "@lit-labs/vscode-extension",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
-        "@lit-labs/analyzer": "^0.13.2",
-        "@lit-labs/tsserver-plugin": "^0.0.1"
+        "@lit-labs/analyzer": "^0.14.0",
+        "@lit-labs/tsserver-plugin": "^0.1.0"
       },
       "devDependencies": {
         "@types/node": "^22.17.0",
@@ -28185,7 +28201,7 @@
       }
     },
     "packages/lit": {
-      "version": "3.3.1",
+      "version": "3.3.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit/reactive-element": "^2.1.0",
@@ -28201,10 +28217,10 @@
       }
     },
     "packages/lit-element": {
-      "version": "4.2.1",
+      "version": "4.2.2",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.4.0",
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
         "@lit/reactive-element": "^2.1.0",
         "lit-html": "^3.3.0"
       },
@@ -28218,7 +28234,7 @@
       }
     },
     "packages/lit-html": {
-      "version": "3.3.1",
+      "version": "3.3.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
@@ -28313,7 +28329,7 @@
     },
     "packages/lit-starter-ts": {
       "name": "@lit/lit-starter-ts",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "lit": "^3.2.0"
@@ -28613,7 +28629,7 @@
     },
     "packages/localize-tools": {
       "name": "@lit/localize-tools",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit/localize": "^0.12.0",
@@ -28633,7 +28649,7 @@
       },
       "devDependencies": {
         "@lit-internal/tests": "0.0.1",
-        "@lit-labs/ssr": "^3.2.2",
+        "@lit-labs/ssr": "^4.0.0",
         "@lit/ts-transformers": "^2.0.1",
         "@types/fs-extra": "^9.0.1",
         "@types/minimist": "^1.2.0",
@@ -28699,7 +28715,7 @@
     },
     "packages/localize/examples/transform-js": {
       "name": "@lit-internal/localize-examples-transform-js",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "dependencies": {
         "@lit/localize": "^0.12.0",
         "lit": "^3.2.0"
@@ -28716,7 +28732,7 @@
     },
     "packages/localize/examples/transform-ts": {
       "name": "@lit-internal/localize-examples-transform-ts",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "dependencies": {
         "@lit/localize": "^0.12.0",
         "lit": "^3.2.0"
@@ -28889,10 +28905,10 @@
     },
     "packages/reactive-element": {
       "name": "@lit/reactive-element",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.4.0"
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
       },
       "devDependencies": {
         "@babel/cli": "^7.22.10",
@@ -28936,7 +28952,7 @@
     },
     "packages/tests-typescript": {
       "name": "@lit-internal/tests-typescript",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "lit": "*",
         "typescript": "5.9.2",

--- a/packages/labs/eleventy-plugin-lit/README.md
+++ b/packages/labs/eleventy-plugin-lit/README.md
@@ -175,7 +175,7 @@ Then the Eleventy will produce `greeting/index.html`:
 <h1>Greetings</h1>
 
 <demo-greeter name="World">
-  <template shadowroot="open">
+  <template shadowrootmode="open">
     <style>
       b { color: red; }
     </style>
@@ -185,7 +185,7 @@ Then the Eleventy will produce `greeting/index.html`:
 ```
 <!-- prettier-ignore-end -->
 
-The `<template shadowroot="open">` element above is an HTML standard called
+The `<template shadowrootmode="open">` element above is an HTML standard called
 declarative shadow DOM. See the [Declarative Shadow
 DOM](#declarative-shadow-dom) section below for more details.
 

--- a/packages/labs/eleventy-plugin-lit/package.json
+++ b/packages/labs/eleventy-plugin-lit/package.json
@@ -95,7 +95,7 @@
   },
   "devDependencies": {
     "@11ty/eleventy": "^1.0.0",
-    "@webcomponents/template-shadowroot": "^0.1.0",
+    "@webcomponents/template-shadowroot": "^0.2.1",
     "rimraf": "^3.0.2"
   }
 }

--- a/packages/labs/eleventy-plugin-lit/src/test/eleventy-plugin-test.ts
+++ b/packages/labs/eleventy-plugin-lit/src/test/eleventy-plugin-test.ts
@@ -231,7 +231,7 @@ modes.forEach((mode) => {
       await rig.read('_site/index.html'),
       normalize(`
         <h1>Heading</h1>
-        <p><my-element><template shadowroot="open" shadowrootmode="open"><!--lit-part 8dHorjH6jDo=--><b>shadow content</b><!--/lit-part--></template></my-element></p>
+        <p><my-element><template shadowrootmode="open"><!--lit-part 8dHorjH6jDo=--><b>shadow content</b><!--/lit-part--></template></my-element></p>
       `)
     );
   });
@@ -267,7 +267,7 @@ modes.forEach((mode) => {
       await rig.read('_site/index.html'),
       normalize(`
         <h1>Heading</h1>
-        <my-element><template shadowroot="open" shadowrootmode="open"><!--lit-part 8dHorjH6jDo=--><b>shadow content</b><!--/lit-part--></template></my-element>
+        <my-element><template shadowrootmode="open"><!--lit-part 8dHorjH6jDo=--><b>shadow content</b><!--/lit-part--></template></my-element>
       `)
     );
   });
@@ -295,7 +295,7 @@ modes.forEach((mode) => {
         <html>
           <body>
             <h1>Heading</h1>
-            <my-element><template shadowroot="open" shadowrootmode="open"><!--lit-part 8dHorjH6jDo=--><b>shadow content</b><!--/lit-part--></template></my-element>
+            <my-element><template shadowrootmode="open"><!--lit-part 8dHorjH6jDo=--><b>shadow content</b><!--/lit-part--></template></my-element>
           </body>
         </html>
       `)
@@ -350,11 +350,11 @@ modes.forEach((mode) => {
       await rig.read('_site/index.html'),
       normalize(`
         <h1>Heading 1</h1>
-        <my-container><template shadowroot="open" shadowrootmode="open"><!--lit-part Pz0gobCCM4E=--><slot></slot><!--/lit-part--></template>
-          <my-content><template shadowroot="open" shadowrootmode="open"><!--lit-part 8dHorjH6jDo=--><b>shadow content</b><!--/lit-part--></template></my-content>
+        <my-container><template shadowrootmode="open"><!--lit-part Pz0gobCCM4E=--><slot></slot><!--/lit-part--></template>
+          <my-content><template shadowrootmode="open"><!--lit-part 8dHorjH6jDo=--><b>shadow content</b><!--/lit-part--></template></my-content>
         </my-container>
         <h1>Heading 2</h1>
-        <p><my-container><template shadowroot="open" shadowrootmode="open"><!--lit-part Pz0gobCCM4E=--><slot></slot><!--/lit-part--></template></my-container></p>
+        <p><my-container><template shadowrootmode="open"><!--lit-part Pz0gobCCM4E=--><slot></slot><!--/lit-part--></template></my-container></p>
       `)
     );
   });
@@ -430,7 +430,7 @@ modes.forEach((mode) => {
         await rig.read('_site/index.html'),
         normalize(`
           <h1>Heading</h1>
-          <p><my-element><template shadowroot="open" shadowrootmode="open"><!--lit-part QMmCfL7Whws=-->INITIAL<!--/lit-part--></template></my-element></p>
+          <p><my-element><template shadowrootmode="open"><!--lit-part QMmCfL7Whws=-->INITIAL<!--/lit-part--></template></my-element></p>
         `)
       );
     });
@@ -457,7 +457,7 @@ modes.forEach((mode) => {
           await rig.read('_site/index.html'),
           normalize(`
             <h1>Heading</h1>
-            <p><my-element><template shadowroot="open" shadowrootmode="open"><!--lit-part JDaFfBEPiAs=-->UPDATED<!--/lit-part--></template></my-element></p>
+            <p><my-element><template shadowrootmode="open"><!--lit-part JDaFfBEPiAs=-->UPDATED<!--/lit-part--></template></my-element></p>
           `)
         );
       });
@@ -516,8 +516,8 @@ modes.forEach((mode) => {
       await rig.read('_site/index.html'),
       normalize(`
         <h1>Heading</h1>
-        <my-element-1><template shadowroot="open" shadowrootmode="open"><!--lit-part wBkDjDE4LIw=--><b>shadow content 1</b><!--/lit-part--></template></my-element-1>
-        <my-element-2><template shadowroot="open" shadowrootmode="open"><!--lit-part gxUDjDE4LIw=--><b>shadow content 2</b><!--/lit-part--></template></my-element-2>
+        <my-element-1><template shadowrootmode="open"><!--lit-part wBkDjDE4LIw=--><b>shadow content 1</b><!--/lit-part--></template></my-element-1>
+        <my-element-2><template shadowrootmode="open"><!--lit-part gxUDjDE4LIw=--><b>shadow content 2</b><!--/lit-part--></template></my-element-2>
       `)
     );
   });
@@ -537,7 +537,7 @@ modes.forEach((mode) => {
         await rig.read(`_site/page${i}/index.html`),
         normalize(`
           <h1>Page ${i}</h1>
-          <p><my-element><template shadowroot="open" shadowrootmode="open"><!--lit-part 8dHorjH6jDo=--><b>shadow content</b><!--/lit-part--></template></my-element></p>
+          <p><my-element><template shadowrootmode="open"><!--lit-part 8dHorjH6jDo=--><b>shadow content</b><!--/lit-part--></template></my-element></p>
         `)
       );
     }

--- a/packages/labs/ssr-client/src/test/attribute-hydration_test.ts
+++ b/packages/labs/ssr-client/src/test/attribute-hydration_test.ts
@@ -46,7 +46,7 @@ suite(`ssr client hydration support`, () => {
           aria-label="foo" hydrate-internals-aria-label="foo"
           aria-roledescription="bar" hydrate-internals-aria-roledescription="bar"
           role="application" hydrate-internals-role="application">
-          <template shadowroot="open" shadowrootmode="open">
+          <template shadowrootmode="open">
             <style>:host{display:block}</style>
             <!--lit-part T5fUn6aagr0=--><div>Foo</div><!--/lit-part-->
           </template>

--- a/packages/labs/ssr-react/src/lib/node/render-custom-element.ts
+++ b/packages/labs/ssr-react/src/lib/node/render-custom-element.ts
@@ -84,7 +84,6 @@ export const renderCustomElement = (tagName: string, props: {} | null) => {
 
   const {mode = 'open', delegatesFocus} = renderer.shadowRootOptions;
   const templateAttributes = {
-    shadowroot: mode,
     shadowrootmode: mode,
     ...(delegatesFocus ? {shadowrootdelegatesfocus: ''} : {}),
   };

--- a/packages/labs/ssr-react/src/test/integration/enable-lit-ssr_test.tsx
+++ b/packages/labs/ssr-react/src/test/integration/enable-lit-ssr_test.tsx
@@ -25,7 +25,7 @@ const bareCEtest = suite('Bare custom elements');
 bareCEtest('single element', () => {
   assert.equal(
     ReactDOMServer.renderToString(<test-element />),
-    `<test-element><template shadowroot="open" shadowrootmode="open"><style>
+    `<test-element><template shadowrootmode="open"><style>
     p {
       color: blue;
     }
@@ -37,7 +37,7 @@ bareCEtest('single element', () => {
 bareCEtest('single element with prop', () => {
   assert.equal(
     ReactDOMServer.renderToString(<test-element name="World" />),
-    `<test-element name="World"><template shadowroot="open" shadowrootmode="open"><style>
+    `<test-element name="World"><template shadowrootmode="open"><style>
     p {
       color: blue;
     }
@@ -53,7 +53,7 @@ bareCEtest('single element within DOM element', () => {
         <test-element />
       </div>
     ),
-    `<div><test-element><template shadowroot="open" shadowrootmode="open"><style>
+    `<div><test-element><template shadowrootmode="open"><style>
     p {
       color: blue;
     }
@@ -67,7 +67,7 @@ bareCEtest('single element with string child', () => {
     ReactDOMServer.renderToString(
       <test-element>some string child</test-element>
     ),
-    `<test-element><template shadowroot="open" shadowrootmode="open"><style>
+    `<test-element><template shadowrootmode="open"><style>
     p {
       color: blue;
     }
@@ -83,7 +83,7 @@ bareCEtest('single element with element child', () => {
         <span>span child</span>
       </test-element>
     ),
-    `<test-element><template shadowroot="open" shadowrootmode="open"><style>
+    `<test-element><template shadowrootmode="open"><style>
     p {
       color: blue;
     }
@@ -100,7 +100,7 @@ bareCEtest('single element with multiple children', () => {
         <p>p</p>
       </test-element>
     ),
-    `<test-element><template shadowroot="open" shadowrootmode="open"><style>
+    `<test-element><template shadowrootmode="open"><style>
     p {
       color: blue;
     }
@@ -118,7 +118,7 @@ bareCEtest('single element with dynamic children', () => {
         ))}
       </test-element>
     ),
-    `<test-element><template shadowroot="open" shadowrootmode="open"><style>
+    `<test-element><template shadowrootmode="open"><style>
     p {
       color: blue;
     }
@@ -132,7 +132,7 @@ bareCEtest('single element with string child via props', () => {
     ReactDOMServer.renderToString(
       <test-element children="some string child"></test-element>
     ),
-    `<test-element><template shadowroot="open" shadowrootmode="open"><style>
+    `<test-element><template shadowrootmode="open"><style>
     p {
       color: blue;
     }
@@ -146,7 +146,7 @@ bareCEtest('single element with element child via props', () => {
     ReactDOMServer.renderToString(
       <test-element children={<span>span child</span>}></test-element>
     ),
-    `<test-element><template shadowroot="open" shadowrootmode="open"><style>
+    `<test-element><template shadowrootmode="open"><style>
     p {
       color: blue;
     }
@@ -167,7 +167,7 @@ bareCEtest('single element with multiple children via props', () => {
         }
       ></test-element>
     ),
-    `<test-element><template shadowroot="open" shadowrootmode="open"><style>
+    `<test-element><template shadowrootmode="open"><style>
     p {
       color: blue;
     }
@@ -185,7 +185,7 @@ bareCEtest('single element with dynamic children via props', () => {
         ))}
       ></test-element>
     ),
-    `<test-element><template shadowroot="open" shadowrootmode="open"><style>
+    `<test-element><template shadowrootmode="open"><style>
     p {
       color: blue;
     }
@@ -201,12 +201,12 @@ bareCEtest('child custom element', () => {
         <test-element />
       </test-element>
     ),
-    `<test-element><template shadowroot="open" shadowrootmode="open"><style>
+    `<test-element><template shadowrootmode="open"><style>
     p {
       color: blue;
     }
   </style><!--lit-part aHUgh01By8I=--><p>Hello, <!--lit-part-->Somebody<!--/lit-part-->!</p>
-      <slot></slot><!--/lit-part--></template><test-element><template shadowroot="open" shadowrootmode="open"><style>
+      <slot></slot><!--/lit-part--></template><test-element><template shadowrootmode="open"><style>
     p {
       color: blue;
     }
@@ -220,8 +220,8 @@ bareCEtest('nested custom element', () => {
   // proper hydration order from parent to child
   assert.equal(
     ReactDOMServer.renderToString(<parent-element />),
-    `<parent-element><template shadowroot="open" shadowrootmode="open"><!--lit-part VWvXc8PRUIg=--><p>Parent</p>
-      <!--lit-node 1--><child-element defer-hydration><template shadowroot="open" shadowrootmode="open"><!--lit-part z0Ym6Oo3MXM=--><p>Child</p><!--/lit-part--></template></child-element><!--/lit-part--></template></parent-element>`
+    `<parent-element><template shadowrootmode="open"><!--lit-part VWvXc8PRUIg=--><p>Parent</p>
+      <!--lit-node 1--><child-element defer-hydration><template shadowrootmode="open"><!--lit-part z0Ym6Oo3MXM=--><p>Child</p><!--/lit-part--></template></child-element><!--/lit-part--></template></parent-element>`
   );
 });
 
@@ -238,7 +238,7 @@ const ReactTestElement = createComponent({
 wrappedCEtest('wrapped element without prop', () => {
   assert.equal(
     ReactDOMServer.renderToString(<ReactTestElement />),
-    `<test-element><template shadowroot="open" shadowrootmode="open"><style>
+    `<test-element><template shadowrootmode="open"><style>
     p {
       color: blue;
     }
@@ -250,7 +250,7 @@ wrappedCEtest('wrapped element without prop', () => {
 wrappedCEtest('wrapped element with prop', () => {
   assert.equal(
     ReactDOMServer.renderToString(<ReactTestElement name="React" />),
-    `<test-element defer-hydration=""><template shadowroot="open" shadowrootmode="open"><style>
+    `<test-element defer-hydration=""><template shadowrootmode="open"><style>
     p {
       color: blue;
     }
@@ -264,7 +264,7 @@ wrappedCEtest('wrapped element with prop and attribute', () => {
     ReactDOMServer.renderToString(
       <ReactTestElement name="React" id="react-test-element" />
     ),
-    `<test-element id="react-test-element" defer-hydration=""><template shadowroot="open" shadowrootmode="open"><style>
+    `<test-element id="react-test-element" defer-hydration=""><template shadowrootmode="open"><style>
     p {
       color: blue;
     }
@@ -284,7 +284,7 @@ wrappedCEtest('wrapped element with object prop', () => {
     ReactDOMServer.renderToString(
       <ReactObjectTestElement user={{name: 'React'}} />
     ),
-    `<object-test-element defer-hydration=""><template shadowroot="open" shadowrootmode="open"><!--lit-part EvGichL14uw=--><p>Hello, <!--lit-part-->React<!--/lit-part-->!</p><!--/lit-part--></template></object-test-element>`
+    `<object-test-element defer-hydration=""><template shadowrootmode="open"><!--lit-part EvGichL14uw=--><p>Hello, <!--lit-part-->React<!--/lit-part-->!</p><!--/lit-part--></template></object-test-element>`
   );
 });
 

--- a/packages/labs/ssr-react/src/test/integration/runtime-jsx_test.tsx
+++ b/packages/labs/ssr-react/src/test/integration/runtime-jsx_test.tsx
@@ -19,7 +19,7 @@ import * as assert from 'uvu/assert';
 test('single element', () => {
   assert.equal(
     ReactDOMServer.renderToString(<test-element />),
-    `<test-element><template shadowroot="open" shadowrootmode="open"><style>
+    `<test-element><template shadowrootmode="open"><style>
     p {
       color: blue;
     }
@@ -31,7 +31,7 @@ test('single element', () => {
 test('single element with prop', () => {
   assert.equal(
     ReactDOMServer.renderToString(<test-element name="World" />),
-    `<test-element name="World"><template shadowroot="open" shadowrootmode="open"><style>
+    `<test-element name="World"><template shadowrootmode="open"><style>
     p {
       color: blue;
     }
@@ -47,7 +47,7 @@ test('single element within DOM element', () => {
         <test-element />
       </div>
     ),
-    `<div><test-element><template shadowroot="open" shadowrootmode="open"><style>
+    `<div><test-element><template shadowrootmode="open"><style>
     p {
       color: blue;
     }
@@ -61,7 +61,7 @@ test('single element with string child', () => {
     ReactDOMServer.renderToString(
       <test-element>some string child</test-element>
     ),
-    `<test-element><template shadowroot="open" shadowrootmode="open"><style>
+    `<test-element><template shadowrootmode="open"><style>
     p {
       color: blue;
     }
@@ -77,7 +77,7 @@ test('single element with element child', () => {
         <span>span child</span>
       </test-element>
     ),
-    `<test-element><template shadowroot="open" shadowrootmode="open"><style>
+    `<test-element><template shadowrootmode="open"><style>
     p {
       color: blue;
     }
@@ -94,7 +94,7 @@ test('single element with multiple children', () => {
         <p>p</p>
       </test-element>
     ),
-    `<test-element><template shadowroot="open" shadowrootmode="open"><style>
+    `<test-element><template shadowrootmode="open"><style>
     p {
       color: blue;
     }
@@ -112,7 +112,7 @@ test('single element with dynamic children', () => {
         ))}
       </test-element>
     ),
-    `<test-element><template shadowroot="open" shadowrootmode="open"><style>
+    `<test-element><template shadowrootmode="open"><style>
     p {
       color: blue;
     }
@@ -126,7 +126,7 @@ test('single element with string child via props', () => {
     ReactDOMServer.renderToString(
       <test-element children="some string child"></test-element>
     ),
-    `<test-element><template shadowroot="open" shadowrootmode="open"><style>
+    `<test-element><template shadowrootmode="open"><style>
     p {
       color: blue;
     }
@@ -140,7 +140,7 @@ test('single element with element child via props', () => {
     ReactDOMServer.renderToString(
       <test-element children={<span>span child</span>}></test-element>
     ),
-    `<test-element><template shadowroot="open" shadowrootmode="open"><style>
+    `<test-element><template shadowrootmode="open"><style>
     p {
       color: blue;
     }
@@ -161,7 +161,7 @@ test('single element with multiple children via props', () => {
         }
       ></test-element>
     ),
-    `<test-element><template shadowroot="open" shadowrootmode="open"><style>
+    `<test-element><template shadowrootmode="open"><style>
     p {
       color: blue;
     }
@@ -179,7 +179,7 @@ test('single element with dynamic children via props', () => {
         ))}
       ></test-element>
     ),
-    `<test-element><template shadowroot="open" shadowrootmode="open"><style>
+    `<test-element><template shadowrootmode="open"><style>
     p {
       color: blue;
     }
@@ -195,12 +195,12 @@ test('custom element child', () => {
         <test-element />
       </test-element>
     ),
-    `<test-element><template shadowroot="open" shadowrootmode="open"><style>
+    `<test-element><template shadowrootmode="open"><style>
     p {
       color: blue;
     }
   </style><!--lit-part aHUgh01By8I=--><p>Hello, <!--lit-part-->Somebody<!--/lit-part-->!</p>
-      <slot></slot><!--/lit-part--></template><test-element><template shadowroot="open" shadowrootmode="open"><style>
+      <slot></slot><!--/lit-part--></template><test-element><template shadowrootmode="open"><style>
     p {
       color: blue;
     }
@@ -214,8 +214,8 @@ test('nested custom element', () => {
   // proper hydration order from parent to child
   assert.equal(
     ReactDOMServer.renderToString(<parent-element />),
-    `<parent-element><template shadowroot="open" shadowrootmode="open"><!--lit-part VWvXc8PRUIg=--><p>Parent</p>
-      <!--lit-node 1--><child-element defer-hydration><template shadowroot="open" shadowrootmode="open"><!--lit-part z0Ym6Oo3MXM=--><p>Child</p><!--/lit-part--></template></child-element><!--/lit-part--></template></parent-element>`
+    `<parent-element><template shadowrootmode="open"><!--lit-part VWvXc8PRUIg=--><p>Parent</p>
+      <!--lit-node 1--><child-element defer-hydration><template shadowrootmode="open"><!--lit-part z0Ym6Oo3MXM=--><p>Child</p><!--/lit-part--></template></child-element><!--/lit-part--></template></parent-element>`
   );
 });
 

--- a/packages/labs/ssr/package.json
+++ b/packages/labs/ssr/package.json
@@ -215,7 +215,7 @@
     "@types/koa-static": "^4.0.1",
     "@types/node": "^20.0.0",
     "@types/resolve": "^1.20.2",
-    "@webcomponents/template-shadowroot": "^0.1.0",
+    "@webcomponents/template-shadowroot": "^0.2.1",
     "command-line-args": "^5.1.1",
     "deepmerge": "^4.2.2",
     "koa": "^2.7.0",

--- a/packages/labs/ssr/src/lib/render-value.ts
+++ b/packages/labs/ssr/src/lib/render-value.ts
@@ -325,7 +325,7 @@ const REGEXP_TEMPLATE_HAS_TOP_LEVEL_PAGE_TAG =
  * - `text`
  *   - Emit end of open tag `>`
  * - `custom-element-shadow`
- *   - Emit `renderer.renderShadow()` (emits `<template shadowroot>` +
+ *   - Emit `renderer.renderShadow()` (emits `<template shadowrootmode>` +
  *     recurses to emit `render()`)
  * - `text`
  *   - Emit run of static text within tag: `<div>child</div>...`
@@ -1034,7 +1034,7 @@ And the inner template was:
               ? ' shadowrootdelegatesfocus'
               : '';
             shadowResult.push(
-              `<template shadowroot="${mode}" shadowrootmode="${mode}"${delegatesfocusAttr}>`
+              `<template shadowrootmode="${mode}"${delegatesfocusAttr}>`
             );
             shadowResult.push(() => shadowContents);
             shadowResult.push('</template>');

--- a/packages/labs/ssr/src/test/lib/render-lit_test.ts
+++ b/packages/labs/ssr/src/test/lib/render-lit_test.ts
@@ -293,7 +293,7 @@ for (const global of [emptyVmGlobal, shimmedVmGlobal]) {
     });
     assert.is(
       result,
-      `<!--lit-part tjmYe1kHIVM=--><test-simple><template shadowroot="open" shadowrootmode="open"><!--lit-part UNbWrd8S5FY=--><main></main><!--/lit-part--></template></test-simple><!--/lit-part-->`
+      `<!--lit-part tjmYe1kHIVM=--><test-simple><template shadowrootmode="open"><!--lit-part UNbWrd8S5FY=--><main></main><!--/lit-part--></template></test-simple><!--/lit-part-->`
     );
     assert.is(customElementsRendered.length, 1);
     assert.is(customElementsRendered[0], 'test-simple');
@@ -307,7 +307,7 @@ for (const global of [emptyVmGlobal, shimmedVmGlobal]) {
     });
     assert.is(
       result,
-      `<!--lit-part tjmYe1kHIVM=--><test-simple defer-hydration><template shadowroot="open" shadowrootmode="open"><!--lit-part UNbWrd8S5FY=--><main></main><!--/lit-part--></template></test-simple><!--/lit-part-->`
+      `<!--lit-part tjmYe1kHIVM=--><test-simple defer-hydration><template shadowrootmode="open"><!--lit-part UNbWrd8S5FY=--><main></main><!--/lit-part--></template></test-simple><!--/lit-part-->`
     );
   });
 
@@ -336,7 +336,7 @@ for (const global of [emptyVmGlobal, shimmedVmGlobal]) {
     // TODO: we'd like to remove the extra space in the start tag
     assert.is(
       result,
-      `<!--lit-part v2CxGIW+qHI=--><!--lit-node 0--><test-property ><template shadowroot="open" shadowrootmode="open"><!--lit-part UNbWrd8S5FY=--><main><!--lit-part-->bar<!--/lit-part--></main><!--/lit-part--></template></test-property><!--/lit-part-->`
+      `<!--lit-part v2CxGIW+qHI=--><!--lit-node 0--><test-property ><template shadowrootmode="open"><!--lit-part UNbWrd8S5FY=--><main><!--lit-part-->bar<!--/lit-part--></main><!--/lit-part--></template></test-property><!--/lit-part-->`
     );
   });
 
@@ -346,7 +346,7 @@ for (const global of [emptyVmGlobal, shimmedVmGlobal]) {
     // TODO: we'd like to remove the extra space in the start tag
     assert.is(
       result,
-      `<!--lit-part ZI1U/5CYP1o=--><!--lit-node 0--><test-property  foo="bar"><template shadowroot="open" shadowrootmode="open"><!--lit-part UNbWrd8S5FY=--><main><!--lit-part-->bar<!--/lit-part--></main><!--/lit-part--></template></test-property><!--/lit-part-->`
+      `<!--lit-part ZI1U/5CYP1o=--><!--lit-node 0--><test-property  foo="bar"><template shadowrootmode="open"><!--lit-part UNbWrd8S5FY=--><main><!--lit-part-->bar<!--/lit-part--></main><!--/lit-part--></template></test-property><!--/lit-part-->`
     );
   });
 
@@ -356,7 +356,7 @@ for (const global of [emptyVmGlobal, shimmedVmGlobal]) {
     // TODO: we'd like to remove the extra space in the start tag
     assert.is(
       result,
-      `<!--lit-part ZI1U/5CYP1o=--><!--lit-node 0--><test-property  foo><template shadowroot="open" shadowrootmode="open"><!--lit-part UNbWrd8S5FY=--><main><!--lit-part--><!--/lit-part--></main><!--/lit-part--></template></test-property><!--/lit-part-->`
+      `<!--lit-part ZI1U/5CYP1o=--><!--lit-node 0--><test-property  foo><template shadowrootmode="open"><!--lit-part UNbWrd8S5FY=--><main><!--lit-part--><!--/lit-part--></main><!--/lit-part--></template></test-property><!--/lit-part-->`
     );
   });
 
@@ -366,7 +366,7 @@ for (const global of [emptyVmGlobal, shimmedVmGlobal]) {
     // TODO: we'd like to remove the extra space in the start tag
     assert.is(
       result,
-      `<!--lit-part ZI1U/5CYP1o=--><!--lit-node 0--><test-property  foo><template shadowroot="open" shadowrootmode="open"><!--lit-part UNbWrd8S5FY=--><main><!--lit-part--><!--/lit-part--></main><!--/lit-part--></template></test-property><!--/lit-part-->`
+      `<!--lit-part ZI1U/5CYP1o=--><!--lit-node 0--><test-property  foo><template shadowrootmode="open"><!--lit-part UNbWrd8S5FY=--><main><!--lit-part--><!--/lit-part--></main><!--/lit-part--></template></test-property><!--/lit-part-->`
     );
   });
 
@@ -376,7 +376,7 @@ for (const global of [emptyVmGlobal, shimmedVmGlobal]) {
     // TODO: we'd like to remove the extra space in the start tag
     assert.is(
       result,
-      `<!--lit-part ZI1U/5CYP1o=--><!--lit-node 0--><test-property  foo><template shadowroot="open" shadowrootmode="open"><!--lit-part UNbWrd8S5FY=--><main><!--lit-part--><!--/lit-part--></main><!--/lit-part--></template></test-property><!--/lit-part-->`
+      `<!--lit-part ZI1U/5CYP1o=--><!--lit-node 0--><test-property  foo><template shadowrootmode="open"><!--lit-part UNbWrd8S5FY=--><main><!--lit-part--><!--/lit-part--></main><!--/lit-part--></template></test-property><!--/lit-part-->`
     );
   });
 
@@ -431,7 +431,7 @@ for (const global of [emptyVmGlobal, shimmedVmGlobal]) {
     // TODO: we'd like to remove the extra space in the start tag
     assert.is(
       result,
-      `<!--lit-part 7z41MJchKXM=--><!--lit-node 0--><test-reflected-properties   bar baz="default reflected string" reflect-foo="badazzled"><template shadowroot="open" shadowrootmode="open"><!--lit-part--><!--/lit-part--></template></test-reflected-properties><!--/lit-part-->`
+      `<!--lit-part 7z41MJchKXM=--><!--lit-node 0--><test-reflected-properties   bar baz="default reflected string" reflect-foo="badazzled"><template shadowrootmode="open"><!--lit-part--><!--/lit-part--></template></test-reflected-properties><!--/lit-part-->`
     );
   });
 
@@ -440,7 +440,7 @@ for (const global of [emptyVmGlobal, shimmedVmGlobal]) {
     const result = await render(elementWithDefaultReflectedProperties);
     assert.is(
       result,
-      `<!--lit-part tktTsdmfB74=--><test-reflected-properties baz="default reflected string"><template shadowroot="open" shadowrootmode="open"><!--lit-part--><!--/lit-part--></template></test-reflected-properties><!--/lit-part-->`
+      `<!--lit-part tktTsdmfB74=--><test-reflected-properties baz="default reflected string"><template shadowrootmode="open"><!--lit-part--><!--/lit-part--></template></test-reflected-properties><!--/lit-part-->`
     );
   });
 
@@ -450,7 +450,7 @@ for (const global of [emptyVmGlobal, shimmedVmGlobal]) {
     // TODO: we'd like to remove the extra space in the start tag
     assert.is(
       result,
-      `<!--lit-part Q0bbGrx71ic=--><!--lit-node 0--><test-will-update  ><template shadowroot="open" shadowrootmode="open"><!--lit-part UNbWrd8S5FY=--><main><!--lit-part-->Foo Bar<!--/lit-part--></main><!--/lit-part--></template></test-will-update><!--/lit-part-->`
+      `<!--lit-part Q0bbGrx71ic=--><!--lit-node 0--><test-will-update  ><template shadowrootmode="open"><!--lit-part UNbWrd8S5FY=--><main><!--lit-part-->Foo Bar<!--/lit-part--></main><!--/lit-part--></template></test-will-update><!--/lit-part-->`
     );
   });
 
@@ -463,25 +463,25 @@ for (const global of [emptyVmGlobal, shimmedVmGlobal]) {
     const result = await render(noSlot);
     assert.is(
       result,
-      `<!--lit-part OpS0yFtM48Q=--><test-simple><template shadowroot="open" shadowrootmode="open"><!--lit-part UNbWrd8S5FY=--><main></main><!--/lit-part--></template><p>Hi</p></test-simple><!--/lit-part-->`
+      `<!--lit-part OpS0yFtM48Q=--><test-simple><template shadowrootmode="open"><!--lit-part UNbWrd8S5FY=--><main></main><!--/lit-part--></template><p>Hi</p></test-simple><!--/lit-part-->`
     );
   });
 
-  test('shadowroot="open"', async () => {
+  test('shadowrootmode="open"', async () => {
     const {render, shadowrootOpen} = await setup();
     const result = await render(shadowrootOpen);
     assert.is(
       result,
-      `<!--lit-part eTOxy3auvsY=--><test-shadowroot-open><template shadowroot="open" shadowrootmode="open"><!--lit-part--><!--/lit-part--></template></test-shadowroot-open><!--/lit-part-->`
+      `<!--lit-part eTOxy3auvsY=--><test-shadowroot-open><template shadowrootmode="open"><!--lit-part--><!--/lit-part--></template></test-shadowroot-open><!--/lit-part-->`
     );
   });
 
-  test('shadowroot="closed"', async () => {
+  test('shadowrootmode="closed"', async () => {
     const {render, shadowrootClosed} = await setup();
     const result = await render(shadowrootClosed);
     assert.is(
       result,
-      `<!--lit-part 35tY6VC7KzI=--><test-shadowroot-closed><template shadowroot="closed" shadowrootmode="closed"><!--lit-part--><!--/lit-part--></template></test-shadowroot-closed><!--/lit-part-->`
+      `<!--lit-part 35tY6VC7KzI=--><test-shadowroot-closed><template shadowrootmode="closed"><!--lit-part--><!--/lit-part--></template></test-shadowroot-closed><!--/lit-part-->`
     );
   });
 
@@ -490,7 +490,7 @@ for (const global of [emptyVmGlobal, shimmedVmGlobal]) {
     const result = await render(shadowrootdelegatesfocus);
     assert.is(
       result,
-      `<!--lit-part Nim07tlWyJ0=--><test-shadowrootdelegatesfocus><template shadowroot="open" shadowrootmode="open" shadowrootdelegatesfocus><!--lit-part--><!--/lit-part--></template></test-shadowrootdelegatesfocus><!--/lit-part-->`
+      `<!--lit-part Nim07tlWyJ0=--><test-shadowrootdelegatesfocus><template shadowrootmode="open" shadowrootdelegatesfocus><!--lit-part--><!--/lit-part--></template></test-shadowrootdelegatesfocus><!--/lit-part-->`
     );
   });
 
@@ -504,12 +504,12 @@ for (const global of [emptyVmGlobal, shimmedVmGlobal]) {
       const result = await render(eventParentAndSingleChildWithoutValue);
       assert.is(
         result,
-        '<!--lit-part RSGZngXXsLg=--><test-events-parent><template shadowroot="open" shadowrootmode="open"><style>\n' +
+        '<!--lit-part RSGZngXXsLg=--><test-events-parent><template shadowrootmode="open"><style>\n' +
           '    :host {\n' +
           '      display: block;\n' +
           '    }\n' +
           '  </style><!--lit-part LLTdYazTGBk=--><main><slot></slot></main><!--/lit-part--></template>' +
-          '<test-events-child data-test><template shadowroot="open" shadowrootmode="open"><!--lit-part Ux1Wl2m85Zk=--><div>events child</div><!--/lit-part--></template></test-events-child></test-events-parent><!--/lit-part-->'
+          '<test-events-child data-test><template shadowrootmode="open"><!--lit-part Ux1Wl2m85Zk=--><div>events child</div><!--/lit-part--></template></test-events-child></test-events-parent><!--/lit-part-->'
       );
       // structuredClone is necessary, as the identity across module loader is not equal.
       assert.equal(structuredClone(eventPath), [
@@ -535,12 +535,12 @@ for (const global of [emptyVmGlobal, shimmedVmGlobal]) {
       const result = await render(eventParentAndSingleChildWithValue);
       assert.is(
         result,
-        '<!--lit-part pLrHZ32UrRU=--><test-events-parent  value="my-test"><template shadowroot="open" shadowrootmode="open"><style>\n' +
+        '<!--lit-part pLrHZ32UrRU=--><test-events-parent  value="my-test"><template shadowrootmode="open"><style>\n' +
           '    :host {\n' +
           '      display: block;\n' +
           '    }\n' +
           '  </style><!--lit-part LLTdYazTGBk=--><main><slot></slot></main><!--/lit-part--></template>' +
-          '<test-events-child data-test="my-test"><template shadowroot="open" shadowrootmode="open"><!--lit-part Ux1Wl2m85Zk=--><div>events child</div><!--/lit-part--></template></test-events-child></test-events-parent><!--/lit-part-->'
+          '<test-events-child data-test="my-test"><template shadowrootmode="open"><!--lit-part Ux1Wl2m85Zk=--><div>events child</div><!--/lit-part--></template></test-events-child></test-events-parent><!--/lit-part-->'
       );
       // structuredClone is necessary, as the identity across module loader is not equal.
       assert.equal(structuredClone(eventPath), [
@@ -565,17 +565,17 @@ for (const global of [emptyVmGlobal, shimmedVmGlobal]) {
       const result = await render(eventParentNesting);
       assert.is(
         result,
-        '<!--lit-part 4D0mmmUOBvU=--><test-events-parent   capture="oc" value="ov"><template shadowroot="open" shadowrootmode="open"><style>\n' +
+        '<!--lit-part 4D0mmmUOBvU=--><test-events-parent   capture="oc" value="ov"><template shadowrootmode="open"><style>\n' +
           '    :host {\n' +
           '      display: block;\n' +
           '    }\n' +
           '  </style><!--lit-part LLTdYazTGBk=--><main><slot></slot></main><!--/lit-part--></template>\n' +
-          '  <test-events-parent   capture="ic" value="iv"><template shadowroot="open" shadowrootmode="open"><style>\n' +
+          '  <test-events-parent   capture="ic" value="iv"><template shadowrootmode="open"><style>\n' +
           '    :host {\n' +
           '      display: block;\n' +
           '    }\n' +
           '  </style><!--lit-part LLTdYazTGBk=--><main><slot></slot></main><!--/lit-part--></template>' +
-          '<test-events-child data-test="ocicivov"><template shadowroot="open" shadowrootmode="open"><!--lit-part Ux1Wl2m85Zk=--><div>events child</div><!--/lit-part--></template></test-events-child>' +
+          '<test-events-child data-test="ocicivov"><template shadowrootmode="open"><!--lit-part Ux1Wl2m85Zk=--><div>events child</div><!--/lit-part--></template></test-events-child>' +
           '</test-events-parent></test-events-parent><!--/lit-part-->'
       );
       // structuredClone is necessary, as the identity across module loader is not equal.
@@ -605,19 +605,19 @@ for (const global of [emptyVmGlobal, shimmedVmGlobal]) {
       const result = await render(eventShadowNested);
       assert.is(
         result,
-        '<!--lit-part QSPfkaBogFk=--><test-events-parent  value="my-test"><template shadowroot="open" shadowrootmode="open"><style>\n' +
+        '<!--lit-part QSPfkaBogFk=--><test-events-parent  value="my-test"><template shadowrootmode="open"><style>\n' +
           '    :host {\n' +
           '      display: block;\n' +
           '    }\n' +
           '  </style><!--lit-part LLTdYazTGBk=--><main><slot></slot></main><!--/lit-part--></template>' +
-          '<test-events-shadow-nested><template shadowroot="open" shadowrootmode="open"><!--lit-part GQHLzN3QO5Q=--><slot></slot><!--lit-node 1--><test-events-parent  value="shadow" defer-hydration>' +
-          '<template shadowroot="open" shadowrootmode="open"><style>\n' +
+          '<test-events-shadow-nested><template shadowrootmode="open"><!--lit-part GQHLzN3QO5Q=--><slot></slot><!--lit-node 1--><test-events-parent  value="shadow" defer-hydration>' +
+          '<template shadowrootmode="open"><style>\n' +
           '    :host {\n' +
           '      display: block;\n' +
           '    }\n' +
           '  </style><!--lit-part LLTdYazTGBk=--><main><slot></slot></main><!--/lit-part--></template><slot name="a"></slot></test-events-parent><!--/lit-part--></template>\n' +
-          '  <div><test-events-child data-test="my-test"><template shadowroot="open" shadowrootmode="open"><!--lit-part Ux1Wl2m85Zk=--><div>events child</div><!--/lit-part--></template></test-events-child>' +
-          '</div><div slot="a"><test-events-child data-test="shadowmy-test"><template shadowroot="open" shadowrootmode="open"><!--lit-part Ux1Wl2m85Zk=--><div>events child</div><!--/lit-part--></template></test-events-child></div>\n' +
+          '  <div><test-events-child data-test="my-test"><template shadowrootmode="open"><!--lit-part Ux1Wl2m85Zk=--><div>events child</div><!--/lit-part--></template></test-events-child>' +
+          '</div><div slot="a"><test-events-child data-test="shadowmy-test"><template shadowrootmode="open"><!--lit-part Ux1Wl2m85Zk=--><div>events child</div><!--/lit-part--></template></test-events-child></div>\n' +
           '  </test-events-shadow-nested></test-events-parent><!--/lit-part-->'
       );
       // structuredClone is necessary, as the identity across module loader is not equal.

--- a/packages/labs/testing/package.json
+++ b/packages/labs/testing/package.json
@@ -109,7 +109,7 @@
     "@lit-labs/ssr": "^4.0.0",
     "@lit-labs/ssr-client": "^1.1.4",
     "@web/test-runner-commands": "^0.6.1",
-    "@webcomponents/template-shadowroot": "^0.1.0",
+    "@webcomponents/template-shadowroot": "^0.2.1",
     "lit": "^2.0.0 || ^3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
resolves #4352 

1. Remove references to `shadowroot`
1. Bump all versions of **@webcomponents/template-shadowroot** to latest (0.2.1)

----

**RESOLVED**

After these changes, all expected test cases pass, but locally I am getting a bunch of errors around integration tests that look like this (will reach out on the Discord for more help)

<details>
<pre>
Running tests...

test/integration/client/basic-global-unshimmed_test.js:

 ❌ basic: global > AttributePart on void element in shadow root (failed on Chromium and Firefox)
      AssertionError: expected '<void-element-host>\n  <template shadowrootmode="open">\n  </template>\n</void-element-host>\n' to equal '<void-element-host>\n</void-element-host>\n'
      + expected - actual
      
       <void-element-host>
      -  <template shadowrootmode="open">
      -  </template>
       </void-element-host>
      
      at Object.assertHtmlEquals (../../../node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:76:17)
      at Object.equal (../../../node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:245:31)
      at assertLightDom (src/test/integration/client/setup.ts:88:18)
      at assertHTML (src/test/integration/client/setup.ts:134:4)
      at o.<anonymous> (src/test/integration/client/setup.ts:285:10)

 ❌ basic: global > AttributePart on raw text element in shadow root (failed on Chromium and Firefox)
      AssertionError: expected '<raw-element-host>\n  <template shadowrootmode="open">\n  </template>\n</raw-element-host>\n' to equal '<raw-element-host>\n</raw-element-host>\n'
      + expected - actual
      
       <raw-element-host>
      -  <template shadowrootmode="open">
      -  </template>
       </raw-element-host>
      
      at Object.assertHtmlEquals (../../../node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:76:17)
      at Object.equal (../../../node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:245:31)
      at assertLightDom (src/test/integration/client/setup.ts:88:18)
      at assertHTML (src/test/integration/client/setup.ts:134:4)
      at o.<anonymous> (src/test/integration/client/setup.ts:285:10)

 ❌ basic: global > LitElement: Basic (failed on Chromium and Firefox)
      AssertionError: expected '<le-basic>\n  <template shadowrootmode="open">\n  </template>\n  x\n</le-basic>\n' to equal '<le-basic>\n  x\n</le-basic>\n'
      + expected - actual
      
       <le-basic>
      -  <template shadowrootmode="open">
      -  </template>
         x
       </le-basic>
      
      at Object.assertHtmlEquals (../../../node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:76:17)
      at Object.equal (../../../node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:245:31)
      at assertLightDom (src/test/integration/client/setup.ts:88:18)
      at assertHTML (src/test/integration/client/setup.ts:158:8)
      at o.<anonymous> (src/test/integration/client/setup.ts:285:10)
      
// ...
</pre>
</details>