### PR TITLE
[context] Expose Options types for ContextConsumer and ContextProvider

### DIFF
--- a/.changeset/expose-context-options-types.md
+++ b/.changeset/expose-context-options-types.md
@@ -1,0 +1,16 @@
+---
+'@lit/context': patch
+---
+
+Expose `Options` types for the `ContextConsumer` and `ContextProvider`
+controllers from `@lit/context` as `ContextConsumerOptions` and
+`ContextProviderOptions` respectively.
+
+These types were already publicly reachable via the
+`new ContextConsumer(host, options)` and `new ContextProvider(host, options)`
+constructor signatures but could not be referenced from user code (e.g.
+when wrapping the controllers), because `ConstructorParameters<…>` does
+not see through the deprecated constructor overload. Exposing them
+under distinct names avoids the collision between the two same-named
+`Options` interfaces in their source modules while keeping the existing
+public API unchanged.

--- a/packages/context/src/index.ts
+++ b/packages/context/src/index.ts
@@ -17,7 +17,9 @@ export {
 } from './lib/create-context.js';
 
 export {ContextConsumer} from './lib/controllers/context-consumer.js';
+export type {Options as ContextConsumerOptions} from './lib/controllers/context-consumer.js';
 export {ContextProvider} from './lib/controllers/context-provider.js';
+export type {Options as ContextProviderOptions} from './lib/controllers/context-provider.js';
 export {ContextRoot} from './lib/context-root.js';
 
 export {provide} from './lib/decorators/provide.js';


### PR DESCRIPTION
> **Dear maintainer** — this PR has a permanent home with methodology + [opt-out](https://github.com/adv0r/tokens-for-good/blob/main/MAINTAINER_REMOVAL.md) at [tokens-for-good](https://github.com/adv0r/tokens-for-good). A one-line "no thanks" → auto-close + blacklist. Sorry for the notification this edit caused.
>
> ---

## Summary

Re-export the `Options` interfaces from `@lit/context`'s public entry
point so that user code wrapping `ContextConsumer` / `ContextProvider`
can reference them without having to copy-paste their definitions.

Adds the following named re-exports from `packages/context/src/index.ts`:

- `ContextConsumerOptions` — alias for the `Options` interface in
  `./lib/controllers/context-consumer.js`
- `ContextProviderOptions` — alias for the `Options` interface in
  `./lib/controllers/context-provider.js`

Aliases are needed because both source modules export a type named
`Options`; the new public names make their package origin obvious and
let both be imported from the same entry point.

Also adds a changeset for `@lit/context` (patch).

Fixes #4837

## Why

The two `Options` interfaces are part of the public constructor
signatures of `ContextConsumer` / `ContextProvider`, but they were
not reachable from `@lit/context`. `ConstructorParameters<typeof X>`
cannot extract them because of the deprecated constructor overload on
each controller. The only workaround today is to copy-paste the type
definitions into user code (see the issue for a concrete wrapper /
lazy-loading use case).

## Backward compatibility

Type-only, additive change. No runtime behavior changes; existing
imports are untouched.

## AI disclosure

Per AGENTS.md / CONTRIBUTING — this is a small AI-generated, unattended
contribution made by a Cursor Anthropic Claude Opus 4.7 agent under
@adv0r as a short personal token-burn initiative before my Cursor
subscription billing cycle ends. Happy to iterate on review.


Made with [Cursor](https://cursor.com)
