### PR TITLE
fix(lit-html): detect incomplete document mocks for TreeWalker

### DIFF
--- a/.changeset/fix-treewalker-mock-check.md
+++ b/.changeset/fix-treewalker-mock-check.md
@@ -1,0 +1,7 @@
+---
+'lit-html': patch
+'lit-element': patch
+'lit': patch
+---
+
+Fix Node document mock detection to check for createTreeWalker so incomplete document mocks (e.g. Stencil Jest) still get the TreeWalker stub.

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -356,7 +356,9 @@ const markerMatch = '?' + marker;
 const nodeMarker = `<${markerMatch}>`;
 
 const d =
-  NODE_MODE && global.document === undefined
+  // Provide a createTreeWalker mock when document is missing or incomplete
+  // (e.g. Stencil Jest's mock document lacks createTreeWalker).
+  NODE_MODE && typeof global.document?.createTreeWalker !== 'function'
     ? ({
         createTreeWalker() {
           return {};


### PR DESCRIPTION
## Summary
Fixes #4855 by treating a document without `createTreeWalker` the same as a missing document in Node mode.

Some test environments (for example Stencil Jest) provide a mock `document` that does not implement `createTreeWalker`. Lit only installed its TreeWalker stub when `document` was `undefined`, so those mocks still threw `createTreeWalker is not a function`.

## Test plan
- [ ] Confirm the condition uses `typeof global.document?.createTreeWalker !== 'function'`
- [ ] Sanity check that a normal browser/document path is unchanged
- [ ] Existing lit-html CI / unit tests pass