### PR TITLE
fix(labs/router): correct enter() callback docs to match implementation

### DIFF
--- a/packages/labs/router/README.md
+++ b/packages/labs/router/README.md
@@ -154,7 +154,7 @@ html`<main>${this.routes.outlet()}</main>`;
 
 #### enter() callbacks
 
-A route can define an `enter()` callback that lets it do work before rendering and optionally reject that route as a match.
+A route can define an `enter()` callback that lets it do work before rendering and optionally cancel the navigation by returning false.
 
 `enter()` can be used to load and wait for necessary component definitions:
 


### PR DESCRIPTION
Fixes #5328

Why
The README for `@lit-labs/router` describes `enter()` as being able to "optionally reject that route as a match," which suggests the router falls through to the next matching route on rejection. In reality, returning `false` from `enter()` cancels the entire navigation (`goto()` returns without trying other routes).

Changes
Updated the description to reflect the actual behavior: "optionally cancel the navigation by returning `false`".

Updated component: `packages/labs/router/README.md`

Testing
Documentation only change. No code behavior was modified.

Surface area
- Labs / Router
- Documentation fix