### PR TITLE
Add ExportDecoratedItems for closure compiler compat

### DIFF
--- a/.changeset/old-geese-try.md
+++ b/.changeset/old-geese-try.md
@@ -1,0 +1,5 @@
+---
+'@lit/context': patch
+---
+
+Add ExportDecoratedItems for closure compiler compatibility

--- a/packages/context/src/lib/decorators/consume.ts
+++ b/packages/context/src/lib/decorators/consume.ts
@@ -39,6 +39,7 @@ import {Context} from '../create-context.js';
  * }
  * ```
  * @category Decorator
+ * @ExportDecoratedItems
  */
 export function consume<ValueType>({
   context,

--- a/packages/context/src/lib/decorators/provide.ts
+++ b/packages/context/src/lib/decorators/provide.ts
@@ -34,6 +34,7 @@ import {ContextProvider} from '../controllers/context-provider.js';
  * }
  * ```
  * @category Decorator
+ * @ExportDecoratedItems
  */
 export function provide<ValueType>({
   context: context,


### PR DESCRIPTION
Fixes issue with closure compiler eliding readonly fields decorated with `@provide` / `@consume` decorators.