### PR TITLE
Add .npmrc with min-release-age=1

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=1


### PR DESCRIPTION
This adds a .npmrc file with the setting `min-release-age=1` which prevents transitive dependencies from being installed, if published less than a day ago. This has no impact on dependencies listed in package.json.
This requires npm 11.10 to be respected.