### PR TITLE
[labs/ssr] Add configuration on LitElementRenderer for calling connectedCallback on LitElement subclasses

### DIFF
--- a/.changeset/great-hotels-tan.md
+++ b/.changeset/great-hotels-tan.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/ssr': minor
+---
+
+Add configuration on LitElementRenderer for disabling SSR or calling connectedCallback on LitElement subclasses

--- a/packages/labs/ssr/README.md
+++ b/packages/labs/ssr/README.md
@@ -272,6 +272,37 @@ In the future we may introduce APIs like `renderToString()` and
 `renderToStream()` that eliminate the need to expose the underlying
 representation.
 
+## LitElementRenderer Configuration
+
+The `LitElementRenderer` has the static property `renderOptions`, which accepts
+callback functions with the element instance to be rendered as the parameter.
+A callback can return an object to indicate the render options for the given
+element or `undefined` to let the next callback evaluate it or fall back to
+the default options.
+
+By default, the `connectedCallback` method is not called during SSR. To enable
+calling `connectedCallback`, return an object with `connectedCallback` set to
+`true`.
+
+```js
+import {LitElementRenderer} from '@lit-labs/ssr';
+
+LitElementRenderer.renderOptions.push((element) =>
+  element.localName === 'my-element' ? {connectedCallback: true} : undefined
+);
+```
+
+To disable rendering an element during SSR, return an object with `disableSsr`
+set to `true`.
+
+```js
+import {LitElementRenderer} from '@lit-labs/ssr';
+
+LitElementRenderer.renderOptions.push((element) =>
+  element.localName === 'my-element' ? {disableSsr: true} : undefined
+);
+```
+
 ## Notes and limitations
 
 Please note the following current limitations with the SSR package:
@@ -286,5 +317,5 @@ Please note the following current limitations with the SSR package:
   - Be aware that you cannot mutate a parent via events, due to the way we stream data via SSR. This means only a use case like `@lit/context` is supported, where events are used to pass data from a parent back to a child to use in its rendering.
   - The DOM tree is not fully formed and the `event.composedPath()` returns a simplified tree, only containing the custom elements.
   - As an alternative to `document.documentElement` or `document.body` (which are expected to be undefined in the server environment) for global event listeners (e.g. for `@lit/context ContextProvider`), you can use the global variable `globalThis.litServerRoot` which is (only) available during SSR (e.g. `new ContextProvider(isServer ? globalThis.litServerRoot : document.body, {...})`).
