### PR TITLE
fix(react): forward element props in node export when DOM is present

### DIFF
--- a/.changeset/fair-mangos-brush.md
+++ b/.changeset/fair-mangos-brush.md
@@ -1,0 +1,5 @@
+---
+'@lit/react': patch
+---
+
+Fix node-export prop forwarding in DOM-like runtimes (e.g. Vitest + jsdom) while preserving Lit SSR behavior.

--- a/packages/react/src/create-component.ts
+++ b/packages/react/src/create-component.ts
@@ -247,6 +247,12 @@ export const createComponent = <
   const ReactComponent = React.forwardRef<I, Props>((props, ref) => {
     const prevElemPropsRef = React.useRef(new Map());
     const elementRef = React.useRef<I | null>(null);
+    const hasDom = typeof window !== 'undefined';
+    const isLitSsrRendering =
+      React.createElement.name === 'litPatchedCreateElement' ||
+      globalThis.litSsrReactEnabled;
+    const shouldApplyDomElementProps =
+      !NODE_MODE || (hasDom && !isLitSsrRendering);
 
     // Props to be passed to React.createElement
     const reactProps: Record<string, unknown> = {};
@@ -270,7 +276,7 @@ export const createComponent = <
     }
 
     // useLayoutEffect produces warnings during server rendering.
-    if (!NODE_MODE) {
+    if (shouldApplyDomElementProps) {
       // This one has no dependency array so it'll run on every re-render.
       React.useLayoutEffect(() => {
         if (elementRef.current === null) {
@@ -304,19 +310,15 @@ export const createComponent = <
       }, []);
     }
 
-    if (NODE_MODE) {
+    if (NODE_MODE && !shouldApplyDomElementProps) {
       // If component is to be server rendered with `@lit/ssr-react`, pass
       // element properties in a special bag to be set by the server-side
       // element renderer.
-      if (
-        (React.createElement.name === 'litPatchedCreateElement' ||
-          globalThis.litSsrReactEnabled) &&
-        Object.keys(elementProps).length
-      ) {
+      if (isLitSsrRendering && Object.keys(elementProps).length) {
         // This property needs to remain unminified.
         reactProps['_$litProps$'] = elementProps;
       }
-    } else {
+    } else if (shouldApplyDomElementProps) {
       // Suppress hydration warning for server-rendered attributes.
       // This property needs to remain unminified.
       reactProps['suppressHydrationWarning'] = true;

--- a/packages/react/src/test/create-component_test.tsx
+++ b/packages/react/src/test/create-component_test.tsx
@@ -119,6 +119,16 @@ const render = (children: React.ReactNode) => {
   });
 };
 
+const importNodeCreateComponent = async () => {
+  // Load the node build explicitly so we can verify behavior when tooling
+  // resolves @lit/react's node export in a DOM-like test environment.
+  return (
+    await import(
+      new URL('../../node/create-component.js', import.meta.url).href
+    )
+  ).createComponent;
+};
+
 if (DEV_MODE) {
   suite('Developer mode warnings', () => {
     let warnings: string[] = [];
@@ -271,6 +281,25 @@ suite('createComponent', () => {
     assert.isOk(el);
     await el.updateComplete;
     assert.isOk(el.hasUpdated);
+  });
+
+  test('node build applies element props when running with DOM APIs', async () => {
+    const createComponentFromNodeBuild = await importNodeCreateComponent();
+    const NodeBuildComponent = createComponentFromNodeBuild({
+      react: React,
+      elementClass: BasicElement,
+      events: basicElementEvents,
+      tagName,
+    });
+
+    const obj = {foo: 123};
+    render(<NodeBuildComponent id="from-node-build" obj={obj} />);
+
+    const el = container.querySelector(tagName)!;
+    await el.updateComplete;
+
+    assert.equal(el.id, 'from-node-build');
+    assert.deepEqual(el.obj, obj);
   });
 
   test('can get ref to element', async () => {


### PR DESCRIPTION
## Summary

This change fixes a behavior gap in `@lit/react` when tooling resolves the `node` export in a DOM-like runtime (for example Vitest + jsdom).

Today, the node build treats all renders as SSR-oriented and skips the DOM prop-application path. In that situation, element props like `id` (and custom element prototype props) can be dropped even though a DOM is present.

This PR keeps SSR behavior intact, but applies element props in node mode when:

- a DOM runtime is present (`window` exists), and
- Lit SSR patching is not active (`litPatchedCreateElement` / `litSsrReactEnabled`).

## Why this is scoped this way

The goal is not to change SSR semantics. The goal is to avoid false-SSR behavior in client-like test environments that happen to resolve the node export.

So the behavior split becomes:

- **True SSR / Lit SSR active:** unchanged (`_$litProps$` path still used)
- **Node export + DOM runtime + no Lit SSR patching:** apply browser-style element prop forwarding

## Changes

- `packages/react/src/create-component.ts`
  - Adds a runtime guard (`shouldApplyDomElementProps`) for node export when DOM is present and Lit SSR is not active.
  - Preserves existing SSR-oriented behavior when Lit SSR is active.
- `packages/react/src/test/create-component_test.tsx`
  - Adds a regression test that imports the **node build** directly and asserts forwarded `id` and object property values in DOM tests.

## Validation

Ran in this branch:

- `npx playwright install chromium firefox webkit`
- `npm run test:dev --workspace=@lit/react -- --force`
- `npm run test:prod --workspace=@lit/react -- --force`
- `npm run test:node --workspace=@lit/react -- --force`

Browser matrix passed (Chromium/Firefox/WebKit).

I also validated against two downstream reproductions that originally surfaced the problem:

- https://github.com/stenciljs/output-targets/issues/791
- https://github.com/stenciljs/output-targets/pull/793

Both pass once this patched `@lit/react` is installed.

## Notes

If you’d prefer a different guard for determining “DOM-like but not Lit SSR” in node mode, I’m happy to adjust it.
