### PR TITLE
[labs/virtualizer] Add child positioning method API (#4839)

### DIFF
--- a/.changeset/add-child-positioning-method.md
+++ b/.changeset/add-child-positioning-method.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/virtualizer': minor
+---
+
+- Added a `positioning` property (`'translate'` | `'absolute'`) that controls how child elements are positioned. Default is `'translate'` (CSS `transform: translate()`); `'absolute'` uses CSS `left`/`top` instead. ([#4839](https://github.com/lit/lit/issues/4839))

--- a/packages/labs/virtualizer/src/LitVirtualizer.ts
+++ b/packages/labs/virtualizer/src/LitVirtualizer.ts
@@ -19,6 +19,8 @@ import {
   defaultRenderItem,
   defaultKeyFunction,
   RenderItemFunction,
+  ChildPositioningMethod,
+  defaultChildPositioningMethod,
 } from './virtualize.js';
 
 export class LitVirtualizer<T = unknown> extends LitElement {
@@ -54,12 +56,29 @@ export class LitVirtualizer<T = unknown> extends LitElement {
   @property({attribute: false})
   pin: PinOptions | undefined;
 
+  /**
+   * Controls how the virtualizer positions its child elements.
+   * - `'translate'` (default): uses CSS `transform: translate()`.
+   * - `'absolute'`: uses CSS `left` and `top` properties.
+   */
+  @property()
+  positioning: ChildPositioningMethod = defaultChildPositioningMethod;
+
   createRenderRoot() {
     return this;
   }
 
   render() {
-    const {items, renderItem, keyFunction, layout, scroller, axis, pin} = this;
+    const {
+      items,
+      renderItem,
+      keyFunction,
+      layout,
+      scroller,
+      axis,
+      pin,
+      positioning,
+    } = this;
     return html`${virtualize({
       items,
       renderItem,
@@ -68,6 +87,7 @@ export class LitVirtualizer<T = unknown> extends LitElement {
       scroller,
       axis,
       pin,
+      positioning,
     })}`;
   }
 

--- a/packages/labs/virtualizer/src/Virtualizer.ts
+++ b/packages/labs/virtualizer/src/Virtualizer.ts
@@ -97,6 +97,10 @@ export interface VirtualizerHostElement extends HTMLElement {
  * a call that looks and behaves essentially the same as for
  * a real Element. May be useful for other things later.
  */
+export type ChildPositioningMethod = 'absolute' | 'translate';
+export const defaultChildPositioningMethod: ChildPositioningMethod =
+  'translate';
+
 export interface VirtualizerChildElementProxy {
   scrollIntoView: (options?: ScrollIntoViewOptions) => void;
 }
@@ -137,6 +141,13 @@ export interface VirtualizerConfig {
    * fires an `unpinned` event.
    */
   pin?: PinOptions;
+
+  /**
+   * Controls how the virtualizer positions its child elements.
+   * - `'translate'` (default): uses CSS `transform: translate()`.
+   * - `'absolute'`: uses CSS `left` and `top` properties.
+   */
+  positioning?: ChildPositioningMethod;
 }
 
 let DefaultLayoutConstructor: LayoutConstructor;
@@ -151,6 +162,9 @@ let DefaultLayoutConstructor: LayoutConstructor;
  */
 export class Virtualizer {
   private _warnings = new InstanceWarnings();
+
+  private _childPositioningMethod: ChildPositioningMethod =
+    defaultChildPositioningMethod;
 
   private _benchmarkStart: number | null = null;
 
@@ -450,6 +464,8 @@ export class Virtualizer {
 
   _init(config: VirtualizerConfig) {
     this._isScroller = !!config.scroller;
+    this._childPositioningMethod =
+      config.positioning || defaultChildPositioningMethod;
     if (config.axis) {
       this._axis = config.axis;
     }
@@ -1501,7 +1517,12 @@ export class Virtualizer {
                   : -insetInlineStart;
             }
 
-            child.style.transform = `translate(${left}px, ${top}px)`;
+            if (this._childPositioningMethod === 'absolute') {
+              child.style.left = left + 'px';
+              child.style.top = top + 'px';
+            } else {
+              child.style.transform = `translate(${left}px, ${top}px)`;
+            }
 
             if (inlineSize !== undefined) {
               child.style.inlineSize = inlineSize + 'px';

--- a/packages/labs/virtualizer/src/Virtualizer.ts
+++ b/packages/labs/virtualizer/src/Virtualizer.ts
@@ -104,6 +104,10 @@ export interface VirtualizerHostElement extends HTMLElement {
  * a call that looks and behaves essentially the same as for
  * a real Element. May be useful for other things later.
  */
+export type ChildPositioningMethod = 'absolute' | 'translate';
+export const defaultChildPositioningMethod: ChildPositioningMethod =
+  'translate';
+
 export interface VirtualizerChildElementProxy {
   scrollIntoView: (options?: ScrollIntoViewOptions) => void;
 }
@@ -144,6 +148,13 @@ export interface VirtualizerConfig {
    * fires an `unpinned` event.
    */
   pin?: PinOptions;
+
+  /**
+   * Controls how the virtualizer positions its child elements.
+   * - `'translate'` (default): uses CSS `transform: translate()`.
+   * - `'absolute'`: uses CSS `left` and `top` properties.
+   */
+  positioning?: ChildPositioningMethod;
 }
 
 let DefaultLayoutConstructor: LayoutConstructor;
@@ -158,6 +169,9 @@ let DefaultLayoutConstructor: LayoutConstructor;
  */
 export class Virtualizer {
   private _warnings = new InstanceWarnings();
+
+  private _childPositioningMethod: ChildPositioningMethod =
+    defaultChildPositioningMethod;
 
   private _benchmarkStart: number | null = null;
 
@@ -465,6 +479,8 @@ export class Virtualizer {
 
   _init(config: VirtualizerConfig) {
     this._isScroller = !!config.scroller;
+    this._childPositioningMethod =
+      config.positioning || defaultChildPositioningMethod;
     if (config.axis) {
       this._axis = config.axis;
     }
@@ -1537,7 +1553,12 @@ export class Virtualizer {
                   : -insetInlineStart;
             }
 
-            child.style.transform = `translate(${left}px, ${top}px)`;
+            if (this._childPositioningMethod === 'absolute') {
+              child.style.left = left + 'px';
+              child.style.top = top + 'px';
+            } else {
+              child.style.transform = `translate(${left}px, ${top}px)`;
+            }
 
             if (inlineSize !== undefined) {
               child.style.inlineSize = inlineSize + 'px';

--- a/packages/labs/virtualizer/src/test/scenarios/positioning.test.ts
+++ b/packages/labs/virtualizer/src/test/scenarios/positioning.test.ts
@@ -1,0 +1,151 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {ignoreBenignErrors} from '../helpers.js';
+import {html, LitElement} from 'lit';
+import {customElement, property} from 'lit/decorators.js';
+import {LitVirtualizer} from '../../lit-virtualizer.js';
+import {ChildPositioningMethod} from '../../Virtualizer.js';
+import '../../lit-virtualizer.js';
+import {expect, html as testingHtml, fixture} from '@open-wc/testing';
+
+@customElement('positioning-test-translate')
+export class TranslateExample extends LitElement {
+  items = new Array(100).fill('').map((_, i) => ({text: `Item ${i}`}));
+
+  render() {
+    return html`
+      <lit-virtualizer
+        scroller
+        style="height: 400px"
+        .items=${this.items}
+        .renderItem=${(item: {text: string}) =>
+          html`<div style="height: 50px">${item.text}</div>`}
+      ></lit-virtualizer>
+    `;
+  }
+}
+
+@customElement('positioning-test-absolute')
+export class AbsoluteExample extends LitElement {
+  items = new Array(100).fill('').map((_, i) => ({text: `Item ${i}`}));
+
+  render() {
+    return html`
+      <lit-virtualizer
+        scroller
+        style="height: 400px"
+        positioning="absolute"
+        .items=${this.items}
+        .renderItem=${(item: {text: string}) =>
+          html`<div style="height: 50px">${item.text}</div>`}
+      ></lit-virtualizer>
+    `;
+  }
+}
+
+@customElement('positioning-test-configurable')
+export class ConfigurableExample extends LitElement {
+  @property()
+  positioning: ChildPositioningMethod = 'translate';
+
+  items = new Array(100).fill('').map((_, i) => ({text: `Item ${i}`}));
+
+  render() {
+    return html`
+      <lit-virtualizer
+        scroller
+        style="height: 400px"
+        .positioning=${this.positioning}
+        .items=${this.items}
+        .renderItem=${(item: {text: string}) =>
+          html`<div style="height: 50px">${item.text}</div>`}
+      ></lit-virtualizer>
+    `;
+  }
+}
+
+describe('Child positioning method', () => {
+  ignoreBenignErrors(beforeEach, afterEach);
+
+  it('uses translate transforms by default', async () => {
+    const example = await fixture(
+      testingHtml`<positioning-test-translate></positioning-test-translate>`
+    );
+    await customElements.whenDefined('lit-virtualizer');
+    const virtualizer = example.shadowRoot!.querySelector(
+      'lit-virtualizer'
+    )! as LitVirtualizer;
+    expect(virtualizer).to.be.instanceOf(LitVirtualizer);
+    await virtualizer.layoutComplete;
+    expect(virtualizer.children.length).to.be.greaterThan(0);
+    const child = virtualizer.children[0] as HTMLElement;
+    expect(child.style.transform).to.include('translate');
+    expect(child.style.left).to.equal('');
+    expect(child.style.top).to.equal('');
+  });
+
+  it('uses left/top positioning when positioning is "absolute"', async () => {
+    const example = await fixture(
+      testingHtml`<positioning-test-absolute></positioning-test-absolute>`
+    );
+    await customElements.whenDefined('lit-virtualizer');
+    const virtualizer = example.shadowRoot!.querySelector(
+      'lit-virtualizer'
+    )! as LitVirtualizer;
+    expect(virtualizer).to.be.instanceOf(LitVirtualizer);
+    await virtualizer.layoutComplete;
+    expect(virtualizer.children.length).to.be.greaterThan(0);
+    const child = virtualizer.children[0] as HTMLElement;
+    expect(child.style.transform).to.equal('');
+    expect(child.style.left).to.not.equal('');
+    expect(child.style.top).to.not.equal('');
+    expect(child.style.left).to.include('px');
+    expect(child.style.top).to.include('px');
+  });
+
+  it('produces the same visual layout with both methods', async () => {
+    const translateExample = await fixture(
+      testingHtml`<positioning-test-configurable></positioning-test-configurable>`
+    );
+    const absoluteExample = (await fixture(
+      testingHtml`<positioning-test-configurable .positioning=${'absolute'}></positioning-test-configurable>`
+    )) as ConfigurableExample;
+
+    const translateVirtualizer =
+      translateExample.shadowRoot!.querySelector('lit-virtualizer')!;
+    const absoluteVirtualizer =
+      absoluteExample.shadowRoot!.querySelector('lit-virtualizer')!;
+
+    await (translateVirtualizer as LitVirtualizer).layoutComplete;
+    await (absoluteVirtualizer as LitVirtualizer).layoutComplete;
+
+    const translateChildren = Array.from(
+      translateVirtualizer.children
+    ) as HTMLElement[];
+    const absoluteChildren = Array.from(
+      absoluteVirtualizer.children
+    ) as HTMLElement[];
+
+    expect(translateChildren.length).to.be.greaterThan(0);
+    expect(absoluteChildren.length).to.be.greaterThan(0);
+
+    // Compare positions of the first few children
+    const count = Math.min(
+      translateChildren.length,
+      absoluteChildren.length,
+      5
+    );
+    for (let i = 0; i < count; i++) {
+      const tRect = translateChildren[i].getBoundingClientRect();
+      const aRect = absoluteChildren[i].getBoundingClientRect();
+      // Heights should match
+      expect(tRect.height).to.equal(aRect.height);
+      // Widths should match
+      expect(tRect.width).to.equal(aRect.width);
+    }
+  });
+});

--- a/packages/labs/virtualizer/src/virtualize.ts
+++ b/packages/labs/virtualizer/src/virtualize.ts
@@ -8,7 +8,7 @@ import {TemplateResult, ChildPart, html, noChange} from 'lit';
 import {directive, DirectiveResult, PartInfo, PartType} from 'lit/directive.js';
 import {AsyncDirective} from 'lit/async-directive.js';
 import {repeat, KeyFn} from 'lit/directives/repeat.js';
-import {Virtualizer} from './Virtualizer.js';
+import {type ChildPositioningMethod, Virtualizer} from './Virtualizer.js';
 import {RangeChangedEvent} from './events.js';
 import {
   LayoutConfigValue,
@@ -16,7 +16,12 @@ import {
   virtualizerAxis,
 } from './layouts/shared/Layout.js';
 
-export {virtualizerRef, VirtualizerHostElement} from './Virtualizer.js';
+export {
+  virtualizerRef,
+  VirtualizerHostElement,
+  ChildPositioningMethod,
+  defaultChildPositioningMethod,
+} from './Virtualizer.js';
 
 /**
  * Configuration options for the virtualize directive.
@@ -53,6 +58,13 @@ export interface VirtualizeDirectiveConfig<T> {
    * fires an `unpinned` event.
    */
   pin?: PinOptions;
+
+  /**
+   * Controls how the virtualizer positions its child elements.
+   * - `'translate'` (default): uses CSS `transform: translate()`.
+   * - `'absolute'`: uses CSS `left` and `top` properties.
+   */
+  positioning?: ChildPositioningMethod;
 }
 
 export type RenderItemFunction<T = unknown> = (
@@ -154,13 +166,14 @@ class VirtualizeDirective<T = unknown> extends AsyncDirective {
     if (this._virtualizer) {
       this._virtualizer.disconnected();
     }
-    const {layout, scroller, items, axis, pin} = config;
+    const {layout, scroller, items, axis, pin, positioning} = config;
     const virtualizer = (this._virtualizer = new Virtualizer({
       hostElement,
       layout,
       scroller,
       axis,
       pin,
+      positioning,
     }));
     virtualizer.items = items;
     // On initial render, lit-html runs directives while the new DOM is


### PR DESCRIPTION
## Summary

Adds a `positioning` property to `LitVirtualizer`, the `virtualize` directive, and the `Virtualizer` class that controls how child elements are placed in the DOM:

- `'translate'` (default) — positions children via `transform: translate(x, y)` (existing behavior)
- `'absolute'` — positions children via `left` / `top` CSS properties

This lands after #5249 (CSS-based direction detection) and #5279 (bug fixes).

Resolves https://github.com/lit/lit/issues/4839

## Changes

- **`Virtualizer.ts`**: New `ChildPositioningMethod` type, `positioning` config option, conditional logic in `_positionChildren()` that switches between `transform` and `left`/`top`
- **`virtualize.ts`**: Re-exports new types, passes `positioning` through to `Virtualizer`
- **`LitVirtualizer.ts`**: New `positioning` property, passed through to directive
- **`test/scenarios/positioning.test.ts`** (new): Tests for default translate behavior, absolute positioning, and visual equivalence between both methods

## Test plan

- [x] All 186 existing + new tests pass
- [ ] Manual verification with both positioning modes in a playground app