### PR TITLE
[task]: Add reset method for Task class to restore initial state

### DIFF
--- a/.changeset/beige-bananas-feel.md
+++ b/.changeset/beige-bananas-feel.md
@@ -1,0 +1,5 @@
+---
+'@lit/task': patch
+---
+
+Add reset method for Task class to restore initial state.

--- a/packages/task/src/task.ts
+++ b/packages/task/src/task.ts
@@ -226,6 +226,8 @@ export class Task<
   private _resolveTaskComplete?: (value: R) => void;
   private _rejectTaskComplete?: (e: unknown) => void;
   private _taskComplete?: Promise<R>;
+  private _initialValue?: R;
+  private _hasInitialValue = false;
 
   constructor(host: ReactiveControllerHost, task: TaskConfig<T, R>);
   constructor(
@@ -250,6 +252,8 @@ export class Task<
     // Providing initialValue puts the task in COMPLETE state and stores the
     // args immediately so it only runs when they change again.
     if ('initialValue' in taskConfig) {
+      this._initialValue = taskConfig.initialValue as R;
+      this._hasInitialValue = true;
       this._value = taskConfig.initialValue;
       this._status = TaskStatus.COMPLETE;
       this._previousArgs = this._getArgs?.();
@@ -402,6 +406,41 @@ export class Task<
     if (this._status === TaskStatus.PENDING) {
       this._abortController?.abort(reason);
     }
+  }
+
+  /**
+   * Resets the task to it's initial state. If an initial value was provided, the
+   * task is set to the COMPLETE state with that value. Otherwise, the task is
+   * set to the INITIAL state.
+   *
+   * Resetting a task while it is running will throw an error. The task must be
+   * aborted or completed before it can be reset.
+   */
+  reset() {
+    if (this._status === TaskStatus.PENDING) {
+      throw new Error(
+        'Cannot reset while task is running; call abort() or wait for completion first.'
+      );
+    }
+
+    if (this._hasInitialValue) {
+      // Restore value to configured initial value/state.
+      this._value = this._initialValue;
+      this._status = TaskStatus.COMPLETE;
+      this._previousArgs = this._getArgs?.();
+    } else {
+      this._status = TaskStatus.INITIAL;
+      this._value = undefined;
+      // Clear remembered args so auto-run can run on same args again.
+      this._previousArgs = undefined;
+    }
+
+    this._error = undefined;
+    this._taskComplete = undefined;
+    this._resolveTaskComplete = undefined;
+    this._rejectTaskComplete = undefined;
+    // Notify host so cleared  initial value/state is rendered promptly.
+    this._host.requestUpdate();
   }
 
   /**

--- a/packages/task/src/test/task_test.ts
+++ b/packages/task/src/test/task_test.ts
@@ -371,6 +371,69 @@ suite('Task', () => {
     assert.strictEqual(el.signal?.aborted, false);
   });
 
+  test('reset throwsn while pending', async () => {
+    const el = getTestElement({args: () => [el.a, el.b], autoRun: false});
+    await renderElement(el);
+
+    // Start a run so the task is pending
+    el.task.run();
+    assert.equal(el.task.status, TaskStatus.PENDING);
+
+    // Resetting while pending should throw
+    assert.throws(() => el.task.reset());
+
+    // Clean up and abort the task
+    el.task.abort();
+    await tasksUpdateComplete();
+  });
+
+  test('reset clears value and error when not running', async () => {
+    const el = getTestElement({args: () => [el.a, el.b], autoRun: false});
+    await renderElement(el);
+
+    el.task.run();
+    el.resolveTask();
+    await tasksUpdateComplete();
+    assert.equal(el.task.status, TaskStatus.COMPLETE);
+    assert.equal(el.task.value, 'a,b');
+
+    // Reset should clear all - status, value, error, and taskComplete
+    el.task.reset();
+    assert.equal(el.task.status, TaskStatus.INITIAL);
+    assert.equal(el.task.value, undefined);
+    assert.equal(el.task.error, undefined);
+
+    const resolved = await el.task.taskComplete;
+    assert.equal(resolved, undefined);
+  });
+
+  test('reset restores initialValue when provided', async () => {
+    let initializing = true; // Allow args to reference el before it's initialized
+    const el = getTestElement({
+      initialValue: 'initial',
+      args: () => [initializing ? 'a' : el.a, initializing ? 'b' : el.b],
+      autoRun: false,
+    });
+    initializing = false;
+
+    await renderElement(el);
+    // Initially the task should be COMPLETE with the initialValue
+    assert.equal(el.task.status, TaskStatus.COMPLETE);
+    assert.equal(el.task.value, 'initial');
+
+    // Run the task to produce a different value
+    el.task.run();
+    el.resolveTask();
+    await tasksUpdateComplete();
+    assert.equal(el.task.status, TaskStatus.COMPLETE);
+    assert.equal(el.task.value, 'a,b');
+
+    // Reset the task to restore the configured initialValue and COMPLETE status
+    el.task.reset();
+    assert.equal(el.task.status, TaskStatus.COMPLETE);
+    assert.equal(el.task.value, 'initial');
+  });
+
   test('tasks do not run when `autoRun` is `false`', async () => {
     const el = getTestElement({args: () => [el.a, el.b], autoRun: false});
     await renderElement(el);


### PR DESCRIPTION
## Changes
- Add `reset()` method for Task class to restore initial state

## Related issues or pull requests

- #5352 