### PR TITLE
[@lit-labs/signals] Corrected State and Computed exports to support TypeScript types

### DIFF
--- a/packages/labs/signals/src/index.ts
+++ b/packages/labs/signals/src/index.ts
@@ -12,7 +12,10 @@ export * from './lib/watch.js';
 export * from './lib/html-tag.js';
 
 export const State = Signal.State;
+export type State<T> = Signal.State<T>;
+
 export const Computed = Signal.Computed;
+export type Computed<T> = Signal.Computed<T>;
 
 export const signal = <T>(value: T, options?: Signal.Options<T>) =>
   new Signal.State(value, options);

--- a/packages/labs/signals/src/test/html-tag_test.ts
+++ b/packages/labs/signals/src/test/html-tag_test.ts
@@ -7,7 +7,14 @@
 import {LitElement} from 'lit';
 import {assert} from '@esm-bundle/chai';
 
-import {SignalWatcher, html, signal} from '../index.js';
+import {
+  Computed,
+  Signal,
+  SignalWatcher,
+  State,
+  html,
+  signal,
+} from '../index.js';
 
 let elementNameId = 0;
 const generateElementName = () => `test-${elementNameId++}`;
@@ -25,7 +32,7 @@ suite('html tag', () => {
   });
 
   test('watches a signal', async () => {
-    const count = signal(0);
+    const count: State<number> = signal(0);
     class TestElement extends SignalWatcher(LitElement) {
       override render() {
         return html`<p>count: ${count}</p>`;
@@ -42,5 +49,28 @@ suite('html tag', () => {
     await el.updateComplete;
 
     assert.equal(el.shadowRoot?.querySelector('p')?.textContent, 'count: 1');
+  });
+
+  test('watches a computed', async () => {
+    const count: State<number> = signal(10);
+    const countTwice: Computed<number> = new Signal.Computed(() => {
+      return count.get() * 2;
+    });
+    class TestElement extends SignalWatcher(LitElement) {
+      override render() {
+        return html`<p>count: ${countTwice}</p>`;
+      }
+    }
+    customElements.define(generateElementName(), TestElement);
+    const el = new TestElement();
+    container.append(el);
+
+    await el.updateComplete;
+    assert.equal(el.shadowRoot?.querySelector('p')?.textContent, 'count: 20');
+
+    count.set(50);
+    await el.updateComplete;
+
+    assert.equal(el.shadowRoot?.querySelector('p')?.textContent, 'count: 100');
   });
 });


### PR DESCRIPTION
## Summary

This PR refactors the re-exports of State and Computed in the `@lit-labs/signals` package. The change ensures that these symbols are available both as runtime values and as types, resolving an issue where they could not be used for type annotations by consumers.

Extended existing test and used newly exported types explicitly. Without the change tests failed on typechecking.

## Motivation

The underlying signal-polyfill library exposes its core classes within a Signal namespace. Previous implementation used a simple constant re-export::

```typescript
export const State = Signal.State;
```

While this works for runtime instantiation, TypeScript does not automatically propagate the type definition from a namespace member when assigned to a const. Consequently, consumers were unable to write code like:

```typescript
import { State } from '@lit-labs/signals';
const mySignal: State<number> = new State(0); // Error: 'State' refers to a value, but is being used as a type here.
```

## Solution

Now explicitly export both the value and the type::

```
export const State = Signal.State;
export type State<T> = Signal.State<T>;
```

## Verification

- Verified that State<T> and Computed<T> are correctly recognized as types in external consumer modules
- Confirmed that npm run build -w @lit-labs/signals generates the expected .js and .d.ts files
- Verified that resulting build has no runtime changes, JS file is still the same
- Used new types in tests for verification

## Notes

I also tried to play around with other options, alternative approach was like:

```typescript
export import State = Signal.State;
export import Computed = Signal.Computed;
```

But looks like it is legacy construct
