### PR TITLE
[reactive-element] Fix useDefault with null and undefined initial values

### DIFF
--- a/.changeset/lucky-crabs-argue.md
+++ b/.changeset/lucky-crabs-argue.md
@@ -1,0 +1,9 @@
+---
+'@lit/reactive-element': patch
+---
+
+Fix `useDefault: true` for properties initialized to `null` or `undefined`. Nullish
+default values are now recorded and restored when an attribute is removed, so a
+`null` default is no longer confused with "no default", and an `undefined` default is
+no longer replaced by `null`. This also fixes a `TypeError` thrown when a standard
+decorator `accessor` with `useDefault: true` was initialized to `null`.

--- a/packages/reactive-element/src/decorators/property.ts
+++ b/packages/reactive-element/src/decorators/property.ts
@@ -153,8 +153,11 @@ export const standardProperty = <C extends Interface<ReactiveElement>, V>(
         this.requestUpdate(name, oldValue, options, true, v);
       },
       init(this: ReactiveElement, v: V): V {
-        if (v !== undefined) {
-          this._$changeProperty(name, undefined, options, v);
+        // Note, an initial value of `undefined` is still recorded when
+        // `useDefault` is used so that it can be restored when an attribute
+        // is removed.
+        if (v !== undefined || options.useDefault === true) {
+          this._$changeProperty(name, undefined, options, true, v);
         }
         return v;
       },

--- a/packages/reactive-element/src/reactive-element.ts
+++ b/packages/reactive-element/src/reactive-element.ts
@@ -295,7 +295,8 @@ export interface PropertyDeclaration<Type = unknown, TypeHint = unknown> {
    *
    * When set, properties must be initialized, either with a field initializer, or an
    * assignment in the constructor. Not initializing the property may lead to
-   * improper handling of subsequent property assignments.
+   * improper handling of subsequent property assignments. The initial value may be
+   * `null` or `undefined`; it is restored as such when the attribute is removed.
    *
    * While this behavior is opt-in, most properties that reflect to attributes should
    * use `useDefault: true` so that their initial values do not reflect.
@@ -1247,12 +1248,22 @@ export abstract class ReactiveElement
             : defaultConverter;
       // mark state reflecting
       this.__reflectingProperty = propName;
-      const convertedValue = converter.fromAttribute!(value, options.type);
-      this[propName as keyof this] =
-        convertedValue ??
-        this.__defaultValues?.get(propName) ??
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (convertedValue as any);
+      let convertedValue = converter.fromAttribute!(value, options.type);
+      // When the attribute is removed (or the converter returns a nullish
+      // value), restore the recorded default value, if there is one. Note,
+      // the default value can itself be `null` or `undefined`, so `has()` is
+      // needed to tell an unrecorded default from a default of `undefined`.
+      // It's only called when `get()` returns `undefined`, which is the
+      // uncommon case.
+      if (convertedValue == null) {
+        const defaultValues = this.__defaultValues;
+        const defaultValue = defaultValues?.get(propName);
+        if (defaultValue !== undefined || defaultValues?.has(propName)) {
+          convertedValue = defaultValue;
+        }
+      }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      this[propName as keyof this] = convertedValue as any;
       // mark state not reflecting
       this.__reflectingProperty = null;
     }
@@ -1298,18 +1309,26 @@ export abstract class ReactiveElement
         newValue = this[name as keyof this];
       }
       options ??= ctor.getPropertyOptions(name);
+      const defaultValues = this.__defaultValues;
       const changed =
         (options.hasChanged ?? notEqual)(newValue, oldValue) ||