-- **connectedCallback Opt-In**: We provide an opt-in for calling `connectedCallback`, which can be enabled via `globalThis.litSsrCallConnectedCallback = true;`. This will enable calling `connectedCallback` (and the `hostConnected` hook for controllers, but not the `hostUpdate` hook) on the server. This e.g. enables using `@lit/context` on the server.
+- **connectedCallback Opt-In**: We provide an opt-in for calling `connectedCallback`, as seen above in `LitElementRenderer Configuration`. Configuring this enables calling `connectedCallback` (and the `hostConnected` hook for controllers, but not the `hostUpdate` hook) on the server. This e.g. enables using `@lit/context` on the server.
 - **Patterns for usage**: As mentioned above under "Status", we intend to flesh out a number of common patterns for using this package, and provide appropriate APIs and documentation for these as the package reaches maturity. Concerns like server/client data management, incremental loading and hydration, etc. are currently beyond the scope of what this package offers, but we believe it should support building these patterns on top of it going forward. Please [file issues](https://github.com/lit/lit/issues/new/choose) for ideas, suggestions, and use cases you may encounter.

--- a/packages/labs/ssr/src/index.ts
+++ b/packages/labs/ssr/src/index.ts
@@ -6,4 +6,5 @@
 
 export * from './lib/render.js';
 export {ElementRenderer} from './lib/element-renderer.js';
+export {LitElementRenderer} from './lib/lit-element-renderer.js';
 export * from './lib/server-template.js';

--- a/packages/labs/ssr/src/lib/lit-element-renderer.ts
+++ b/packages/labs/ssr/src/lib/lit-element-renderer.ts
@@ -36,15 +36,59 @@ LitElement.prototype['createRenderRoot'] = function () {
 };
 
 /**
+ * The render options for a specific element in LitElementRenderer.
+ */
+export interface LitElementRendererRenderOptions {
+  /**
+   * Whether to call connectedCallback during SSR.
+   * @default false
+   */
+  connectedCallback?: boolean;
+  /**
+   * Whether to disable SSR for the element.
+   * @default false
+   */
+  disableSsr?: boolean;
+}
+
+/**
  * ElementRenderer implementation for LitElements
  */
 export class LitElementRenderer extends ElementRenderer {
   override element: LitElement;
 
+  private _disabled = false;
+
   static override matchesClass(ctor: typeof HTMLElement) {
     // This property needs to remain unminified.
     return (ctor as unknown as typeof LitElement)['_$litElement$'];
   }
+
+  /**
+   * Configure options for specific elements.
+   * Callbacks are called in order for each element being rendered and can be
+   * used to configure options such as whether to call connectedCallback for
+   * a given element or to disable SSR.
+   *
+   * @example
+   *
+   * ```ts
+   * import {LitElementRenderer} from '@lit-labs/ssr';
+   *
+   * // Disable SSR for `my-element`.
+   * LitElementRenderer.renderOptions.push(
+   *   (element) => element.localName === 'my-element' ? {disableSsr: true} : undefined
+   * );
+   *
+   * // Call connectedCallback for `my-element` by returning an options object with `connectedCallback` set to true.
+   * LitElementRenderer.renderOptions.push(
+   *   (element) => element.localName === 'my-element' ? {connectedCallback: true} : undefined
+   * );
+   * ```
+   */
+  static readonly renderOptions: ((
+    element: LitElement
+  ) => LitElementRendererRenderOptions | undefined)[] = [];
 
   constructor(tagName: string) {
     super(tagName);
@@ -82,9 +126,31 @@ export class LitElementRenderer extends ElementRenderer {
   }
 
   override connectedCallback() {
-    // Optionally call connectedCallback via setting: `litSsrCallConnectedCallback`
-    // Enable this flag to process events dispatched handled via connectedCallback.
     if (globalThis.litSsrCallConnectedCallback) {
+      console.warn(
+        'litSsrCallConnectedCallback is deprecated. ' +
+          'Please use LitElementRenderer.renderOptions instead.'
+      );
+    }
+
+    let renderOptions: LitElementRendererRenderOptions | undefined;
+    for (const optionsCallback of LitElementRenderer.renderOptions) {
+      const options = optionsCallback(this.element);
+      if (options) {
+        renderOptions = options;
+        break;
+      }
+    }
+
+    if (renderOptions?.disableSsr) {
+      this._disabled = true;
+      return;
+    }
+
+    if (
+      globalThis.litSsrCallConnectedCallback ||
+      renderOptions?.connectedCallback
+    ) {
       // Prevent enabling asynchronous updating by overriding enableUpdating
       // with a no-op.
       this.element['enableUpdating'] = function () {};
@@ -95,9 +161,10 @@ export class LitElementRenderer extends ElementRenderer {
         const className = this.element.constructor.name;
         console.warn(
           `Calling ${className}.connectedCallback() resulted in a thrown ` +
-            'error. Consider removing `litSsrCallConnectedCallback` to ' +
-            'prevent calling connectedCallback or add isServer checks to ' +
-            'your code to prevent calling browser API during SSR.'
+            'error. Consider configuring `LitElementRenderer.renderOptions` ' +
+            'to prevent calling connectedCallback for unsupported elements ' +
+            'or add isServer checks to your code to prevent calling browser ' +
+            'API during SSR.'
         );
         throw e;
       }
@@ -121,7 +188,13 @@ export class LitElementRenderer extends ElementRenderer {
     attributeToProperty(this.element as LitElement, name, value);
   }
 
-  override renderShadow(renderInfo: RenderInfo): ThunkedRenderResult {
+  override renderShadow(
+    renderInfo: RenderInfo
+  ): ThunkedRenderResult | undefined {
+    if (this._disabled) {
+      return undefined;
+    }
+
     const result: ThunkedRenderResult = [];
     // Render styles.
     const styles = (this.element.constructor as typeof LitElement)

--- a/packages/labs/ssr/src/test/lib/render-lit_test.ts
+++ b/packages/labs/ssr/src/test/lib/render-lit_test.ts
@@ -1278,6 +1278,60 @@ for (const global of [emptyVmGlobal, shimmedVmGlobal]) {
       render(renderServerOnlyElementPart);
     }, /Server-only templates don't support element parts/);
   });
+
+  /* Render Options */
+
+  test('enable connectedCallback for specific element', async () => {
+    const {
+      render,
+      eventParentAndChildrenForCallbackConnectedFilter,
+      setupEvents,
+    } = await setup();
+    const {eventPath, reset} = setupEvents({
+      connectedCallbackElement: 'test-events-child',
+    });
+    try {
+      const result = await render(
+        eventParentAndChildrenForCallbackConnectedFilter
+      );
+      assert.is(
+        result,
+        '<!--lit-part gZU30y7yqRY=--><test-events-parent><template shadowroot="open" shadowrootmode="open"><style>\n' +
+          '    :host {\n' +
+          '      display: block;\n' +
+          '    }\n' +
+          '  </style><!--lit-part LLTdYazTGBk=--><main><slot></slot></main><!--/lit-part--></template>' +
+          '<test-events-child data-test><template shadowroot="open" shadowrootmode="open"><!--lit-part Ux1Wl2m85Zk=-->' +
+          '<div>events child</div><!--/lit-part--></template></test-events-child>' +
+          '<test-events-child-inert><template shadowroot="open" shadowrootmode="open"><!--lit-part qwEoALVvGsQ=--><div>events child inert</div><!--/lit-part--></template>' +
+          '</test-events-child-inert></test-events-parent><!--/lit-part-->'
+      );
+      // structuredClone is necessary, as the identity across module loader is not equal.
+      assert.equal(structuredClone(eventPath), [
+        'lit-server-root/capture/CAPTURING_PHASE/test-events-child{id:1}',
+        'test-events-parent{id:0}/capture/CAPTURING_PHASE/test-events-child{id:1}',
+        'slot{id:2,host:test-events-parent}/capture/CAPTURING_PHASE/test-events-child{id:1}',
+        'test-events-child{id:1}/capture/AT_TARGET/test-events-child{id:1}',
+        'test-events-child{id:1}/non-capture/AT_TARGET/test-events-child{id:1}',
+        'slot{id:2,host:test-events-parent}/non-capture/BUBBLING_PHASE/test-events-child{id:1}',
+        'test-events-parent{id:0}/non-capture/BUBBLING_PHASE/test-events-child{id:1}',
+        'lit-server-root/non-capture/BUBBLING_PHASE/test-events-child{id:1}',
+      ]);
+    } finally {
+      reset();
+    }
+  });
+
+  test('disable SSR for specific element', async () => {
+    const {render, noSsrTemplate, setupExclusion} = await setup();
+    using _ = setupExclusion();
+    const result = await render(noSsrTemplate);
+    assert.is(
+      result,
+      '<!--lit-part 2fjWohnOnvA=--><test-simple><template shadowroot="open" shadowrootmode="open"><!--lit-part UNbWrd8S5FY=--><main></main><!--/lit-part--></template></test-simple>' +
+        '<no-ssr></no-ssr><!--/lit-part-->'
+    );
+  });
 }
 
 test.run();

--- a/packages/labs/ssr/src/test/test-files/render-test-module.ts
+++ b/packages/labs/ssr/src/test/test-files/render-test-module.ts
@@ -12,6 +12,7 @@ import {LitElement, css, PropertyValues} from 'lit';
 import {property, customElement} from 'lit/decorators.js';
 import type {HTMLElementWithEventMeta} from '@lit-labs/ssr-dom-shim';
 import {html as serverhtml} from '../../lib/server-template.js';
+import {LitElementRenderer} from '../../lib/lit-element-renderer.js';
 export {digestForTemplateResult} from '@lit-labs/ssr-client';
 
 export {renderThunked as render} from '../../lib/render.js';
@@ -233,13 +234,21 @@ let nextId = 0;
 // Pattern: element-name{id,host?}/capture/eventPhase/target{id}
 let eventPath: string[] = [];
 
-export const setupEvents = () => {
+export const setupEvents = (options?: {connectedCallbackElement?: string}) => {
   nextId = 0;
   eventPath = [];
-  globalThis.litSsrCallConnectedCallback = true;
+  if (options?.connectedCallbackElement) {
+    LitElementRenderer.renderOptions.push((element) =>
+      element.localName === options.connectedCallbackElement
+        ? {connectedCallback: true}
+        : undefined
+    );
+  } else {
+    LitElementRenderer.renderOptions.push(() => ({connectedCallback: true}));
+  }
   return {
     eventPath,
-    reset: () => delete globalThis.litSsrCallConnectedCallback,
+    reset: () => (LitElementRenderer.renderOptions.length = 0),
   };
 };
 
@@ -371,6 +380,14 @@ export class TestEventsChild extends EventTargetTestBase {
   }
 }
 
+@customElement('test-events-child-inert')
+export class TestEventsChildInert extends TestEventsChild {
+  override render() {
+    // prettier-ignore
+    return html`<div>events child inert</div>`;
+  }
+}
+
 @customElement('test-events-shadow-nested')
 export class TestEventsShadowNested extends EventTargetTestBase {
   override render() {
@@ -405,6 +422,9 @@ export class TestEventsNestedSlots extends EventTargetTestBase {
 
 // prettier-ignore
 export const eventParentAndSingleChildWithoutValue = html`<test-events-parent><test-events-child></test-events-child></test-events-parent>`;
+
+// prettier-ignore
+export const eventParentAndChildrenForCallbackConnectedFilter = html`<test-events-parent><test-events-child></test-events-child><test-events-child-inert></test-events-child-inert></test-events-parent>`;
 
 // prettier-ignore
 export const eventParentAndSingleChildWithValue = html`<test-events-parent value="my-test"><test-events-child></test-events-child></test-events-parent>`;
@@ -656,3 +676,26 @@ export const renderServerScriptNotJavaScript = serverhtml`
 // This doesn't have to make sense, the test is that it'll throw at the
 // template preparation phase.
 export const renderServerOnlyElementPart = serverhtml`<div ${'foo'}></div>`;
+
+/* Render Options */
+
+export const setupExclusion = () => {
+  LitElementRenderer.renderOptions.push((element) =>
+    element.localName === 'no-ssr' ? {disableSsr: true} : undefined
+  );
+  return {
+    [Symbol.dispose]() {
+      LitElementRenderer.renderOptions.length = 0;
+    },
+  };
+};
+
+@customElement('no-ssr')
+export class NoSsr extends LitElement {
+  override render() {
+    // prettier-ignore
+    return html`<main></main>`;
+  }
+}
+
+export const noSsrTemplate = html`<test-simple></test-simple><no-ssr></no-ssr>`;


### PR DESCRIPTION
This PR introduces the static property `renderOptions?: ((element: LitElement) => LitElementRendererRenderOptions | undefined)[]` on `LitElementRenderer`. This allows an easier or more fine granular configuration for which elements `connectedCallback` should be called or SSR should be skipped.

This PR also deprecates `globalThis.litSsrCallConnectedCallback` as `LitElementRenderer.renderOptions` is a full replacement.

Closes #5175 (more utility is planned, but that might take longer to get consensus)