### PR TITLE
[localize-tools] Fix generic call expressions inside msg() substitutions

### DIFF
--- a/.changeset/fix-localize-tools-generic-call-substitution.md
+++ b/.changeset/fix-localize-tools-generic-call-substitution.md
@@ -1,0 +1,5 @@
+---
+'@lit/localize-tools': patch
+---
+
+Fix `parseStringAsTemplateLiteral` misparsing TypeScript generic call expressions inside `${...}` template substitutions. Previously the helper parsed template literal bodies with `ts.ScriptKind.JS`, so an expression like `${foo<T>(arg)}` was parsed as a chain of comparison operators (`(foo < T) > (arg)`) instead of a generic call. Parsing as TypeScript now correctly recognizes the type argument list and produces a `CallExpression`.

--- a/.changeset/shiny-seals-yawn.md
+++ b/.changeset/shiny-seals-yawn.md
@@ -1,5 +1,5 @@
 ---
-"@lit-labs/ssr-dom-shim": patch
+'@lit-labs/ssr-dom-shim': patch
 ---
 
 fix(ssr-dom-shim): Add stubs for TS 6.0.3 compatibility

--- a/packages/localize-tools/src/tests/typescript.unit.test.ts
+++ b/packages/localize-tools/src/tests/typescript.unit.test.ts
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import ts from 'typescript';
+import {test} from 'uvu';
+// eslint-disable-next-line import/extensions
+import * as assert from 'uvu/assert';
+import {parseStringAsTemplateLiteral} from '../typescript.js';
+
+test('parses a no-substitution template literal body', () => {
+  const node = parseStringAsTemplateLiteral('Hello World');
+  assert.ok(ts.isNoSubstitutionTemplateLiteral(node));
+  assert.is((node as ts.NoSubstitutionTemplateLiteral).text, 'Hello World');
+});
+
+test('parses an identifier substitution as an Identifier', () => {
+  const node = parseStringAsTemplateLiteral('Hello ${name}!');
+  assert.ok(ts.isTemplateExpression(node));
+  const span = (node as ts.TemplateExpression).templateSpans[0];
+  assert.ok(ts.isIdentifier(span.expression));
+  assert.is((span.expression as ts.Identifier).text, 'name');
+});
+
+// Regression test for a bug where TypeScript generic call expressions inside
+// ${...} substitutions were misparsed as a chain of comparison operators.
+//
+// Given `${foo<T>(arg)}`, parsing the template literal body with
+// `ts.ScriptKind.JS` would yield `(foo < T) > (arg)` (a BinaryExpression) and
+// any consumer that re-emitted the AST would print `foo < T > (arg)`, which
+// at runtime evaluates to `false` and silently drops the call's side effects.
+// Parsing with `ts.ScriptKind.TS` correctly recognizes `<T>` as a type
+// argument list and produces a CallExpression.
+test('parses a generic call expression substitution as a CallExpression', () => {
+  const node = parseStringAsTemplateLiteral("<b>${fn<T>({a: 'x'})}</b>");
+  assert.ok(ts.isTemplateExpression(node));
+  const expr = (node as ts.TemplateExpression).templateSpans[0].expression;
+  assert.ok(
+    ts.isCallExpression(expr),
+    `Expected CallExpression, got ${ts.SyntaxKind[expr.kind]}. ` +
+      `This indicates the template literal body was parsed as JavaScript ` +
+      `instead of TypeScript, causing the generic call to be misparsed as a ` +
+      `chain of comparison operators.`
+  );
+  const call = expr as ts.CallExpression;
+  assert.ok(ts.isIdentifier(call.expression));
+  assert.is((call.expression as ts.Identifier).text, 'fn');
+  assert.is(call.typeArguments?.length, 1);
+  assert.is(call.arguments.length, 1);
+});
+
+test('parses nested generic call substitutions correctly', () => {
+  const node = parseStringAsTemplateLiteral(
+    'a ${foo<T>()} b ${bar<U, V>(1)} c'
+  );
+  assert.ok(ts.isTemplateExpression(node));
+  const spans = (node as ts.TemplateExpression).templateSpans;
+  assert.is(spans.length, 2);
+  assert.ok(ts.isCallExpression(spans[0].expression));
+  assert.ok(ts.isCallExpression(spans[1].expression));
+  assert.is(
+    (spans[1].expression as ts.CallExpression).typeArguments?.length,
+    2
+  );
+});
+
+test.run();

--- a/packages/localize-tools/src/typescript.ts
+++ b/packages/localize-tools/src/typescript.ts
@@ -103,12 +103,17 @@ export function escapeTextContentToEmbedInTemplateLiteral(
 export function parseStringAsTemplateLiteral(
   templateLiteralBody: string
 ): ts.TemplateLiteral {
+  // Parse as TypeScript (not JavaScript) so that generic call expressions
+  // such as `foo<T>(arg)` inside `${...}` substitutions are recognized as
+  // type-argument calls. With ScriptKind.JS they would be misparsed as a
+  // chain of comparison operators (`foo < T > (arg)`) which evaluates to
+  // `false` at runtime.
   const file = ts.createSourceFile(
     '__DUMMY__.ts',
     '`' + templateLiteralBody + '`',
     ts.ScriptTarget.ESNext,
     false,
-    ts.ScriptKind.JS
+    ts.ScriptKind.TS
   );
   if (file.statements.length !== 1) {
     throw new Error('Internal error: expected 1 statement');


### PR DESCRIPTION
## Summary

`parseStringAsTemplateLiteral` in `@lit/localize-tools` parsed template literal bodies with `ts.ScriptKind.JS`. JavaScript has no generic-call syntax, so an expression like `${foo<T>(arg)}` inside a `msg()` template substitution was parsed as `(foo < T) > (arg)` (a `BinaryExpression` chain) instead of a `CallExpression` with a type argument list.

In contexts that re-emit the parsed AST, this prints as `foo < T > (arg)`, which evaluates to `false` at runtime and silently drops any side effects of the call. Source/English branches are unaffected because they reuse the original TypeScript-parsed source AST; translated branches that flow back through `parseStringAsTemplateLiteral` are vulnerable.

The fix is a one-line, surgical change: parse with `ts.ScriptKind.TS` so the TypeScript parser correctly disambiguates `<T>` as a type argument list. There is no behavior change for non-generic substitutions; TypeScript's parser is a strict superset of JavaScript's for this input.

### Changes
- `packages/localize-tools/src/typescript.ts`: switch `parseStringAsTemplateLiteral` to `ts.ScriptKind.TS` (with a comment explaining why).
- `packages/localize-tools/src/tests/typescript.unit.test.ts`: new unit test file with 4 tests, including a regression test that asserts a generic call substitution parses as a `CallExpression` (not a `BinaryExpression`).
- `.changeset/`: patch changeset for `@lit/localize-tools`.

## Test plan
- [x] `npm test` in `packages/localize-tools` passes (`test:unit` 80/80, `test:unit:ssr` 4/4, `test:check-tsc` clean).
- [x] New regression test fails on `main` (with `ScriptKind.JS`) and passes with the fix.
- [x] `npm run format` and ESLint clean on changed files.

Made with [Cursor](https://cursor.com)