### PR TITLE
fix(ssr-dom-shim): Add stubs for TS 6.0.3 compatibility

### DIFF
--- a/.changeset/shiny-seals-yawn.md
+++ b/.changeset/shiny-seals-yawn.md
@@ -1,0 +1,5 @@
+---
+"@lit-labs/ssr-dom-shim": patch
+---
+
+fix(ssr-dom-shim): Add stubs for TS 6.0.3 compatibility

--- a/packages/labs/ssr-dom-shim/src/index.ts
+++ b/packages/labs/ssr-dom-shim/src/index.ts
@@ -754,6 +754,13 @@ class CustomElementRegistry implements RealCustomElementRegistry {
     return this.__reverseDefinitions.get(ctor) ?? null;
   }
 
+  initialize(_root: Node): void {
+    throw new Error(
+      `customElements.initialize is not currently supported in SSR. ` +
+        `Please file a bug if you need it.`
+    );
+  }
+
   upgrade(_element: HTMLElement) {
     // In SSR this doesn't make a lot of sense, so we do nothing.
     throw new Error(

--- a/packages/labs/ssr-dom-shim/src/lib/css.ts
+++ b/packages/labs/ssr-dom-shim/src/lib/css.ts
@@ -84,6 +84,7 @@ const CSSRuleShim = class CSSRule implements CSSRuleInterface {
   static readonly SUPPORTS_RULE: 12 = 12 as const;
   static readonly COUNTER_STYLE_RULE: 11 = 11 as const;
   static readonly FONT_FEATURE_VALUES_RULE: 14 = 14 as const;
+  static readonly MARGIN_RULE: 9 = 9 as const;
   readonly STYLE_RULE: 1 = 1 as const;
   readonly CHARSET_RULE: 2 = 2 as const;
   readonly IMPORT_RULE: 3 = 3 as const;
@@ -96,6 +97,7 @@ const CSSRuleShim = class CSSRule implements CSSRuleInterface {
   readonly SUPPORTS_RULE: 12 = 12 as const;
   readonly COUNTER_STYLE_RULE: 11 = 11 as const;
   readonly FONT_FEATURE_VALUES_RULE: 14 = 14 as const;
+  readonly MARGIN_RULE: 9 = 9 as const;
   __parentStyleSheet: CSSStyleSheet | null = null;
 
   cssText: string = '';


### PR DESCRIPTION
Adds missing stubs to ssr-dom-shim for:
- CustomElementRegistry.prototype.initialize
- CSSRule.MARGIN_RULE

Without these stubs lit will not build with TS 6.0.3.