### PR TITLE
fix: set correct path to sub path imports in generators

### DIFF
--- a/.changeset/cute-pens-boil.md
+++ b/.changeset/cute-pens-boil.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/analyzer': patch
+---
+
+Use javascript path instead of windows path on module path

--- a/packages/labs/analyzer/src/lib/references.ts
+++ b/packages/labs/analyzer/src/lib/references.ts
@@ -222,7 +222,9 @@ export const getImportReference = (
       const sourceFilePath = location.getSourceFile().fileName as AbsolutePath;
       const module = getModuleInfo(sourceFilePath, analyzer);
       refPackage = module.packageJson.name;
-      refModule = path.join(path.dirname(module.jsPath), specifier);
+      refModule = path
+        .join(path.dirname(module.jsPath), specifier)
+        .replace(/\\/g, '/');
     } else if (analyzer.path.isAbsolute(specifier)) {
       // Absolute import; no package, just use the entire path as the
       // module

--- a/packages/labs/analyzer/src/lib/references.ts
+++ b/packages/labs/analyzer/src/lib/references.ts
@@ -289,7 +289,7 @@ const getLocalReference = (
   return new Reference({
     name,
     package: module.packageJson.name,
-    module: module.jsPath,
+    module: module.jsPath.replace(/\\/g, '/'),
     dereference: () =>
       getResolvedExportFromSourcePath(
         location.getSourceFile().fileName as AbsolutePath,

--- a/packages/labs/gen-wrapper-angular/goldens/test-element-a/src/element-events.ts
+++ b/packages/labs/gen-wrapper-angular/goldens/test-element-a/src/element-events.ts
@@ -46,6 +46,12 @@ export class ElementEvents {
       this.eventSubclassEvent.emit(e);
     });
 
+    this._el.addEventListener('type-sub-custom-event', (e: Event) => {
+      // TODO(justinfagnani): we need to let the element say how to get a value
+      // from an event, ex: e.value
+      this.typeSubCustomEventEvent.emit(e);
+    });
+
     this._el.addEventListener('special-event', (e: Event) => {
       // TODO(justinfagnani): we need to let the element say how to get a value
       // from an event, ex: e.value
@@ -79,6 +85,9 @@ export class ElementEvents {
 
   @Output()
   eventSubclassEvent = new EventEmitter<unknown>();
+
+  @Output()
+  typeSubCustomEventEvent = new EventEmitter<unknown>();
 
   @Output()
   specialEventEvent = new EventEmitter<unknown>();

--- a/packages/labs/gen-wrapper-angular/package.json
+++ b/packages/labs/gen-wrapper-angular/package.json
@@ -20,7 +20,7 @@
     "build": "wireit",
     "test": "wireit",
     "test:gen": "wireit",
-    "test:update-goldens": "UPDATE_TEST_GOLDENS=true npm run test:gen"
+    "test:update-goldens": "cross-env UPDATE_TEST_GOLDENS=true npm run test:gen"
   },
   "wireit": {
     "build": {

--- a/packages/labs/gen-wrapper-react/goldens/test-element-a/src/element-events.ts
+++ b/packages/labs/gen-wrapper-react/goldens/test-element-a/src/element-events.ts
@@ -4,10 +4,12 @@ import {createComponent, EventName} from '@lit/react';
 import {ElementEvents as ElementEventsElement} from '@lit-internal/test-element-a/element-events.js';
 import {MyDetail} from '@lit-internal/test-element-a/detail-type.js';
 import {EventSubclass} from '@lit-internal/test-element-a/element-events.js';
+import {TypeSub} from '@lit-internal/test-element-a/sub/type-sub.js';
 import {SpecialEvent} from '@lit-internal/test-element-a/special-event.js';
 import {TemplateResult} from 'lit';
 export type {MyDetail} from '@lit-internal/test-element-a/detail-type.js';
 export type {EventSubclass} from '@lit-internal/test-element-a/element-events.js';
+export type {TypeSub} from '@lit-internal/test-element-a/sub/type-sub.js';
 export type {SpecialEvent} from '@lit-internal/test-element-a/special-event.js';
 export type {TemplateResult} from 'lit';
 
@@ -26,6 +28,9 @@ export const ElementEvents = createComponent({
       CustomEvent<MyDetail>
     >,
     onEventSubclass: 'event-subclass' as EventName<EventSubclass>,
+    onTypeSubCustomEvent: 'type-sub-custom-event' as EventName<
+      CustomEvent<TypeSub>
+    >,
     onSpecialEvent: 'special-event' as EventName<SpecialEvent>,
     onTemplateResultCustomEvent: 'template-result-custom-event' as EventName<
       CustomEvent<TemplateResult>

--- a/packages/labs/gen-wrapper-react/package.json
+++ b/packages/labs/gen-wrapper-react/package.json
@@ -19,7 +19,7 @@
     "build": "wireit",
     "test": "wireit",
     "test:gen": "wireit",
-    "test:update-goldens": "UPDATE_TEST_GOLDENS=true npm run test:gen"
+    "test:update-goldens": "cross-env UPDATE_TEST_GOLDENS=true npm run test:gen"
   },
   "wireit": {
     "build": {

--- a/packages/labs/gen-wrapper-vue/goldens/test-element-a/src/ElementEvents.vue
+++ b/packages/labs/gen-wrapper-vue/goldens/test-element-a/src/ElementEvents.vue
@@ -1,6 +1,7 @@
 <script lang="ts">
 export type {MyDetail} from '@lit-internal/test-element-a/detail-type.js';
 export type {EventSubclass} from '@lit-internal/test-element-a/element-events.js';
+export type {TypeSub} from '@lit-internal/test-element-a/sub/type-sub.js';
 export type {SpecialEvent} from '@lit-internal/test-element-a/special-event.js';
 export type {TemplateResult} from 'lit';
 </script>
@@ -10,6 +11,7 @@ import {assignSlotNodes, Slots} from '@lit-labs/vue-utils/wrapper-utils.js';
 import '@lit-internal/test-element-a/element-events.js';
 import {MyDetail} from '@lit-internal/test-element-a/detail-type.js';
 import {EventSubclass} from '@lit-internal/test-element-a/element-events.js';
+import {TypeSub} from '@lit-internal/test-element-a/sub/type-sub.js';
 import {SpecialEvent} from '@lit-internal/test-element-a/special-event.js';
 import {TemplateResult} from 'lit';
 
@@ -35,6 +37,7 @@ const emit = defineEmits<{
   (e: 'number-custom-event', payload: CustomEvent<number>): void;
   (e: 'my-detail-custom-event', payload: CustomEvent<MyDetail>): void;
   (e: 'event-subclass', payload: EventSubclass): void;
+  (e: 'type-sub-custom-event', payload: CustomEvent<TypeSub>): void;
   (e: 'special-event', payload: SpecialEvent): void;
   (
     e: 'template-result-custom-event',
@@ -54,6 +57,8 @@ const render = () => {
       emit('my-detail-custom-event', event as CustomEvent<MyDetail>),
     onEventSubclass: (event: EventSubclass) =>
       emit('event-subclass', event as EventSubclass),
+    onTypeSubCustomEvent: (event: CustomEvent<TypeSub>) =>
+      emit('type-sub-custom-event', event as CustomEvent<TypeSub>),
     onSpecialEvent: (event: SpecialEvent) =>
       emit('special-event', event as SpecialEvent),
     onTemplateResultCustomEvent: (event: CustomEvent<TemplateResult>) =>

--- a/packages/labs/gen-wrapper-vue/goldens/test-element-a/src/sub/ElementSub.vue
+++ b/packages/labs/gen-wrapper-vue/goldens/test-element-a/src/sub/ElementSub.vue
@@ -1,10 +1,15 @@
+<script lang="ts">
+export type {ElementSubEnum} from '@lit-internal/test-element-a/sub/element-sub.js';
+</script>
 <script setup lang="ts">
 import {h, useSlots, reactive} from 'vue';
 import {assignSlotNodes, Slots} from '@lit-labs/vue-utils/wrapper-utils.js';
 import '@lit-internal/test-element-a/sub/element-sub.js';
+import {ElementSubEnum} from '@lit-internal/test-element-a/sub/element-sub.js';
 
 export interface Props {
   foo?: string | undefined;
+  enum?: ElementSubEnum | undefined;
 }
 
 const vueProps = defineProps<Props>();

--- a/packages/labs/gen-wrapper-vue/package.json
+++ b/packages/labs/gen-wrapper-vue/package.json
@@ -19,7 +19,7 @@
     "build": "wireit",
     "test": "wireit",
     "test:gen": "wireit",
-    "test:update-goldens": "UPDATE_TEST_GOLDENS=true npm run test:gen"
+    "test:update-goldens": "cross-env UPDATE_TEST_GOLDENS=true npm run test:gen"
   },
   "wireit": {
     "build": {

--- a/packages/labs/test-projects/test-element-a/src/element-events.ts
+++ b/packages/labs/test-projects/test-element-a/src/element-events.ts
@@ -8,8 +8,10 @@ import {LitElement, html, TemplateResult} from 'lit';
 import {customElement, property} from 'lit/decorators.js';
 import {SpecialEvent} from './special-event.js';
 import {MyDetail} from './detail-type.js';
+import {TypeSub} from './sub/type-sub.js';
 
 export {SpecialEvent} from './special-event.js';
+export {TypeSub} from './sub/type-sub.js';
 export {MyDetail} from './detail-type.js';
 export class EventSubclass extends Event {
   aStr: string;
@@ -31,6 +33,7 @@ declare global {
   interface HTMLElementEventMap {
     'event-subclass': EventSubclass;
     'special-event': SpecialEvent;
+    'type-sub-custom-event': CustomEvent<TypeSub>;
     'string-custom-event': CustomEvent<string>;
     'number-custom-event': CustomEvent<number>;
     'my-detail-custom-event': CustomEvent<MyDetail>;
@@ -44,6 +47,7 @@ declare global {
  * @fires number-custom-event {CustomEvent<number>} A custom event with a number payload
  * @fires my-detail-custom-event {CustomEvent<MyDetail>} A custom event with a MyDetail payload.
  * @fires event-subclass {EventSubclass} The subclass event with a string and number payload
+ * @fires type-sub-custom-event {CustomEvent<TypeSub>} A custom event with a TypeSub payload.
  * @fires special-event {SpecialEvent} The special event with a number payload
  * @fires template-result-custom-event {CustomEvent<TemplateResult>} The result-custom-event with a TemplateResult payload.
  */
@@ -95,6 +99,20 @@ export class ElementEvents extends LitElement {
   fireTemplateResultCustomEvent(detail = html``, fromNode = this) {
     fromNode.dispatchEvent(
       new CustomEvent('template-result-custom-event', {
+        detail,
+        bubbles: true,
+        composed: true,
+        cancelable: true,
+      })
+    );
+  }
+
+  fireTypeSubCustomEvent(
+    detail = {name: 'John', age: 30} as TypeSub,
+    fromNode = this
+  ) {
+    fromNode.dispatchEvent(
+      new CustomEvent<TypeSub>('type-sub-custom-event', {
         detail,
         bubbles: true,
         composed: true,

--- a/packages/labs/test-projects/test-element-a/src/sub/element-sub.ts
+++ b/packages/labs/test-projects/test-element-a/src/sub/element-sub.ts
@@ -8,6 +8,12 @@ import {LitElement, html, css} from 'lit';
 import {customElement, property} from 'lit/decorators.js';
 import {Foo, Bar as Baz} from '../package-stuff.js';
 
+export enum ElementSubEnum {
+  FOO = 'foo',
+  BAR = 'bar',
+  BAZ = 'baz',
+}
+
 /**
  * This is a description of my element. It's pretty great. The description has
  * text that spans multiple lines.
@@ -33,6 +39,9 @@ export class ElementSub extends LitElement {
 
   @property()
   foo?: string;
+
+  @property()
+  enum?: ElementSubEnum;
 
   override render() {
     return html`

--- a/packages/labs/test-projects/test-element-a/src/sub/type-sub.ts
+++ b/packages/labs/test-projects/test-element-a/src/sub/type-sub.ts
@@ -1,0 +1,4 @@
+export type TypeSub = {
+  name: string;
+  age: number;
+};


### PR DESCRIPTION
Befor the fix, when generating wrappers on windows the path became invalid for the import
```js
import {TypeSub} from '@lit-internal/test-element-a/sub\type-sub.js';
```
This fix, changes this to
```js
import {TypeSub} from '@lit-internal/test-element-a/sub/type-sub.js';
```
It also adds test for this.