-        // When there is no change, check a corner case that can occur when
-        // 1. there's a initial value which was not reflected
-        // 2. the property is subsequently set to this value.
-        // For example, `prop: {useDefault: true, reflect: true}`
-        // and el.prop = 'foo'. This should be considered a change if the
-        // attribute is not set because we will now reflect the property to the attribute.
-        (options.useDefault &&
-          options.reflect &&
-          newValue === this.__defaultValues?.get(name) &&
-          !this.hasAttribute(ctor.__attributeNameForProperty(name, options)!));
+        // When there is no change, check the corner cases that can occur with
+        // `useDefault`.
+        (options.useDefault === true &&
+          // 1. The default value has not been recorded yet, which happens when
+          // a property is initialized to `undefined`. The default must be
+          // recorded so that it can be restored when an attribute is removed.
+          (defaultValues?.has(name) !== true ||
+            // 2. There's an initial value which was not reflected and the
+            // property is subsequently set to this value. For example,
+            // `prop: {useDefault: true, reflect: true}` and el.prop = 'foo'.
+            // This should be considered a change if the attribute is not set
+            // because we will now reflect the property to the attribute.
+            (options.reflect === true &&
+              newValue === defaultValues.get(name) &&
+              !this.hasAttribute(
+                ctor.__attributeNameForProperty(name, options)!
+              ))));
       if (changed) {
         this._$changeProperty(name, oldValue, options);
       } else {
@@ -1329,18 +1348,29 @@ export abstract class ReactiveElement
     name: PropertyKey,
     oldValue: unknown,
     {useDefault, reflect, wrapped}: PropertyDeclaration,
+    useInitializeValue = false,
     initializeValue?: unknown
   ) {
     // Record default value when useDefault is used. This allows us to
-    // restore this value when the attribute is removed.
+    // restore this value when the attribute is removed. Note, the default
+    // value may be `null` or `undefined`, so `has()` is used to check whether
+    // it has already been recorded.
     if (useDefault && !(this.__defaultValues ??= new Map()).has(name)) {
       this.__defaultValues.set(
         name,
-        initializeValue ?? oldValue ?? this[name as keyof this]
+        useInitializeValue
+          ? initializeValue
+          : // A wrapped accessor is initialized outside of our setter, so the
+            // previous value is the initial value; otherwise our setter has
+            // already stored the value being initialized.
+            wrapped === true
+            ? oldValue
+            : this[name as keyof this]
       );
-      // if this is not wrapping an accessor, it must be an initial setting
-      // and in this case we do not want to record the change or reflect.
-      if (wrapped !== true || initializeValue !== undefined) {
+      // If an initial value was given, or this is not wrapping an accessor
+      // and therefore must be an initial setting, we do not want to record
+      // the change or reflect.
+      if (useInitializeValue || wrapped !== true) {
         return;
       }
     }
@@ -1497,9 +1527,12 @@ export abstract class ReactiveElement
           if (
             wrapped === true &&
             !this._$changedProperties.has(p) &&
-            value !== undefined
+            // Note, an initial value of `undefined` is still recorded when
+            // `useDefault` is used so that it can be restored when an
+            // attribute is removed.
+            (value !== undefined || options.useDefault === true)
           ) {
-            this._$changeProperty(p, undefined, options, value);
+            this._$changeProperty(p, undefined, options, true, value);
           }
         }
       }

--- a/packages/reactive-element/src/test/decorators-modern/property_test.ts
+++ b/packages/reactive-element/src/test/decorators-modern/property_test.ts
@@ -659,6 +659,72 @@ suite('@property', () => {
     ]);
   });
 
