### PR TITLE
[labs/virtualizer] fix memory leak: unobserve children that leave the rendered range

### DIFF
--- a/.changeset/tame-melons-clean.md
+++ b/.changeset/tame-melons-clean.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/virtualizer': patch
+---
+
+Fix a memory leak: children were never unobserved from `_childrenRO` after leaving the rendered range, so every item a virtualizer ever rendered stayed alive for its whole lifetime.

--- a/packages/labs/virtualizer/src/Virtualizer.ts
+++ b/packages/labs/virtualizer/src/Virtualizer.ts
@@ -156,6 +156,12 @@ export class Virtualizer {
    */
   private _childrenRO: ResizeObserver | null = null;
 
+  /**
+   * Children currently observed by `_childrenRO`, so we can unobserve ones
+   * that leave the range instead of leaking them forever.
+   */
+  private _observedChildren = new Set<HTMLElement>();
+
   private _mutationObserver: MutationObserver | null = null;
 
   private _scrollEventListeners: (Element | Window)[] = [];
@@ -281,6 +287,24 @@ export class Virtualizer {
     this._childrenRO = new _ResizeObserver!(
       this._childrenSizeChanged.bind(this)
     );
+    this._observedChildren.clear();
+  }
+
+  // Syncs _childrenRO's observed set with the current range, unobserving
+  // children that are no longer rendered.
+  private _updateObservedChildren(
+    children: Array<HTMLElement> = this._children
+  ) {
+    const current = new Set(children);
+    for (const child of this._observedChildren) {
+      if (!current.has(child)) {
+        this._childrenRO!.unobserve(child);
+      }
+    }
+    for (const child of current) {
+      this._childrenRO!.observe(child);
+    }
+    this._observedChildren = current;
   }
 
   _initHostElement(config: VirtualizerConfig) {
@@ -322,7 +346,7 @@ export class Virtualizer {
       this._hostElementRO!.observe(ancestor);
     });
     this._hostElementRO!.observe(this._scrollerController!.element);
-    this._children.forEach((child) => this._childrenRO!.observe(child));
+    this._updateObservedChildren();
     this._scrollEventListeners.forEach((target) =>
       target.addEventListener('scroll', this, this._scrollEventListenerOptions)
     );
@@ -346,6 +370,7 @@ export class Virtualizer {
     this._hostElementRO = null;
     this._childrenRO?.disconnect();
     this._childrenRO = null;
+    this._observedChildren.clear();
     this._rejectLayoutCompletePromise('disconnected');
     this._connected = false;
   }
@@ -552,7 +577,13 @@ export class Virtualizer {
   _finishDOMUpdate() {
     if (this._connected) {
       // _childrenRO should be non-null if we're connected
-      this._children.forEach((child) => this._childrenRO!.observe(child));
+      const children = this._children;
+      this._updateObservedChildren(children);
+      if (children.length === 0) {
+        // No children means _childrenSizeChanged won't fire, so
+        // layoutComplete would never resolve otherwise.
+        this._scheduleLayoutComplete();
+      }
       this._checkScrollIntoViewTarget(this._childrenPos);
       this._positionChildren(this._childrenPos);
       this._sizeHostElement(this._scrollSize);

--- a/packages/labs/virtualizer/src/test/scenarios/resize-observer-leak.test.ts
+++ b/packages/labs/virtualizer/src/test/scenarios/resize-observer-leak.test.ts
@@ -1,0 +1,108 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {ignoreBenignErrors} from '../helpers.js';
+import {virtualizerFixture} from '../virtualizer-test-utilities.js';
+import {expect} from '@open-wc/testing';
+
+/**
+ * Spies on every `ResizeObserver` instance created while installed, tracking
+ * which elements are currently observed by any of them. Restores the
+ * original methods on `teardown()`.
+ */
+function spyOnResizeObserver() {
+  const observedElements = new Set<Element>();
+  const originalObserve = ResizeObserver.prototype.observe;
+  const originalUnobserve = ResizeObserver.prototype.unobserve;
+
+  ResizeObserver.prototype.observe = function (
+    this: ResizeObserver,
+    target: Element,
+    options?: ResizeObserverOptions
+  ) {
+    observedElements.add(target);
+    return originalObserve.call(this, target, options);
+  };
+  ResizeObserver.prototype.unobserve = function (
+    this: ResizeObserver,
+    target: Element
+  ) {
+    observedElements.delete(target);
+    return originalUnobserve.call(this, target);
+  };
+
+  return {
+    observedElements,
+    teardown() {
+      ResizeObserver.prototype.observe = originalObserve;
+      ResizeObserver.prototype.unobserve = originalUnobserve;
+    },
+  };
+}
+
+/**
+ * The actual rendered row elements, excluding Virtualizer's internal
+ * `virtualizer-sizer` element (which `_hostElementRO`, a *different*
+ * `ResizeObserver` used for the host itself, legitimately keeps observing
+ * for the virtualizer's whole lifetime).
+ */
+function renderedRowElements(host: Element): Element[] {
+  return Array.from(host.querySelectorAll(':not([virtualizer-sizer])'));
+}
+
+describe('Virtualizer does not leak children via ResizeObserver', () => {
+  ignoreBenignErrors(beforeEach, afterEach);
+
+  it('unobserves children once they leave the rendered range', async () => {
+    const {observedElements, teardown} = spyOnResizeObserver();
+
+    try {
+      const {host, controller, scroller} = await virtualizerFixture({
+        nItems: 200,
+      });
+
+      const initialRows = renderedRowElements(host);
+      expect(initialRows.length).to.be.greaterThan(0);
+      for (const row of initialRows) {
+        expect(observedElements.has(row)).to.equal(true);
+      }
+
+      // Scroll far enough that none of the initially-rendered items remain
+      // in the rendered range.
+      scroller.scrollTo({top: 100000});
+      await controller.layoutComplete;
+
+      for (const row of initialRows) {
+        expect(observedElements.has(row)).to.equal(false);
+      }
+    } finally {
+      teardown();
+    }
+  });
+
+  it('unobserves all children when the rendered range becomes empty', async () => {
+    const {observedElements, teardown} = spyOnResizeObserver();
+
+    try {
+      const {host, controller} = await virtualizerFixture({nItems: 50});
+
+      const initialRows = renderedRowElements(host);
+      expect(initialRows.length).to.be.greaterThan(0);
+      for (const row of initialRows) {
+        expect(observedElements.has(row)).to.equal(true);
+      }
+
+      host.style.display = 'none';
+      await controller.layoutComplete;
+
+      for (const row of initialRows) {
+        expect(observedElements.has(row)).to.equal(false);
+      }
+    } finally {
+      teardown();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`_childrenRO` (the ResizeObserver watching rendered children) only ever calls `observe()`, never `unobserve()`. Since a ResizeObserver keeps a strong reference to its targets regardless of whether they're still in the DOM, every item a virtualizer ever rendered stays alive for its whole lifetime. On any list that scrolls or re-renders, this grows without bound.

Found this from a heap snapshot diff on a production app using `lit-virtualizer` for a live-updating table: DOM node counts grew in exact multiples of one rendered page between snapshots, and the leaked nodes traced back as fully intact and reachable, not orphaned. That pointed at something still holding a reference rather than a GC issue, and reading through `Virtualizer.ts` showed `observe()` calls with no matching `unobserve()` anywhere.

## Fix

- Track which children are currently observed (`_observedChildren`) and unobserve any that drop out of range on each update (`_updateObservedChildren`).
- This exposed a bug in `layoutComplete`: it resolves via `_childrenSizeChanged`, which never fires once the range is empty (nothing left to observe). Previously masked by the leak itself, since a stale observed child would still report resizing to 0x0 when hidden or removed. Fixed by scheduling `layoutComplete` directly when the range is empty.

## Testing

- Added a regression test (`resize-observer-leak.test.ts`) that spies on `ResizeObserver.prototype.observe`/`unobserve` to check children get unobserved both when scrolled out of range and when the range empties out. Confirmed it fails without the fix and passes with it.
- Full `packages/labs/virtualizer` suite: 114 -> 116 passed (2 new), 0 failed.
- `tsc --build`: no new type errors.
- `eslint` / `prettier`: clean.

## Notes

Didn't find an existing issue for this one, happy to file one if you'd rather have it tracked separately. Changeset included.
