### PR TITLE
[lit-html] Add support for handling duplicate attribute bindings in templates

### DIFF
--- a/.changeset/plenty-ghosts-battle.md
+++ b/.changeset/plenty-ghosts-battle.md
@@ -1,0 +1,5 @@
+---
+'lit-html': patch
+---
+
+Add support for handling duplicate attribute bindings in templates by providing a warning message in DEV mode.

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -968,6 +968,7 @@ class Template {
     let node: Node | null;
     let nodeIndex = 0;
     let attrNameIndex = 0;
+    let hasDuplicateAttrs = false;
     const partCount = strings.length - 1;
     const parts = this.parts;
 
@@ -1010,24 +1011,49 @@ class Template {
         if ((node as Element).hasAttributes()) {
           for (const name of (node as Element).getAttributeNames()) {
             if (name.endsWith(boundAttributeSuffix)) {
-              const realName = attrNames[attrNameIndex++];
               const value = (node as Element).getAttribute(name)!;
               const statics = value.split(marker);
-              const m = /([.?@])?(.*)/.exec(realName)!;
-              parts.push({
-                type: ATTRIBUTE_PART,
-                index: nodeIndex,
-                name: m[2],
-                strings: statics,
-                ctor:
-                  m[1] === '.'
-                    ? PropertyPart
-                    : m[1] === '?'
-                      ? BooleanAttributePart
-                      : m[1] === '@'
-                        ? EventPart
-                        : AttributePart,
-              });
+              // Extract the base attribute name (without the bound suffix)
+              const domAttrName = name.slice(0, -boundAttributeSuffix.length);
+              // Handle duplicate attribute names: when the same attribute name
+              // appears multiple times in a template (e.g., ?disabled twice),
+              // the HTML parser collapses them into a single DOM attribute.
+              // We need to create parts for all template bindings with this name.
+              let attrCount = 0;
+              while (
+                attrNameIndex < attrNames.length &&
+                attrNames[attrNameIndex] !== undefined
+              ) {
+                const realName = attrNames[attrNameIndex];
+                const m = /([.?@])?(.*)/.exec(realName)!;
+                const templateAttrName = m[2];
+
+                // Check if this template attribute matches the DOM attribute
+                if (templateAttrName !== domAttrName) {
+                  break;
+                }
+
+                attrCount++;
+                if (attrCount > 1) {
+                  hasDuplicateAttrs = true;
+                }
+
+                parts.push({
+                  type: ATTRIBUTE_PART,
+                  index: nodeIndex,
+                  name: templateAttrName,
+                  strings: statics,
+                  ctor:
+                    m[1] === '.'
+                      ? PropertyPart
+                      : m[1] === '?'
+                        ? BooleanAttributePart
+                        : m[1] === '@'
+                          ? EventPart
+                          : AttributePart,
+                });
+                attrNameIndex++;
+              }
               (node as Element).removeAttribute(name);
             } else if (name.startsWith(marker)) {
               parts.push({
@@ -1083,22 +1109,27 @@ class Template {
     }
 
     if (DEV_MODE) {
-      // If there was a duplicate attribute on a tag, then when the tag is
-      // parsed into an element the attribute gets de-duplicated. We can detect
-      // this mismatch if we haven't precisely consumed every attribute name
-      // when preparing the template. This works because `attrNames` is built
-      // from the template string and `attrNameIndex` comes from processing the
-      // resulting DOM.
-      if (attrNames.length !== attrNameIndex) {
-        throw new Error(
+      // Emit a warning if we detected duplicate attributes
+      if (hasDuplicateAttrs) {
+        issueWarning(
+          'multiple-bound-attribute-values',
           `Detected duplicate attribute bindings. This occurs if your template ` +
             `has duplicate attributes on an element tag. For example ` +
             `"<input ?disabled=\${true} ?disabled=\${false}>" contains a ` +
-            `duplicate "disabled" attribute. The error was detected in ` +
+            `duplicate "disabled" attribute. The warning was detected in ` +
             `the following template: \n` +
             '`' +
             strings.join('${...}') +
             '`'
+        );
+      }
+      // Assert that we found all the attribute names we expected. This is a
+      // sanity check that the template compiler and runtime are in sync.
+      // Please report an issue if you see this error.
+      if (attrNames.length !== attrNameIndex) {
+        throw new Error(
+          `Internal error: expected ${attrNames.length} attribute names, found ${attrNameIndex}. ` +
+            `Please report an issue at https://github.com/lit/lit/issues/new`
         );
       }
     }

--- a/packages/lit-html/src/test/lit-html_test.ts
+++ b/packages/lit-html/src/test/lit-html_test.ts
@@ -1166,6 +1166,70 @@ suite('lit-html', () => {
         'B'
       );
     });
+
+    test('does not throw with duplicate attribute bindings', () => {
+      // Regression test for lit/lit#2241: duplicate attributes should not cause errors
+      const disabled = false;
+      const length = 8;
+      const placeholder = 'Name';
+      const myTemplate = () => html`
+        <input ?disabled=${disabled} length=${length} ?disabled=${disabled} placeholder=${placeholder}>
+      `;
+      // This should not throw
+      assert.doesNotThrow(() => render(myTemplate(), container));
+      // The element should exist and have the correct bound attributes
+      const input = container.querySelector('input');
+      assert.ok(input);
+      assert.equal(input.hasAttribute('disabled'), false);
+      assert.equal(input.getAttribute('length'), '8');
+      assert.equal(input.getAttribute('placeholder'), 'Name');
+    });
+
+    test('handles duplicate attribute with static and bound values', () => {
+      // Test case: one static, one bound occurrence of the same attribute
+      const value = 'bound-value';
+      const myTemplate = () => html`
+        <div data-test="static" data-test=${value}></div>
+      `;
+      assert.doesNotThrow(() => render(myTemplate(), container));
+      const div = container.querySelector('div');
+      assert.ok(div);
+      // The bound value should take precedence (last binding wins)
+      assert.equal(div.getAttribute('data-test'), 'bound-value');
+    });
+
+    test('handles multiple duplicate boolean attributes on same element', () => {
+      const flag1 = true;
+      const flag2 = false;
+      const myTemplate = () => html`
+        <button ?disabled=${flag1} ?disabled=${flag2}></button>
+      `;
+      assert.doesNotThrow(() => render(myTemplate(), container));
+      const button = container.querySelector('button');
+      assert.ok(button);
+      // Both bindings should work correctly
+      assert.equal(button.hasAttribute('disabled'), false);
+      // Re-render with different values
+      render(
+        html`<button ?disabled=${true} ?disabled=${true}></button>`,
+        container
+      );
+      assert.equal(button.hasAttribute('disabled'), true);
+    });
+
+    test('handles duplicate attributes across multiple elements', () => {
+      const value1 = 'val1';
+      const value2 = 'val2';
+      const myTemplate = () => html`
+        <input data-x=${value1} data-x=${value2}>
+        <input data-y=${value1}>
+      `;
+      assert.doesNotThrow(() => render(myTemplate(), container));
+      const inputs = container.querySelectorAll('input');
+      assert.equal(inputs.length, 2);
+      assert.equal(inputs[0].getAttribute('data-x'), 'val2'); // Last value wins
+      assert.equal(inputs[1].getAttribute('data-y'), 'val1');
+    });
   });
 
   suite('boolean attributes', () => {


### PR DESCRIPTION
## Changes
- Add support for handling duplicate attribute bindings in templates by providing a warning message in DEV mode.

## Related issues or pull requests

- #2241 