+  test('useDefault with nullish default values', async () => {
+    class E extends ReactiveElement {
+      @property({reflect: true, useDefault: true})
+      accessor accNul: string | null = null;
+
+      @property({reflect: true, useDefault: true})
+      accessor accUndef: string | undefined = undefined;
+
+      #gsNul: string | null = null;
+      get gsNul() {
+        return this.#gsNul;
+      }
+      @property({reflect: true, useDefault: true})
+      set gsNul(v: string | null) {
+        const old = this.gsNul;
+        this.#gsNul = v;
+        this.requestUpdate('gsNul', old);
+      }
+
+      #gsUndef: string | undefined = undefined;
+      get gsUndef() {
+        return this.#gsUndef;
+      }
+      @property({reflect: true, useDefault: true})
+      set gsUndef(v: string | undefined) {
+        const old = this.gsUndef;
+        this.#gsUndef = v;
+        this.requestUpdate('gsUndef', old);
+      }
+    }
+    customElements.define(generateElementName(), E);
+    const el = new E();
+    container.appendChild(el);
+    await el.updateComplete;
+    // Nullish defaults are not reflected.
+    assert.isFalse(el.hasAttributes());
+    assert.strictEqual(el.accNul, null);
+    assert.strictEqual(el.accUndef, undefined);
+    assert.strictEqual(el.gsNul, null);
+    assert.strictEqual(el.gsUndef, undefined);
+
+    // Setting a value reflects it.
+    el.accNul = 'c';
+    el.accUndef = 'd';
+    el.gsNul = 'e';
+    el.gsUndef = 'f';
+    await el.updateComplete;
+    assert.equal(el.getAttribute('accnul'), 'c');
+    assert.equal(el.getAttribute('accundef'), 'd');
+    assert.equal(el.getAttribute('gsnul'), 'e');
+    assert.equal(el.getAttribute('gsundef'), 'f');
+
+    // Removing the attribute restores the nullish default, and preserves the
+    // difference between a `null` and an `undefined` default.
+    el.removeAttribute('accnul');
+    el.removeAttribute('accundef');
+    el.removeAttribute('gsnul');
+    el.removeAttribute('gsundef');
+    assert.strictEqual(el.accNul, null);
+    assert.strictEqual(el.accUndef, undefined);
+    assert.strictEqual(el.gsNul, null);
+    assert.strictEqual(el.gsUndef, undefined);
+    await el.updateComplete;
+    assert.isFalse(el.hasAttributes());
+  });
+
   test('useDefault does not reflect', async () => {
     class E extends ReactiveElement {
       @property({reflect: true, useDefault: true})

--- a/packages/reactive-element/src/test/decorators/property_test.ts
+++ b/packages/reactive-element/src/test/decorators/property_test.ts
@@ -647,6 +647,86 @@ suite('@property', () => {
     ]);
   });
 
+  test('useDefault with nullish default values', async () => {
+    class E extends ReactiveElement {
+      @property({reflect: true, useDefault: true})
+      nul: string | null = null;
+
+      @property({reflect: true, useDefault: true})
+      undef: string | undefined = undefined;
+
+      @property({reflect: true, useDefault: true})
+      accessor accNul: string | null = null;
+
+      @property({reflect: true, useDefault: true})
+      accessor accUndef: string | undefined = undefined;
+
+      #gsNul: string | null = null;
+      get gsNul() {
+        return this.#gsNul;
+      }
+
+      @property({reflect: true, useDefault: true})
+      set gsNul(v: string | null) {
+        this.#gsNul = v;
+      }
+
+      #gsUndef: string | undefined = undefined;
+      get gsUndef() {
+        return this.#gsUndef;
+      }
+
+      @property({reflect: true, useDefault: true})
+      set gsUndef(v: string | undefined) {
+        this.#gsUndef = v;
+      }
+    }
+    customElements.define(generateElementName(), E);
+    const el = new E();
+    container.appendChild(el);
+    await el.updateComplete;
+    // Nullish defaults are not reflected.
+    assert.isFalse(el.hasAttributes());
+    assert.strictEqual(el.nul, null);
+    assert.strictEqual(el.undef, undefined);
+    assert.strictEqual(el.accNul, null);
+    assert.strictEqual(el.accUndef, undefined);
+    assert.strictEqual(el.gsNul, null);
+    assert.strictEqual(el.gsUndef, undefined);
+
+    // Setting a value reflects it.
+    el.nul = 'a';
+    el.undef = 'b';
+    el.accNul = 'c';
+    el.accUndef = 'd';
+    el.gsNul = 'e';
+    el.gsUndef = 'f';
+    await el.updateComplete;
+    assert.equal(el.getAttribute('nul'), 'a');
+    assert.equal(el.getAttribute('undef'), 'b');
+    assert.equal(el.getAttribute('accnul'), 'c');
+    assert.equal(el.getAttribute('accundef'), 'd');
+    assert.equal(el.getAttribute('gsnul'), 'e');
+    assert.equal(el.getAttribute('gsundef'), 'f');
+
+    // Removing the attribute restores the nullish default, and preserves the
+    // difference between a `null` and an `undefined` default.
+    el.removeAttribute('nul');
+    el.removeAttribute('undef');
+    el.removeAttribute('accnul');
+    el.removeAttribute('accundef');
+    el.removeAttribute('gsnul');
+    el.removeAttribute('gsundef');
+    assert.strictEqual(el.nul, null);
+    assert.strictEqual(el.undef, undefined);
+    assert.strictEqual(el.accNul, null);
+    assert.strictEqual(el.accUndef, undefined);
+    assert.strictEqual(el.gsNul, null);
+    assert.strictEqual(el.gsUndef, undefined);
+    await el.updateComplete;
+    assert.isFalse(el.hasAttributes());
+  });
+
   test('useDefault does not reflect', async () => {
     class E extends ReactiveElement {
       @property({reflect: true, useDefault: true})

--- a/packages/reactive-element/src/test/reactive-element_test.ts
+++ b/packages/reactive-element/src/test/reactive-element_test.ts
@@ -1107,6 +1107,132 @@ suite('ReactiveElement', () => {
     assert.deepEqual(el.gsReflectArr, [0]);
   });
 
+  test('useDefault with nullish default values', async () => {
+    class E extends ReactiveElement {
+      static override get properties() {
+        return {
+          nul: {reflect: true, useDefault: true},
+          undef: {reflect: true, useDefault: true},
+          accNul: {reflect: true, useDefault: true},
+          accUndef: {reflect: true, useDefault: true},
+          gsNul: {reflect: true, useDefault: true},
+          gsUndef: {reflect: true, useDefault: true},
+        };
+      }
+
+      nul: string | null = null;
+      undef: string | undefined = undefined;
+      accessor accNul: string | null = null;
+      accessor accUndef: string | undefined = undefined;
+
+      #gsNul: string | null = null;
+      get gsNul() {
+        return this.#gsNul;
+      }
+      set gsNul(value: string | null) {
+        this.#gsNul = value;
+      }
+      #gsUndef: string | undefined = undefined;
+      get gsUndef() {
+        return this.#gsUndef;
+      }
+      set gsUndef(value: string | undefined) {
+        this.#gsUndef = value;
+      }
+
+      changes = new Map<PropertyKey, unknown>();
+
+      override updated(changed: PropertyValues) {
+        this.changes = new Map(changed);
+      }
+    }
+    customElements.define(generateElementName(), E);
+    const el = new E();
+    container.appendChild(el);
+    await el.updateComplete;
+    // Nullish defaults are not reflected.
+    assert.isFalse(el.hasAttributes());
+    assert.strictEqual(el.nul, null);
+    assert.strictEqual(el.undef, undefined);
+    assert.strictEqual(el.accNul, null);
+    assert.strictEqual(el.accUndef, undefined);
+    assert.strictEqual(el.gsNul, null);
+    assert.strictEqual(el.gsUndef, undefined);
+
+    // Setting a value reflects it.
+    el.nul = 'a';
+    el.undef = 'b';
+    el.accNul = 'c';
+    el.accUndef = 'd';
+    el.gsNul = 'e';
+    el.gsUndef = 'f';
+    await el.updateComplete;
+    assert.equal(el.getAttribute('nul'), 'a');
+    assert.equal(el.getAttribute('undef'), 'b');
+    assert.equal(el.getAttribute('accnul'), 'c');
+    assert.equal(el.getAttribute('accundef'), 'd');
+    assert.equal(el.getAttribute('gsnul'), 'e');
+    assert.equal(el.getAttribute('gsundef'), 'f');
+    // The nullish defaults are reported as the previous values.
+    assert.deepEqual(Array.from(el.changes), [
+      ['nul', null],
+      ['undef', undefined],
+      ['accNul', null],
+      ['accUndef', undefined],
+      ['gsNul', null],
+      ['gsUndef', undefined],
+    ]);
+
+    // Removing the attribute restores the nullish default, and preserves
+    // the difference between a `null` and an `undefined` default.
+    el.removeAttribute('nul');
+    el.removeAttribute('undef');
+    el.removeAttribute('accnul');
+    el.removeAttribute('accundef');
+    el.removeAttribute('gsnul');
+    el.removeAttribute('gsundef');
+    assert.strictEqual(el.nul, null);
+    assert.strictEqual(el.undef, undefined);
+    assert.strictEqual(el.accNul, null);
+    assert.strictEqual(el.accUndef, undefined);
+    assert.strictEqual(el.gsNul, null);
+    assert.strictEqual(el.gsUndef, undefined);
+    await el.updateComplete;
+    assert.isFalse(el.hasAttributes());
+
+    // The defaults are also recorded when properties are set before the
+    // first update.
+    const el2 = new E();
+    container.appendChild(el2);
+    el2.nul = 'a';
+    el2.undef = 'b';
+    el2.accNul = 'c';
+    el2.accUndef = 'd';
+    el2.gsNul = 'e';
+    el2.gsUndef = 'f';
+    await el2.updateComplete;
+    assert.deepEqual(Array.from(el2.changes), [
+      ['nul', null],
+      ['undef', undefined],
+      ['accNul', null],
+      ['accUndef', undefined],
+      ['gsNul', null],
+      ['gsUndef', undefined],
+    ]);
+    el2.removeAttribute('nul');
+    el2.removeAttribute('undef');
+    el2.removeAttribute('accnul');
+    el2.removeAttribute('accundef');
+    el2.removeAttribute('gsnul');
+    el2.removeAttribute('gsundef');
+    assert.strictEqual(el2.nul, null);
+    assert.strictEqual(el2.undef, undefined);
+    assert.strictEqual(el2.accNul, null);
+    assert.strictEqual(el2.accUndef, undefined);
+    assert.strictEqual(el2.gsNul, null);
+    assert.strictEqual(el2.gsUndef, undefined);
+  });
+
   test('fromAttribute can set prop to null or undefined', () => {
     class A extends ReactiveElement {
       static override get properties() {


### PR DESCRIPTION
Fixes https://github.com/lit/lit/issues/5366

Defaults were recorded and restored with `??` chains, which can't distinguish an unrecorded default from one that's `null` or `undefined`.

This change records the initial value explicitly and use `has()` when restoring it.