### PR TITLE
Inline @rollup/plugin-virtual in the name-cache seeder

### DIFF
--- a/package.json
+++ b/package.json
@@ -273,7 +273,6 @@
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-replace": "^5.0.7",
     "@rollup/plugin-terser": "^0.4.4",
-    "@rollup/plugin-virtual": "^3.0.2",
     "@types/chai": "^4.3.1",
     "@types/mocha": "^9.1.1",
     "@types/node": "^22.17.0",

--- a/rollup-common.js
+++ b/rollup-common.js
@@ -10,8 +10,51 @@ import copy from 'rollup-plugin-copy';
 import nodeResolve from '@rollup/plugin-node-resolve';
 import sourcemaps from 'rollup-plugin-sourcemaps';
 import replace from '@rollup/plugin-replace';
-import virtual from '@rollup/plugin-virtual';
+import {resolve as pathResolve, dirname as pathDirname} from 'path';
 import inject from '@rollup/plugin-inject';
+
+// Minimal inline replacement for @rollup/plugin-virtual, used only by the
+// name-cache seeder build below. Inlining it (rather than depending on the
+// published plugin) keeps rollup-common.js buildable from source in
+// environments where @rollup/plugin-virtual is not available as a package
+// (e.g. Linux distributions that build everything from source), which is
+// required for the seeder — and therefore reproducible minified output — to
+// work there. Behaviour matches @rollup/plugin-virtual: it serves the
+// in-memory seeder module and resolves relative imports from it to real files.
+const VIRTUAL_PREFIX = '\0virtual:';
+const virtual = (modules) => {
+  const resolvedIds = new Map();
+  for (const id of Object.keys(modules)) {
+    resolvedIds.set(pathResolve(id), modules[id]);
+  }
+  return {
+    name: 'virtual',
+    resolveId(id, importer) {
+      if (id in modules) {
+        return VIRTUAL_PREFIX + id;
+      }
+      if (importer) {
+        const importerNoPrefix = importer.startsWith(VIRTUAL_PREFIX)
+          ? importer.slice(VIRTUAL_PREFIX.length)
+          : importer;
+        const resolved = pathResolve(pathDirname(importerNoPrefix), id);
+        if (resolvedIds.has(resolved)) {
+          return VIRTUAL_PREFIX + resolved;
+        }
+      }
+      return null;
+    },
+    load(id) {
+      if (id.startsWith(VIRTUAL_PREFIX)) {
+        const idNoPrefix = id.slice(VIRTUAL_PREFIX.length);
+        return idNoPrefix in modules
+          ? modules[idNoPrefix]
+          : resolvedIds.get(idNoPrefix);
+      }
+      return null;
+    },
+  };
+};
 
 // Prefixes used with minified class and stable properties on objects to avoid
 // collisions with user code and/or subclasses between packages. They are


### PR DESCRIPTION
### Summary

The production Rollup config seeds a shared Terser name cache by bundling every entry point into one throwaway module and minifying it first, so that every mangled property gets a unique, stable name before the real per-module builds run. That seeder build is the only reason the minified output is deterministic.

The seeder's throwaway input module is supplied via `@rollup/plugin-virtual`. That is the **only** use of the plugin in the whole config, and the slice of its behaviour we rely on is tiny: serve one in-memory module and resolve the relative `./development/*.js` imports inside it back to real files.

This PR inlines that ~30-line equivalent and drops the `@rollup/plugin-virtual` devDependency. The inlined `virtual()` is behaviourally identical (same `\0virtual:` id prefix, same relative-import resolution), so generated output is unchanged — only the plumbing that feeds the seeder module differs.

### Motivation

Linux distributions build packages from source and can only use build tooling that is itself packaged. `@rollup/plugin-virtual` is not packaged in Debian, so the Debian build of Lit currently drops the seeder entirely and the minified `lit-html` output is **not reproducible** — property names such as `this.t` / `this.i` flip between builds. Inlining the helper lets the seeder — and therefore reproducible output — work without the extra dependency.

The identical inlined helper is already in use in the Debian `node-lit` package, where a full `reprotest` run confirms the minified output becomes bit-for-bit reproducible with this change (and is not reproducible without it).

### Notes

- Build-only change; no published package output changes, so no changeset is included. Happy to add one if preferred.
- Google Individual CLA signed.
